### PR TITLE
Removed strict_types from ClassMethodsHydrator

### DIFF
--- a/src/ClassMethods.php
+++ b/src/ClassMethods.php
@@ -6,8 +6,6 @@
  * @license   https://github.com/laminas/laminas-hydrator/blob/master/LICENSE.md New BSD License
  */
 
-declare(strict_types=1);
-
 namespace Laminas\Hydrator;
 
 use function sprintf;

--- a/src/ClassMethodsHydrator.php
+++ b/src/ClassMethodsHydrator.php
@@ -6,8 +6,6 @@
  * @license   https://github.com/laminas/laminas-hydrator/blob/master/LICENSE.md New BSD License
  */
 
-declare(strict_types=1);
-
 namespace Laminas\Hydrator;
 
 use Laminas\Stdlib\ArrayUtils;

--- a/test/ClassMethodsHydratorTest.php
+++ b/test/ClassMethodsHydratorTest.php
@@ -15,6 +15,7 @@ use LaminasTest\Hydrator\TestAsset\ArraySerializable;
 use LaminasTest\Hydrator\TestAsset\ClassMethodsCamelCase;
 use LaminasTest\Hydrator\TestAsset\ClassMethodsCamelCaseMissing;
 use LaminasTest\Hydrator\TestAsset\ClassMethodsOptionalParameters;
+use LaminasTest\Hydrator\TestAsset\ClassMethodsTypeDeclaration;
 use PHPUnit\Framework\TestCase;
 use TypeError;
 
@@ -120,5 +121,12 @@ class ClassMethodsHydratorTest extends TestCase
         $this->expectException(TypeError::class);
         $this->expectExceptionMessage('must be an object');
         $this->hydrator->hydrate([], 'non-object');
+    }
+
+    public function testHydrateWithNonStrictTypes()
+    {
+        $expected = 42;
+        $typeDeclaration = $this->hydrator->hydrate(['int' => (string) $expected], new ClassMethodsTypeDeclaration());
+        $this->assertSame($expected, $typeDeclaration->getInt());
     }
 }

--- a/test/TestAsset/ClassMethodsTypeDeclaration.php
+++ b/test/TestAsset/ClassMethodsTypeDeclaration.php
@@ -1,0 +1,32 @@
+<?php
+
+/**
+ * @see       https://github.com/laminas/laminas-hydrator for the canonical source repository
+ * @copyright https://github.com/laminas/laminas-hydrator/blob/master/COPYRIGHT.md
+ * @license   https://github.com/laminas/laminas-hydrator/blob/master/LICENSE.md New BSD License
+ */
+
+declare(strict_types=1);
+
+namespace LaminasTest\Hydrator\TestAsset;
+
+/**
+ * Test asset to check that type declarations use implicit casting (no strict_types)
+ */
+class ClassMethodsTypeDeclaration
+{
+    /**
+     * @var int
+     */
+    public $int;
+
+    public function getInt() : int
+    {
+        return $this->int;
+    }
+
+    public function setInt(int $int) : void
+    {
+        $this->int = $int;
+    }
+}


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | no
| BC Break      | yes
| New Feature   | no
| RFC           | yes
| QA            | no

We use ClassMethodsHydrator for populating models from database query results. The setters have type hints. Prior to 3.0 all worked well - although the database returns things as strings, they were coerced to the correct type by PHP.

The introduction of `strict_types` break this.

While I'm all for using `strict_types` generally, I think this is a special case. Re-implementing PHP's built-in type coercion to make the class methods hydrator work with database query results adds a lot of complexity for zero gain.

See https://discourse.laminas.dev/t/remove-strict-types-from-classmethodshydrator/1475 for discussion.

