### PR TITLE
Add php 7.4 to travis build matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,13 +18,19 @@ matrix:
     - php: 7.2
       env:
         - DEPS=latest
-        - CS_CHECK=true
-        - TEST_COVERAGE=true
-        - STATIC_ANALYSIS=true
     - php: 7.3
       env:
         - DEPS=lowest
     - php: 7.3
+      env:
+        - DEPS=latest
+        - CS_CHECK=true
+        - TEST_COVERAGE=true
+        - STATIC_ANALYSIS=true
+    - php: 7.4
+      env:
+        - DEPS=lowest
+    - php: 7.4
       env:
         - DEPS=latest
 

--- a/composer.json
+++ b/composer.json
@@ -40,7 +40,7 @@
         "laminas/laminas-modulemanager": "^2.8",
         "laminas/laminas-serializer": "^2.9",
         "laminas/laminas-servicemanager": "^3.3.2",
-        "phpspec/prophecy": "^1.7.5",
+        "phpspec/prophecy": ">=1.10.2",
         "phpstan/phpstan": "^0.10.5",
         "phpunit/phpunit": "^8.5.2 || ^9.0"
     },

--- a/composer.json
+++ b/composer.json
@@ -42,7 +42,7 @@
         "laminas/laminas-servicemanager": "^3.3.2",
         "phpspec/prophecy": "^1.7.5",
         "phpstan/phpstan": "^0.10.5",
-        "phpunit/phpunit": "^8.0"
+        "phpunit/phpunit": "^8.5.2 || ^9.0"
     },
     "suggest": {
         "laminas/laminas-eventmanager": "^3.2, to support aggregate hydrator usage",


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | no
| BC Break      | no
| New Feature   | no
| RFC           | no
| QA            | yes

### Description
Add php 7.4 to travis builds and move CS checks to php 7.3 from security only 7.2