### PR TITLE
Allow anonymous object usage with hydrators

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ All notable changes to this project will be documented in this file, in reverse 
 
 ### Changed
 
+- [#30](https://github.com/laminas/laminas-hydrator/pull/30) modifies all `Laminas\Hydrator\Filter\FilterInterface` implementations shipped with the package, marking them as `final`. If you previously extended them, you will need to copy and paste the implementations, or open an issue requesting removal of the `final` keyword, detailing your use case.
+
 - [#30](https://github.com/laminas/laminas-hydrator/pull/30) changes the signature of `Laminas\Hydrator\Filter\FilterInterface::filter()` to now accept a second, optional argument, `?object $instance = null`.  This argument's primary use case is with anonymous objects, to facilitate reflection; the `ClassMethodsHydrator`, for instance, was updated to pass the `$instance` value only when an anonymous object is detected.  All filter implementations have been updated to the new signature.
 
 ### Deprecated
@@ -22,7 +24,7 @@ All notable changes to this project will be documented in this file, in reverse 
 
 ### Fixed
 
-- Nothing.
+- [#30](https://github.com/laminas/laminas-hydrator/pull/30) fixes the filter system to allow usage with anonymous objects.
 
 ## 3.2.0 - 2020-10-06
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ All notable changes to this project will be documented in this file, in reverse 
 
 ### Changed
 
-- Nothing.
+- [#30](https://github.com/laminas/laminas-hydrator/pull/30) changes the signature of `Laminas\Hydrator\Filter\FilterInterface::filter()` to now accept a second, optional argument, `?object $instance = null`.  This argument's primary use case is with anonymous objects, to facilitate reflection; the `ClassMethodsHydrator`, for instance, was updated to pass the `$instance` value only when an anonymous object is detected.  All filter implementations have been updated to the new signature.
 
 ### Deprecated
 

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -4,3 +4,4 @@ parameters:
         - src/
     ignoreErrors:
         - '#Result of \|{2} is always true#'
+        - '#Method Laminas\\Hydrator\\Filter\\FilterInterface::filter\(\) invoked with 2 parameters, 1 required#'

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,34 +1,26 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:noNamespaceSchemaLocation="./vendor/phpunit/phpunit/phpunit.xsd"
-         bootstrap="./vendor/autoload.php"
-         colors="true">
-    <testsuites>
-        <testsuite name="laminas-hydrator Test Suite">
-            <directory>./test/</directory>
-        </testsuite>
-    </testsuites>
-
-    <groups>
-        <exclude>
-            <group>disable</group>
-        </exclude>
-    </groups>
-
-    <filter>
-        <whitelist addUncoveredFilesFromWhitelist="true">
-            <directory suffix=".php">./src</directory>
-        </whitelist>
-    </filter>
-
-    <php>
-        <ini name="date.timezone" value="UTC"/>
-
-        <!-- OB_ENABLED should be enabled for some tests to check if all
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd" bootstrap="./vendor/autoload.php" colors="true">
+  <coverage includeUncoveredFiles="true">
+    <include>
+      <directory suffix=".php">./src</directory>
+    </include>
+  </coverage>
+  <testsuites>
+    <testsuite name="laminas-hydrator Test Suite">
+      <directory>./test/</directory>
+    </testsuite>
+  </testsuites>
+  <groups>
+    <exclude>
+      <group>disable</group>
+    </exclude>
+  </groups>
+  <php>
+    <ini name="date.timezone" value="UTC"/>
+    <!-- OB_ENABLED should be enabled for some tests to check if all
              functionality works as expected. Such tests include those for
              Laminas\Soap and Laminas\Session, which require that headers not be sent
              in order to work. -->
-        <env name="TESTS_LAMINAS_OB_ENABLED" value="false" />
-
-    </php>
+    <env name="TESTS_LAMINAS_OB_ENABLED" value="false"/>
+  </php>
 </phpunit>

--- a/src/Filter/FilterComposite.php
+++ b/src/Filter/FilterComposite.php
@@ -19,7 +19,7 @@ use function count;
 use function is_callable;
 use function sprintf;
 
-class FilterComposite implements FilterInterface
+final class FilterComposite implements FilterInterface
 {
     /**
      * Constant to add with "or" condition

--- a/src/Filter/FilterComposite.php
+++ b/src/Filter/FilterComposite.php
@@ -123,19 +123,20 @@ class FilterComposite implements FilterInterface
      *
      * @param string $property Parameter will be e.g. Parent\Namespace\Class::method
      */
-    public function filter(string $property) : bool
+    public function filter(string $property, ?object $instance = null) : bool
     {
-        return $this->atLeastOneOrFilterIsTrue($property) && $this->allAndFiltersAreTrue($property);
+        return $this->atLeastOneOrFilterIsTrue($property, $instance)
+            && $this->allAndFiltersAreTrue($property, $instance);
     }
 
-    private function atLeastOneOrFilterIsTrue(string $property) : bool
+    private function atLeastOneOrFilterIsTrue(string $property, ?object $instance = null) : bool
     {
         if (count($this->orFilter) === 0) {
             return true;
         }
 
         foreach ($this->orFilter as $filter) {
-            if ($this->executeFilter($filter, $property) === true) {
+            if ($this->executeFilter($filter, $property, $instance) === true) {
                 return true;
             }
         }
@@ -143,14 +144,14 @@ class FilterComposite implements FilterInterface
         return false;
     }
 
-    private function allAndFiltersAreTrue(string $property) : bool
+    private function allAndFiltersAreTrue(string $property, ?object $instance = null) : bool
     {
         if (count($this->andFilter) === 0) {
             return true;
         }
 
         foreach ($this->andFilter as $filter) {
-            if ($this->executeFilter($filter, $property) === false) {
+            if ($this->executeFilter($filter, $property, $instance) === false) {
                 return false;
             }
         }
@@ -161,13 +162,14 @@ class FilterComposite implements FilterInterface
     /**
      * @param callable|FilterInterface $filter
      */
-    private function executeFilter($filter, string $property) : bool
+    private function executeFilter($filter, string $property, ?object $instance = null) : bool
     {
         if (is_callable($filter)) {
-            return $filter($property);
+            /** @psalm-var callable(string, ?object):bool $filter */
+            return $filter($property, $instance);
         }
 
-        return $filter->filter($property);
+        return $filter->filter($property, $instance);
     }
 
     /**

--- a/src/Filter/FilterInterface.php
+++ b/src/Filter/FilterInterface.php
@@ -15,7 +15,12 @@ interface FilterInterface
     /**
      * Should return true, if the given filter does not match
      *
+     * Filters may take an optional second parameter, typed as a null or an
+     * object. When present, it represents the object instance on which the
+     * property should exist. For an example, see the ClassMethodsHydrator,
+     * and the NumberOfParameterFilter.
+     *
      * @param string $property The name of the property
      */
-    public function filter(string $property) : bool;
+    public function filter(string $property, ?object $instance = null) : bool;
 }

--- a/src/Filter/GetFilter.php
+++ b/src/Filter/GetFilter.php
@@ -13,7 +13,7 @@ namespace Laminas\Hydrator\Filter;
 use function strpos;
 use function substr;
 
-class GetFilter implements FilterInterface
+final class GetFilter implements FilterInterface
 {
     public function filter(string $property, ?object $instance = null) : bool
     {

--- a/src/Filter/GetFilter.php
+++ b/src/Filter/GetFilter.php
@@ -15,7 +15,7 @@ use function substr;
 
 class GetFilter implements FilterInterface
 {
-    public function filter(string $property) : bool
+    public function filter(string $property, ?object $instance = null) : bool
     {
         $pos = strpos($property, '::');
         if ($pos !== false) {

--- a/src/Filter/HasFilter.php
+++ b/src/Filter/HasFilter.php
@@ -14,7 +14,7 @@ use function strpos;
 
 class HasFilter implements FilterInterface
 {
-    public function filter(string $property) : bool
+    public function filter(string $property, ?object $instance = null) : bool
     {
         $pos = strpos($property, '::');
         if ($pos !== false) {

--- a/src/Filter/HasFilter.php
+++ b/src/Filter/HasFilter.php
@@ -12,7 +12,7 @@ namespace Laminas\Hydrator\Filter;
 
 use function strpos;
 
-class HasFilter implements FilterInterface
+final class HasFilter implements FilterInterface
 {
     public function filter(string $property, ?object $instance = null) : bool
     {

--- a/src/Filter/IsFilter.php
+++ b/src/Filter/IsFilter.php
@@ -14,7 +14,7 @@ use function strpos;
 
 class IsFilter implements FilterInterface
 {
-    public function filter(string $property) : bool
+    public function filter(string $property, ?object $instance = null) : bool
     {
         $pos = strpos($property, '::');
         if ($pos !== false) {

--- a/src/Filter/IsFilter.php
+++ b/src/Filter/IsFilter.php
@@ -12,7 +12,7 @@ namespace Laminas\Hydrator\Filter;
 
 use function strpos;
 
-class IsFilter implements FilterInterface
+final class IsFilter implements FilterInterface
 {
     public function filter(string $property, ?object $instance = null) : bool
     {

--- a/src/Filter/MethodMatchFilter.php
+++ b/src/Filter/MethodMatchFilter.php
@@ -13,7 +13,7 @@ namespace Laminas\Hydrator\Filter;
 use function strpos;
 use function substr;
 
-class MethodMatchFilter implements FilterInterface
+final class MethodMatchFilter implements FilterInterface
 {
     /**
      * The method to exclude

--- a/src/Filter/MethodMatchFilter.php
+++ b/src/Filter/MethodMatchFilter.php
@@ -39,7 +39,7 @@ class MethodMatchFilter implements FilterInterface
         $this->exclude = $exclude;
     }
 
-    public function filter(string $property) : bool
+    public function filter(string $property, ?object $instance = null) : bool
     {
         $pos = strpos($property, '::');
         if ($pos !== false) {

--- a/src/Filter/NumberOfParameterFilter.php
+++ b/src/Filter/NumberOfParameterFilter.php
@@ -36,10 +36,12 @@ class NumberOfParameterFilter implements FilterInterface
     /**
      * @throws InvalidArgumentException
      */
-    public function filter(string $property) : bool
+    public function filter(string $property, ?object $instance = null) : bool
     {
         try {
-            $reflectionMethod = new ReflectionMethod($property);
+            $reflectionMethod = $instance !== null
+                ? new ReflectionMethod($instance, $property)
+                : new ReflectionMethod($property);
         } catch (ReflectionException $exception) {
             throw new InvalidArgumentException(sprintf(
                 'Method %s does not exist',

--- a/src/Filter/NumberOfParameterFilter.php
+++ b/src/Filter/NumberOfParameterFilter.php
@@ -16,7 +16,7 @@ use ReflectionMethod;
 
 use function sprintf;
 
-class NumberOfParameterFilter implements FilterInterface
+final class NumberOfParameterFilter implements FilterInterface
 {
     /**
      * The number of parameters being accepted

--- a/src/Filter/OptionalParametersFilter.php
+++ b/src/Filter/OptionalParametersFilter.php
@@ -21,7 +21,7 @@ use function sprintf;
 /**
  * Filter that includes methods which have no parameters or only optional parameters
  */
-class OptionalParametersFilter implements FilterInterface
+final class OptionalParametersFilter implements FilterInterface
 {
     /**
      * Map of methods already analyzed

--- a/src/Filter/OptionalParametersFilter.php
+++ b/src/Filter/OptionalParametersFilter.php
@@ -38,14 +38,20 @@ class OptionalParametersFilter implements FilterInterface
      * @throws InvalidArgumentException if reflection fails due to the method
      *     not existing.
      */
-    public function filter(string $property) : bool
+    public function filter(string $property, ?object $instance = null) : bool
     {
-        if (isset(static::$propertiesCache[$property])) {
-            return static::$propertiesCache[$property];
+        $cacheName = $instance !== null
+            ? (new ReflectionMethod($instance, $property))->getName()
+            : $property;
+
+        if (array_key_exists($cacheName, static::$propertiesCache)) {
+            return static::$propertiesCache[$cacheName];
         }
 
         try {
-            $reflectionMethod = new ReflectionMethod($property);
+            $reflectionMethod = $instance !== null
+                ? new ReflectionMethod($instance, $property)
+                : new ReflectionMethod($property);
         } catch (ReflectionException $exception) {
             throw new InvalidArgumentException(sprintf('Method %s does not exist', $property));
         }
@@ -57,6 +63,6 @@ class OptionalParametersFilter implements FilterInterface
             }
         );
 
-        return static::$propertiesCache[$property] = empty($mandatoryParameters);
+        return static::$propertiesCache[$cacheName] = empty($mandatoryParameters);
     }
 }

--- a/test/ClassMethodsHydratorTest.php
+++ b/test/ClassMethodsHydratorTest.php
@@ -43,7 +43,7 @@ class ClassMethodsHydratorTest extends TestCase
     /**
      * Verifies that extraction can happen even when a getter has parameters if those are all optional
      */
-    public function testCanExtractFromMethodsWithOptionalParameters()
+    public function testCanExtractFromMethodsWithOptionalParameters(): void
     {
         $this->assertSame(['foo' => 'bar'], $this->hydrator->extract(new ClassMethodsOptionalParameters()));
     }
@@ -51,7 +51,7 @@ class ClassMethodsHydratorTest extends TestCase
     /**
      * Verifies that the hydrator can act on different instance types
      */
-    public function testCanHydratedPromiscuousInstances()
+    public function testCanHydratedPromiscuousInstances(): void
     {
         /* @var $classMethodsCamelCase ClassMethodsCamelCase */
         $classMethodsCamelCase = $this->hydrator->hydrate(
@@ -82,7 +82,7 @@ class ClassMethodsHydratorTest extends TestCase
     /**
      * Verifies the options must be an array or Traversable
      */
-    public function testSetOptionsThrowsException()
+    public function testSetOptionsThrowsException(): void
     {
         $this->expectException(TypeError::class);
         $this->expectExceptionMessage('iterable');
@@ -92,7 +92,7 @@ class ClassMethodsHydratorTest extends TestCase
     /**
      * Verifies options can be set from a Traversable object
      */
-    public function testSetOptionsFromTraversable()
+    public function testSetOptionsFromTraversable(): void
     {
         $options = new \ArrayObject([
             'underscoreSeparatedKeys' => false,
@@ -105,7 +105,7 @@ class ClassMethodsHydratorTest extends TestCase
     /**
      * Verifies a TypeError is thrown for extracting a non-object
      */
-    public function testExtractNonObjectThrowsTypeError()
+    public function testExtractNonObjectThrowsTypeError(): void
     {
         $this->expectException(TypeError::class);
         $this->expectExceptionMessage('object');
@@ -115,14 +115,14 @@ class ClassMethodsHydratorTest extends TestCase
     /**
      * Verifies a TypeError is thrown for hydrating a non-object
      */
-    public function testHydrateNonObjectThrowsTypeError()
+    public function testHydrateNonObjectThrowsTypeError(): void
     {
         $this->expectException(TypeError::class);
         $this->expectExceptionMessage('object');
         $this->hydrator->hydrate([], 'non-object');
     }
 
-    public function testExtractClassWithoutAnyMethod()
+    public function testExtractClassWithoutAnyMethod(): void
     {
         $data = $this->hydrator->extract(
             new TestAsset\ClassWithoutAnyMethod()
@@ -130,9 +130,10 @@ class ClassMethodsHydratorTest extends TestCase
         self::assertSame([], $data);
     }
 
-    public function testCanExtractFromAnonymousClassMethods()
+    public function testCanExtractFromAnonymousClassMethods(): void
     {
-        $anonymous = new class extends ClassMethodsOptionalParameters {};
+        $anonymous = new class extends ClassMethodsOptionalParameters {
+        };
         $this->assertSame(['foo' => 'bar'], $this->hydrator->extract($anonymous));
     }
 }

--- a/test/ClassMethodsHydratorTest.php
+++ b/test/ClassMethodsHydratorTest.php
@@ -129,4 +129,10 @@ class ClassMethodsHydratorTest extends TestCase
         );
         self::assertSame([], $data);
     }
+
+    public function testCanExtractFromAnonymousClassMethods()
+    {
+        $anonymous = new class extends ClassMethodsOptionalParameters {};
+        $this->assertSame(['foo' => 'bar'], $this->hydrator->extract($anonymous));
+    }
 }

--- a/test/Filter/FilterCompositeTest.php
+++ b/test/Filter/FilterCompositeTest.php
@@ -126,7 +126,7 @@ class FilterCompositeTest extends TestCase
                 {
                     $this->value = $value;
                 }
-                public function filter(string $property) : bool
+                public function filter(string $property, ?object $instance = null) : bool
                 {
                     return $this->value;
                 }

--- a/test/ObjectPropertyHydratorTest.php
+++ b/test/ObjectPropertyHydratorTest.php
@@ -41,7 +41,7 @@ class ObjectPropertyHydratorTest extends TestCase
     /**
      * Verify that we get an exception when trying to extract on a non-object
      */
-    public function testHydratorExtractThrowsExceptionOnNonObjectParameter()
+    public function testHydratorExtractThrowsExceptionOnNonObjectParameter(): void
     {
         $this->expectException(TypeError::class);
         $this->hydrator->extract('thisIsNotAnObject');
@@ -50,7 +50,7 @@ class ObjectPropertyHydratorTest extends TestCase
     /**
      * Verify that we get an exception when trying to hydrate a non-object
      */
-    public function testHydratorHydrateThrowsExceptionOnNonObjectParameter()
+    public function testHydratorHydrateThrowsExceptionOnNonObjectParameter(): void
     {
         $this->expectException(TypeError::class);
         $this->hydrator->hydrate(['some' => 'data'], 'thisIsNotAnObject');
@@ -59,7 +59,7 @@ class ObjectPropertyHydratorTest extends TestCase
     /**
      * Verifies that the hydrator can extract from property of stdClass objects
      */
-    public function testCanExtractFromStdClass()
+    public function testCanExtractFromStdClass(): void
     {
         $object = new \stdClass();
         $object->foo = 'bar';
@@ -70,7 +70,7 @@ class ObjectPropertyHydratorTest extends TestCase
     /**
      * Verifies that the extraction process works on classes that aren't stdClass
      */
-    public function testCanExtractFromGenericClass()
+    public function testCanExtractFromGenericClass(): void
     {
         $this->assertSame(
             [
@@ -86,7 +86,7 @@ class ObjectPropertyHydratorTest extends TestCase
     /**
      * Verify hydration of {@see \stdClass}
      */
-    public function testCanHydrateStdClass()
+    public function testCanHydrateStdClass(): void
     {
         $object = new \stdClass();
         $object->foo = 'bar';
@@ -99,7 +99,7 @@ class ObjectPropertyHydratorTest extends TestCase
     /**
      * Verify that new properties are created if the object is stdClass
      */
-    public function testCanHydrateAdditionalPropertiesToStdClass()
+    public function testCanHydrateAdditionalPropertiesToStdClass(): void
     {
         $object = new \stdClass();
         $object->foo = 'bar';
@@ -114,7 +114,7 @@ class ObjectPropertyHydratorTest extends TestCase
     /**
      * Verify that it can hydrate our class public properties
      */
-    public function testCanHydrateGenericClassPublicProperties()
+    public function testCanHydrateGenericClassPublicProperties(): void
     {
         $object = $this->hydrator->hydrate(
             [
@@ -137,7 +137,7 @@ class ObjectPropertyHydratorTest extends TestCase
     /**
      * Verify that it can hydrate new properties on generic classes
      */
-    public function testCanHydrateGenericClassNonExistingProperties()
+    public function testCanHydrateGenericClassNonExistingProperties(): void
     {
         $object = $this->hydrator->hydrate(['newProperty' => 'newPropertyValue'], new ObjectPropertyTestAsset());
 
@@ -147,7 +147,7 @@ class ObjectPropertyHydratorTest extends TestCase
     /**
      * Verify that hydration is skipped for class properties (it is an object hydrator after all)
      */
-    public function testSkipsPublicStaticClassPropertiesHydration()
+    public function testSkipsPublicStaticClassPropertiesHydration(): void
     {
         $this->hydrator->hydrate(
             ['foo' => '1', 'bar' => '2', 'baz' => '3'],
@@ -162,8 +162,46 @@ class ObjectPropertyHydratorTest extends TestCase
     /**
      * Verify that extraction is skipped for class properties (it is an object hydrator after all)
      */
-    public function testSkipsPublicStaticClassPropertiesExtraction()
+    public function testSkipsPublicStaticClassPropertiesExtraction(): void
     {
         $this->assertEmpty($this->hydrator->extract(new ClassWithPublicStaticProperties()));
+    }
+
+    public function testCanExtractFromAnonymousClass(): void
+    {
+        /** @psalm-var ObjectPropertyTestAsset $anonymous */
+        $anonymous = new class extends ObjectPropertyTestAsset {
+        };
+        $this->assertSame(
+            [
+                'foo' => 'bar',
+                'bar' => 'foo',
+                'blubb' => 'baz',
+                'quo' => 'blubb'
+            ],
+            $this->hydrator->extract($anonymous)
+        );
+    }
+
+    public function testCanHydrateAnonymousClass(): void
+    {
+        /** @psalm-var ObjectPropertyTestAsset $object */
+        $object = $this->hydrator->hydrate(
+            [
+                'foo' => 'foo',
+                'bar' => 'bar',
+                'blubb' => 'blubb',
+                'quo' => 'quo',
+                'quin' => 'quin'
+            ],
+            new class extends ObjectPropertyTestAsset {
+            }
+        );
+
+        $this->assertSame('foo', $object->get('foo'));
+        $this->assertSame('bar', $object->get('bar'));
+        $this->assertSame('blubb', $object->get('blubb'));
+        $this->assertSame('quo', $object->get('quo'));
+        $this->assertNotSame('quin', $object->get('quin'));
     }
 }


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | no (not needed)
| Bugfix        | yes
| BC Break      | yes
| New Feature   | yes
| RFC           | no
| QA            | no

### Description

As detailed in #25, the `ClassMethodsHydrator` does not play well with anonymous objects.

To address this, this patch modifies the `FilterInterface` signature to take an optional, second argument, `?object $instance = null`. This allows the various filters that allowed properties using `{object}::{property}` notation to also allow an optional `$instance`. When present, filters that need to do reflection can use the `$instance` for those purposes.

Also, all `FilterInterface` implementations shipped with the package are now marked as `final`, to allow us to change signatures if needed for future bugfixes.

Finally, the patch also adds tests for each hydrator to validate that they play well with anonymous objects.

Closes #26 
Fixes #25 