### PR TITLE
Feature/php 8 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,31 +6,31 @@ cache:
 
 env:
   global:
-    - COMPOSER_ARGS="--no-interaction"
+    - COMPOSER_ARGS="--no-interaction --ignore-platform-reqs"
     - COVERAGE_DEPS="php-coveralls/php-coveralls"
 
 matrix:
   fast_finish: true
   include:
-    - php: 7.2
-      env:
-        - DEPS=lowest
-    - php: 7.2
-      env:
-        - DEPS=latest
     - php: 7.3
       env:
         - DEPS=lowest
     - php: 7.3
       env:
         - DEPS=latest
+    - php: 7.4
+      env:
+        - DEPS=lowest
         - CS_CHECK=true
         - TEST_COVERAGE=true
         - STATIC_ANALYSIS=true
     - php: 7.4
       env:
+        - DEPS=latest
+    - php: 8.0
+      env:
         - DEPS=lowest
-    - php: 7.4
+    - php: 8.0
       env:
         - DEPS=latest
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,10 +27,10 @@ matrix:
     - php: 7.4
       env:
         - DEPS=latest
-    - php: 8.0
+    - php: nightly
       env:
         - DEPS=lowest
-    - php: 8.0
+    - php: nightly
       env:
         - DEPS=latest
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,12 +21,12 @@ matrix:
     - php: 7.4
       env:
         - DEPS=lowest
-        - CS_CHECK=true
-        - TEST_COVERAGE=true
-        - STATIC_ANALYSIS=true
     - php: 7.4
       env:
         - DEPS=latest
+        - CS_CHECK=true
+        - TEST_COVERAGE=true
+        - STATIC_ANALYSIS=true
     - php: nightly
       env:
         - DEPS=lowest

--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
         }
     },
     "require": {
-        "php": "^7.2",
+        "php": "^7.3 || ~8.0.0",
         "laminas/laminas-stdlib": "^3.2.1",
         "laminas/laminas-zendframework-bridge": "^1.0"
     },
@@ -37,7 +37,7 @@
         "laminas/laminas-servicemanager": "^3.3.2",
         "phpspec/prophecy": ">=1.10.2",
         "phpstan/phpstan": "^0.10.5",
-        "phpunit/phpunit": "^8.5.2 || ^9.0"
+        "phpunit/phpunit": "~9.3.0"
     },
     "suggest": {
         "laminas/laminas-eventmanager": "^3.2, to support aggregate hydrator usage",

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
     },
     "require": {
         "php": "^7.3 || ~8.0.0",
-        "laminas/laminas-stdlib": "^3.2.1",
+        "laminas/laminas-stdlib": "^3.3",
         "laminas/laminas-zendframework-bridge": "^1.0"
     },
     "require-dev": {

--- a/src/ArraySerializableHydrator.php
+++ b/src/ArraySerializableHydrator.php
@@ -79,7 +79,7 @@ class ArraySerializableHydrator extends AbstractHydrator
             // Ensure any previously populated values not in the replacement
             // remain following population.
             if (method_exists($object, 'getArrayCopy') && is_callable([$object, 'getArrayCopy'])) {
-                $original = $object->getArrayCopy($object);
+                $original = $object->getArrayCopy();
                 $replacement = array_merge($original, $replacement);
             }
             $object->exchangeArray($replacement);

--- a/test/ArraySerializableHydratorTest.php
+++ b/test/ArraySerializableHydratorTest.php
@@ -46,7 +46,7 @@ class ArraySerializableHydratorTest extends TestCase
     public function testHydratorExtractThrowsExceptionOnNonObjectParameter()
     {
         $this->expectException(TypeError::class);
-        $this->expectExceptionMessage('must be an object');
+        $this->expectExceptionMessage('object');
         $this->hydrator->extract('thisIsNotAnObject');
     }
 
@@ -56,7 +56,7 @@ class ArraySerializableHydratorTest extends TestCase
     public function testHydratorHydrateThrowsExceptionOnNonObjectParameter()
     {
         $this->expectException(TypeError::class);
-        $this->expectExceptionMessage('must be an object');
+        $this->expectExceptionMessage('object');
         $this->hydrator->hydrate(['some' => 'data'], 'thisIsNotAnObject');
     }
 

--- a/test/ClassMethodsHydratorTest.php
+++ b/test/ClassMethodsHydratorTest.php
@@ -85,7 +85,7 @@ class ClassMethodsHydratorTest extends TestCase
     public function testSetOptionsThrowsException()
     {
         $this->expectException(TypeError::class);
-        $this->expectExceptionMessage('must be iterable');
+        $this->expectExceptionMessage('iterable');
         $this->hydrator->setOptions('invalid options');
     }
 
@@ -108,7 +108,7 @@ class ClassMethodsHydratorTest extends TestCase
     public function testExtractNonObjectThrowsTypeError()
     {
         $this->expectException(TypeError::class);
-        $this->expectExceptionMessage('must be an object');
+        $this->expectExceptionMessage('object');
         $this->hydrator->extract('non-object');
     }
 
@@ -118,7 +118,7 @@ class ClassMethodsHydratorTest extends TestCase
     public function testHydrateNonObjectThrowsTypeError()
     {
         $this->expectException(TypeError::class);
-        $this->expectExceptionMessage('must be an object');
+        $this->expectExceptionMessage('object');
         $this->hydrator->hydrate([], 'non-object');
     }
 

--- a/test/NamingStrategy/CompositeNamingStrategyTest.php
+++ b/test/NamingStrategy/CompositeNamingStrategyTest.php
@@ -35,11 +35,11 @@ class CompositeNamingStrategyTest extends TestCase
     {
         /* @var $defaultNamingStrategy NamingStrategyInterface|\PHPUnit_Framework_MockObject_MockObject*/
         $defaultNamingStrategy = $this->createMock(NamingStrategyInterface::class);
-        $defaultNamingStrategy->expects($this->at(0))
+        $defaultNamingStrategy->expects($this->once())
             ->method('hydrate')
             ->with('foo')
             ->will($this->returnValue('Foo'));
-        $defaultNamingStrategy->expects($this->at(1))
+        $defaultNamingStrategy->expects($this->once())
             ->method('extract')
             ->with('Foo')
             ->will($this->returnValue('foo'));

--- a/test/ReflectionHydratorTest.php
+++ b/test/ReflectionHydratorTest.php
@@ -54,7 +54,7 @@ class ReflectionHydratorTest extends TestCase
         $argument = (int) 1;
 
         $this->expectException(TypeError::class);
-        $this->expectExceptionMessage('must be an object');
+        $this->expectExceptionMessage('object');
 
         $this->hydrator->extract($argument);
     }
@@ -64,7 +64,7 @@ class ReflectionHydratorTest extends TestCase
         $argument = (int) 1;
 
         $this->expectException(TypeError::class);
-        $this->expectExceptionMessage('must be an object');
+        $this->expectExceptionMessage('object');
 
         $this->hydrator->hydrate([ 'foo' => 'bar' ], $argument);
     }

--- a/test/StandaloneHydratorPluginManagerFactoryTest.php
+++ b/test/StandaloneHydratorPluginManagerFactoryTest.php
@@ -35,7 +35,7 @@ class StandaloneHydratorPluginManagerFactoryTest extends TestCase
     protected function setUp() : void
     {
         $this->factory   = new StandaloneHydratorPluginManagerFactory();
-        $this->container = $this->prophesize(ContainerInterface::class);
+        $this->container = $this->createMock(ContainerInterface::class);
     }
 
     public function assertDefaultServices(
@@ -74,7 +74,7 @@ class StandaloneHydratorPluginManagerFactoryTest extends TestCase
 
     public function testCreatesPluginManagerWithDefaultServices()
     {
-        $manager = ($this->factory)($this->container->reveal());
+        $manager = ($this->factory)($this->container);
         $this->assertDefaultServices($manager);
     }
 }

--- a/test/Strategy/CollectionStrategyTest.php
+++ b/test/Strategy/CollectionStrategyTest.php
@@ -73,14 +73,14 @@ class CollectionStrategyTest extends TestCase
     {
         // @codingStandardsIgnoreStart
         return [
-            'array'                     => [[], TypeError::class, 'must be of the type string'],
-            'boolean-false'             => [false, TypeError::class, 'must be of the type string'],
-            'boolean-true'              => [true, TypeError::class, 'must be of the type string'],
-            'float'                     => [mt_rand() / mt_getrandmax(), TypeError::class, 'must be of the type string'],
-            'integer'                   => [mt_rand(), TypeError::class, 'must be of the type string'],
-            'null'                      => [null, TypeError::class, 'must be of the type string'],
-            'object'                    => [new stdClass(), TypeError::class, 'must be of the type string'],
-            'resource'                  => [fopen(__FILE__, 'r'), TypeError::class, 'must be of the type string'],
+            'array'                     => [[], TypeError::class, 'type string'],
+            'boolean-false'             => [false, TypeError::class, 'type string'],
+            'boolean-true'              => [true, TypeError::class, 'type string'],
+            'float'                     => [mt_rand() / mt_getrandmax(), TypeError::class, 'type string'],
+            'integer'                   => [mt_rand(), TypeError::class, 'type string'],
+            'null'                      => [null, TypeError::class, 'type string'],
+            'object'                    => [new stdClass(), TypeError::class, 'type string'],
+            'resource'                  => [fopen(__FILE__, 'r'), TypeError::class, 'type string'],
             'string-non-existent-class' => ['FooBarBaz9000', Exception\InvalidArgumentException::class, 'class name needs to be the name of an existing class'],
         ];
         // @codingStandardsIgnoreEnd

--- a/test/Strategy/HydratorStrategyTest.php
+++ b/test/Strategy/HydratorStrategyTest.php
@@ -56,14 +56,14 @@ class HydratorStrategyTest extends TestCase
     {
         // @codingStandardsIgnoreStart
         return [
-            'array'                     => [[], TypeError::class, 'must be of the type string'],
-            'boolean-false'             => [false, TypeError::class, 'must be of the type string'],
-            'boolean-true'              => [true, TypeError::class, 'must be of the type string'],
-            'float'                     => [mt_rand() / mt_getrandmax(), TypeError::class, 'must be of the type string'],
-            'integer'                   => [mt_rand(), TypeError::class, 'must be of the type string'],
-            'null'                      => [null, TypeError::class, 'must be of the type string'],
-            'object'                    => [new stdClass(), TypeError::class, 'must be of the type string'],
-            'resource'                  => [fopen(__FILE__, 'r'), TypeError::class, 'must be of the type string'],
+            'array'                     => [[], TypeError::class, 'type string'],
+            'boolean-false'             => [false, TypeError::class, 'type string'],
+            'boolean-true'              => [true, TypeError::class, 'type string'],
+            'float'                     => [mt_rand() / mt_getrandmax(), TypeError::class, 'type string'],
+            'integer'                   => [mt_rand(), TypeError::class, 'type string'],
+            'null'                      => [null, TypeError::class, 'type string'],
+            'object'                    => [new stdClass(), TypeError::class, 'type string'],
+            'resource'                  => [fopen(__FILE__, 'r'), TypeError::class, 'type string'],
             'string-non-existent-class' => ['FooBarBaz9000', InvalidArgumentException::class, 'class name needs to be the name of an existing class'],
         ];
         // @codingStandardsIgnoreEnd


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | no
| BC Break      | no
| New Feature   | yes
| RFC           | yes
| QA            | yes

### Description

Adds PHP 8 support:

- Adds `~8.0.0` as an additional PHP constraint.
- Bumps minimum supported PHP version to 7.3.
- Bumps PHPUnit version to `~9.3.0` (prior to 9.3 did not support PHP 8; 9.4 is currently broken under PHP 8).
- Updates unit tests to work under new constraints; in particular, removes usage of Prophecy in favor of native PHPUnit mocks.

Fixes #29 