### PR TITLE
Fix compatibility with array_walk() overriden by swoole

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@ All notable changes to this project will be documented in this file, in reverse 
 
 ### Fixed
 
-- Nothing.
+- [#5](https://github.com/laminas/laminas-hydrator/pull/5) Fixes error with array_walk() overriden by swoole not accepting array callable. Array callable is converted closure
 
 ## 3.0.2 - 2019-03-15
 

--- a/src/Filter/FilterComposite.php
+++ b/src/Filter/FilterComposite.php
@@ -11,6 +11,7 @@ declare(strict_types=1);
 namespace Laminas\Hydrator\Filter;
 
 use ArrayObject;
+use Closure;
 use Laminas\Hydrator\Exception\InvalidArgumentException;
 
 use function array_walk;
@@ -49,8 +50,8 @@ class FilterComposite implements FilterInterface
      */
     public function __construct(array $orFilters = [], array $andFilters = [])
     {
-        array_walk($orFilters, [$this, 'validateFilter']);
-        array_walk($andFilters, [$this, 'validateFilter']);
+        array_walk($orFilters, Closure::fromCallable([$this, 'validateFilter']));
+        array_walk($andFilters, Closure::fromCallable([$this, 'validateFilter']));
 
         $this->orFilter = new ArrayObject($orFilters);
         $this->andFilter = new ArrayObject($andFilters);


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | yes
| BC Break      | no
| New Feature   | no
| RFC           | no
| QA            | no

### Description
Swoole 4.4.0 and higher does not accept array callables in overridden array_walk(). This fix simply converts array callable into closure.
