### PR TITLE
Adds new strategy for PHP’s DateTimeImmutable object

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to this project will be documented in this file, in reverse 
 
 ### Added
 
+- [#17](https://github.com/laminas/laminas-hydrator/pull/17) adds a new strategy, `DateTimeImmutableFormatterStrategy`, to provide bidirectional conversion between strings and `DateTimeImmutable` instances.
+
 - [#16](https://github.com/laminas/laminas-hydrator/pull/16) adds a new strategy implementation, `Laminas\Hydrator\Strategy\Hydrator`. It can be used to hydrate nested objects and vice versa.
 
 ### Changed

--- a/docs/book/v3/strategies/datetime-immutable-formatter-strategy.md
+++ b/docs/book/v3/strategies/datetime-immutable-formatter-strategy.md
@@ -1,0 +1,98 @@
+# DateTimeImmutableFormatter
+
+`DateTimeImmutableFormatterStrategy` provides **bidirectional conversion between
+strings and `DateTimeImmutable` instances**.
+
+The strategy uses `DateTimeFormatterStrategy` for conversion where the
+[input and output formats](../strategy.md#laminas-hydrator-strategy-datetimeformatterstrategy)
+can be set.
+
+## Basic Usage
+
+The following code example shows the isolated usage without adding the strategy
+to a hydrator.
+
+### Create and configure strategy
+
+Create the strategy and set the [input and output formats](../strategy.md#laminas-hydrator-strategy-datetimeformatterstrategy)
+via the `DateTimeFormatterStrategy`.
+
+```php
+$strategy = new Laminas\Hydrator\Strategy\DateTimeImmutableFormatterStrategy(
+    new Laminas\Hydrator\Strategy\DateTimeFormatterStrategy('Y-m-d')
+);
+```
+
+### Hydrate data
+
+```php
+$hydrated = $strategy->hydrate('2020-07-01');
+
+var_dump($hydrated instanceof DateTimeImmutable); // true
+```
+
+### Extract data
+
+```php
+$extracted = $strategy->extract(
+    DateTimeImmutable::createFromFormat('Y-m-d', '2020-07-01')
+);
+
+echo $extracted // '2020-07-01'
+```
+
+## Example
+
+The following example shows the hydration for a class with a property.
+
+An example class which represents a music album with a release date.
+
+```php
+class Album
+{
+    private ?DateTimeImmutable $releaseDate;
+
+    public function __construct(?DateTimeImmutable $releaseDate = null)
+    {
+        $this->releaseDate = $releaseDate;
+    }
+
+    public function getReleaseDate() : ?DateTimeImmutable
+    {
+        return $this->releaseDate;
+    }
+}
+```
+
+### Create hydrator and add strategy
+
+Create a hydrator and add `DateTimeImmutableFormatterStrategy` as strategy.
+
+```php
+$hydrator = new Laminas\Hydrator\ReflectionHydrator();
+$hydrator->addStrategy(
+    'releaseDate',
+    new Laminas\Hydrator\Strategy\DateTimeImmutableFormatterStrategy(
+        new Laminas\Hydrator\Strategy\DateTimeFormatterStrategy('Y-m-d')
+    )
+);
+```
+
+### Hydrate data
+
+Create an instance of the example class and hydrate data.
+
+```php
+$album = new Album();
+$hydrator->hydrate(['releaseDate' => '2020-07-01'], $album);
+
+var_dump($album->getReleaseDate() instanceof DateTimeImmutable); // true
+```
+
+### Extract data
+
+```php
+$extracted = $hydrator->extract($album);
+
+echo $extracted; // '2020-07-01'
+```

--- a/docs/book/v3/strategies/datetime-immutable-formatter-strategy.md
+++ b/docs/book/v3/strategies/datetime-immutable-formatter-strategy.md
@@ -9,7 +9,7 @@ can be set.
 
 ## Basic Usage
 
-The following code example shows the isolated usage without adding the strategy
+The following code example shows standalone usage without adding the strategy
 to a hydrator.
 
 ### Create and configure strategy
@@ -43,9 +43,9 @@ echo $extracted // '2020-07-01'
 
 ## Example
 
-The following example shows the hydration for a class with a property.
+The following example demonstrates hydration for a class with a property.
 
-An example class which represents a music album with a release date.
+An example class which represents a music album with a release date:
 
 ```php
 class Album
@@ -66,7 +66,7 @@ class Album
 
 ### Create hydrator and add strategy
 
-Create a hydrator and add `DateTimeImmutableFormatterStrategy` as strategy.
+Create a hydrator and add `DateTimeImmutableFormatterStrategy` as strategy:
 
 ```php
 $hydrator = new Laminas\Hydrator\ReflectionHydrator();
@@ -80,7 +80,7 @@ $hydrator->addStrategy(
 
 ### Hydrate data
 
-Create an instance of the example class and hydrate data.
+Create an instance of the example class and hydrate data:
 
 ```php
 $album = new Album();

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -13,6 +13,7 @@ nav:
       - "Filters": v3/filter.md
       - "Strategies":
         - Introduction: v3/strategy.md
+        - DateTimeImmutableFormatter: v3/strategies/datetime-immutable-formatter-strategy.md
         - Hydrator: v3/strategies/hydrator.md
       - "Aggregates": v3/aggregate.md
       - "Naming Strategies":

--- a/src/Strategy/DateTimeImmutableFormatterStrategy.php
+++ b/src/Strategy/DateTimeImmutableFormatterStrategy.php
@@ -1,0 +1,66 @@
+<?php
+
+/**
+ * @see       https://github.com/laminas/laminas-hydrator for the canonical source repository
+ * @copyright https://github.com/laminas/laminas-hydrator/blob/master/COPYRIGHT.md
+ * @license   https://github.com/laminas/laminas-hydrator/blob/master/LICENSE.md New BSD License
+ */
+
+declare(strict_types=1);
+
+namespace Laminas\Hydrator\Strategy;
+
+use DateTime;
+use DateTimeImmutable;
+use DateTimeInterface;
+
+class DateTimeImmutableFormatterStrategy implements StrategyInterface
+{
+    /** @var DateTimeFormatterStrategy  */
+    private $dateTimeStrategy;
+
+    public function __construct(DateTimeFormatterStrategy $dateTimeStrategy)
+    {
+        $this->dateTimeStrategy = $dateTimeStrategy;
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * Converts to date time string
+     *
+     * @param mixed|DateTimeInterface $value
+     * @return mixed|string If a non-DateTimeInterface $value is provided, it
+     *     will be returned unmodified; otherwise, it will be extracted to a
+     *     string.
+     */
+    public function extract($value, ?object $object = null)
+    {
+        return $this->dateTimeStrategy->extract($value, $object);
+    }
+
+    /**
+     * Converts date time string to DateTimeImmutable instance for injecting to object
+     *
+     * {@inheritDoc}
+     *
+     * @param mixed|string $value
+     * @return mixed|DateTimeImmutable
+     * @throws Exception\InvalidArgumentException if $value is not null, not a
+     *     string, nor a DateTimeInterface.
+     */
+    public function hydrate($value, ?array $data = null)
+    {
+        if ($value instanceof DateTimeImmutable) {
+            return $value;
+        }
+
+        $hydrated = $this->dateTimeStrategy->hydrate($value, $data);
+
+        if ($hydrated instanceof DateTime) {
+            return DateTimeImmutable::createFromMutable($hydrated);
+        }
+
+        return $hydrated ? : $value;
+    }
+}

--- a/test/Strategy/DateTimeImmutableFormatterStrategyTest.php
+++ b/test/Strategy/DateTimeImmutableFormatterStrategyTest.php
@@ -1,0 +1,83 @@
+<?php
+
+/**
+ * @see       https://github.com/laminas/laminas-hydrator for the canonical source repository
+ * @copyright https://github.com/laminas/laminas-hydrator/blob/master/COPYRIGHT.md
+ * @license   https://github.com/laminas/laminas-hydrator/blob/master/LICENSE.md New BSD License
+ */
+
+declare(strict_types=1);
+
+namespace LaminasTest\Hydrator\Strategy;
+
+use DateTimeImmutable;
+use Generator;
+use Laminas\Hydrator\Strategy\DateTimeFormatterStrategy;
+use Laminas\Hydrator\Strategy\DateTimeImmutableFormatterStrategy;
+use PHPUnit\Framework\TestCase;
+use stdClass;
+
+class DateTimeImmutableFormatterStrategyTest extends TestCase
+{
+    /** @var DateTimeImmutableFormatterStrategy */
+    private $strategy;
+
+    protected function setUp() : void
+    {
+        $this->strategy = new DateTimeImmutableFormatterStrategy(
+            new DateTimeFormatterStrategy('Y-m-d')
+        );
+    }
+
+    public function testExtraction() : void
+    {
+        $this->assertEquals(
+            '2020-05-25',
+            $this->strategy->extract(new DateTimeImmutable('2020-05-25'))
+        );
+    }
+
+    public function testHydrationWithDateTimeImmutableObjectShouldReturnSame() : void
+    {
+        $dateTime = new DateTimeImmutable('2020-05-25');
+        $this->assertEquals($dateTime, $this->strategy->hydrate($dateTime));
+    }
+
+    public function testHydrationShouldReturnImmutableDateTimeObject() : void
+    {
+        $this->assertInstanceOf(
+            DateTimeImmutable::class,
+            $this->strategy->hydrate('2020-05-25')
+        );
+    }
+
+    public function testHydrationShouldReturnDateTimeObjectWithSameValue() : void
+    {
+        $this->assertSame(
+            '2020-05-25',
+            $this->strategy->hydrate('2020-05-25')->format('Y-m-d')
+        );
+    }
+
+    /**
+     * @param mixed $value
+     * @dataProvider dataProviderForInvalidDateValues
+     */
+    public function testHydrationShouldReturnInvalidDateValuesAsIs($value) : void
+    {
+        $this->assertSame($value, $this->strategy->hydrate($value));
+    }
+
+    public function dataProviderForInvalidDateValues() : Generator
+    {
+        $values = [
+            'null'          => null,
+            'empty-string'  => '',
+            'foo'           => 'foo',
+        ];
+
+        foreach ($values as $key => $value) {
+            yield $key => [$value];
+        }
+    }
+}


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| New Feature   | yes

## Example

```php
class BlogPost
{
    private $creationDate;

    public function getCreationDate()
    {
        return $this->creationDate;
    }
}

$hydrator = new Laminas\Hydrator\ReflectionHydrator();
$hydrator->addStrategy(
    'creationDate',
    new Laminas\Hydrator\Strategy\DateTimeImmutableFormatterStrategy(
        new Laminas\Hydrator\Strategy\DateTimeFormatterStrategy('Y-m-d')
    )
);

$blogPost = new BlogPost();
$hydrator->hydrate(['creationDate' => '2020-06-25'], $blogPost);

var_dump($blogPost->getCreationDate() instanceof DateTimeImmutable); // true
```

