### PR TITLE
Adds Psalm integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -45,7 +45,7 @@ install:
   - stty cols 120 && composer show
 
 script:
-  - if [[ $STATIC_ANALYSIS == 'true' ]]; then composer analyse ; fi
+  - if [[ $STATIC_ANALYSIS == 'true' ]]; then composer static-analysis ; fi
   - if [[ $TEST_COVERAGE == 'true' ]]; then composer test-coverage ; else composer test ; fi
   - if [[ $CS_CHECK == 'true' ]]; then composer cs-check ; fi
 

--- a/composer.json
+++ b/composer.json
@@ -35,9 +35,8 @@
         "laminas/laminas-modulemanager": "^2.8",
         "laminas/laminas-serializer": "^2.9",
         "laminas/laminas-servicemanager": "^3.3.2",
-        "phpspec/prophecy": ">=1.10.2",
-        "phpstan/phpstan": "^0.10.5",
-        "phpunit/phpunit": "~9.3.0"
+        "phpunit/phpunit": "~9.3.0",
+        "vimeo/psalm": "^3.16"
     },
     "suggest": {
         "laminas/laminas-eventmanager": "^3.2, to support aggregate hydrator usage",
@@ -55,13 +54,13 @@
         }
     },
     "scripts": {
-        "analyse": "phpstan analyse --no-progress",
         "check": [
             "@cs-check",
             "@test"
         ],
         "cs-check": "phpcs",
         "cs-fix": "phpcbf",
+        "static-analysis": "psalm --shepherd --stats",
         "test": "phpunit --colors=always",
         "test-coverage": "phpunit --colors=always --coverage-clover clover.xml"
     },

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1,0 +1,1947 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<files psalm-version="3.16@d03e5ef057d6adc656c0ff7e166c50b73b4f48f3">
+  <file src="src/Aggregate/AggregateHydrator.php">
+    <DocblockTypeContradiction occurrences="1">
+      <code>null === $this-&gt;eventManager</code>
+    </DocblockTypeContradiction>
+    <MissingConstructor occurrences="1">
+      <code>$eventManager</code>
+    </MissingConstructor>
+  </file>
+  <file src="src/ArraySerializable.php">
+    <DeprecatedClass occurrences="1">
+      <code>ArraySerializable::class</code>
+    </DeprecatedClass>
+  </file>
+  <file src="src/ArraySerializableHydrator.php">
+    <MixedArgument occurrences="2">
+      <code>$name</code>
+      <code>$original</code>
+    </MixedArgument>
+    <MixedArgumentTypeCoercion occurrences="1">
+      <code>$key</code>
+    </MixedArgumentTypeCoercion>
+    <MixedArrayAccess occurrences="2">
+      <code>$data[$name]</code>
+      <code>$data[$name]</code>
+    </MixedArrayAccess>
+    <MixedArrayAssignment occurrences="1">
+      <code>$data[$name]</code>
+    </MixedArrayAssignment>
+    <MixedAssignment occurrences="8">
+      <code>$data</code>
+      <code>$data[$name]</code>
+      <code>$extractedName</code>
+      <code>$name</code>
+      <code>$original</code>
+      <code>$replacement[$name]</code>
+      <code>$value</code>
+      <code>$value</code>
+    </MixedAssignment>
+    <MixedInferredReturnType occurrences="1">
+      <code>array</code>
+    </MixedInferredReturnType>
+    <MixedReturnStatement occurrences="1">
+      <code>$data</code>
+    </MixedReturnStatement>
+  </file>
+  <file src="src/ClassMethods.php">
+    <DeprecatedClass occurrences="1">
+      <code>ClassMethods::class</code>
+    </DeprecatedClass>
+  </file>
+  <file src="src/ClassMethodsHydrator.php">
+    <DocblockTypeContradiction occurrences="2">
+      <code>$options instanceof Traversable</code>
+      <code>null === $this-&gt;extractionMethodsCache[$objectClass]</code>
+    </DocblockTypeContradiction>
+    <MixedArgument occurrences="4">
+      <code>$options</code>
+      <code>$options['methodExistsCheck']</code>
+      <code>$options['underscoreSeparatedKeys']</code>
+      <code>$realAttributeName</code>
+    </MixedArgument>
+    <MixedArgumentTypeCoercion occurrences="2">
+      <code>$property</code>
+      <code>$property</code>
+    </MixedArgumentTypeCoercion>
+    <MixedAssignment occurrences="3">
+      <code>$realAttributeName</code>
+      <code>$value</code>
+      <code>$values[$realAttributeName]</code>
+    </MixedAssignment>
+    <MixedMethodCall occurrences="2">
+      <code>$methodName</code>
+      <code>$this-&gt;hydrationMethodsCache[$propertyFqn]</code>
+    </MixedMethodCall>
+  </file>
+  <file src="src/DelegatingHydrator.php">
+    <MixedInferredReturnType occurrences="1">
+      <code>HydratorInterface</code>
+    </MixedInferredReturnType>
+    <MixedReturnStatement occurrences="1">
+      <code>$this-&gt;hydrators-&gt;get(get_class($object))</code>
+    </MixedReturnStatement>
+  </file>
+  <file src="src/DelegatingHydratorFactory.php">
+    <MixedInferredReturnType occurrences="1">
+      <code>ContainerInterface</code>
+    </MixedInferredReturnType>
+    <MixedReturnStatement occurrences="3">
+      <code>$container-&gt;get('HydratorManager')</code>
+      <code>$container-&gt;get(HydratorPluginManager::class)</code>
+      <code>$container-&gt;get(\Zend\Hydrator\HydratorPluginManager::class)</code>
+    </MixedReturnStatement>
+  </file>
+  <file src="src/Filter/FilterComposite.php">
+    <MixedArgument occurrences="2">
+      <code>$filter</code>
+      <code>$filter</code>
+    </MixedArgument>
+    <MixedAssignment occurrences="2">
+      <code>$filter</code>
+      <code>$filter</code>
+    </MixedAssignment>
+    <MixedInferredReturnType occurrences="1">
+      <code>bool</code>
+    </MixedInferredReturnType>
+    <MixedReturnStatement occurrences="1">
+      <code>$filter($property)</code>
+    </MixedReturnStatement>
+  </file>
+  <file src="src/HydratorPluginManager.php">
+    <DeprecatedClass occurrences="8">
+      <code>ArraySerializable::class</code>
+      <code>ClassMethods::class</code>
+      <code>ObjectProperty::class</code>
+      <code>Reflection::class</code>
+      <code>\Zend\Hydrator\ArraySerializable::class</code>
+      <code>\Zend\Hydrator\ClassMethods::class</code>
+      <code>\Zend\Hydrator\ObjectProperty::class</code>
+      <code>\Zend\Hydrator\Reflection::class</code>
+    </DeprecatedClass>
+    <DuplicateArrayKey occurrences="4">
+      <code>\Zend\Hydrator\ArraySerializable::class =&gt; ArraySerializableHydrator::class</code>
+      <code>\Zend\Hydrator\ClassMethods::class =&gt; ClassMethodsHydrator::class</code>
+      <code>\Zend\Hydrator\ObjectProperty::class =&gt; ObjectPropertyHydrator::class</code>
+      <code>\Zend\Hydrator\Reflection::class =&gt; ReflectionHydrator::class</code>
+    </DuplicateArrayKey>
+  </file>
+  <file src="src/HydratorPluginManagerFactory.php">
+    <MixedArgument occurrences="1">
+      <code>$config['hydrators']</code>
+    </MixedArgument>
+    <MixedArrayAccess occurrences="1">
+      <code>$config['hydrators']</code>
+    </MixedArrayAccess>
+    <MixedAssignment occurrences="1">
+      <code>$config</code>
+    </MixedAssignment>
+  </file>
+  <file src="src/Iterator/HydratingIteratorIterator.php">
+    <MissingParamType occurrences="1">
+      <code>$prototype</code>
+    </MissingParamType>
+    <MixedArgument occurrences="1">
+      <code>$currentValue</code>
+    </MixedArgument>
+    <MixedAssignment occurrences="1">
+      <code>$currentValue</code>
+    </MixedAssignment>
+    <MixedMethodCall occurrences="1">
+      <code>new $prototype</code>
+    </MixedMethodCall>
+  </file>
+  <file src="src/Module.php">
+    <MixedAssignment occurrences="2">
+      <code>$container</code>
+      <code>$serviceListener</code>
+    </MixedAssignment>
+    <MixedMethodCall occurrences="2">
+      <code>addServiceManager</code>
+      <code>get</code>
+    </MixedMethodCall>
+  </file>
+  <file src="src/NamingStrategy/MapNamingStrategy.php">
+    <MissingClosureParamType occurrences="2">
+      <code>$key</code>
+      <code>$value</code>
+    </MissingClosureParamType>
+    <MixedPropertyTypeCoercion occurrences="2">
+      <code>$strategy-&gt;flipMapping($extractionMap)</code>
+      <code>$strategy-&gt;flipMapping($hydrationMap)</code>
+    </MixedPropertyTypeCoercion>
+    <MixedReturnTypeCoercion occurrences="2">
+      <code>array_flip($array)</code>
+      <code>string[]</code>
+    </MixedReturnTypeCoercion>
+  </file>
+  <file src="src/NamingStrategy/UnderscoreNamingStrategy/CamelCaseToUnderscoreFilter.php">
+    <MissingClosureParamType occurrences="3">
+      <code>$matches</code>
+      <code>$value</code>
+      <code>$value</code>
+    </MissingClosureParamType>
+    <MixedArgument occurrences="3">
+      <code>$matches[1]</code>
+      <code>$value</code>
+      <code>$value</code>
+    </MixedArgument>
+    <MixedArrayAccess occurrences="1">
+      <code>$matches[1]</code>
+    </MixedArrayAccess>
+    <MixedInferredReturnType occurrences="1">
+      <code>string</code>
+    </MixedInferredReturnType>
+    <MixedReturnStatement occurrences="1">
+      <code>$lowerFunction($filtered)</code>
+    </MixedReturnStatement>
+  </file>
+  <file src="src/NamingStrategy/UnderscoreNamingStrategy/StringSupportTrait.php">
+    <DocblockTypeContradiction occurrences="2">
+      <code>$this-&gt;mbStringSupport === null</code>
+      <code>$this-&gt;pcreUnicodeSupport === null</code>
+    </DocblockTypeContradiction>
+    <MissingConstructor occurrences="4">
+      <code>$mbStringSupport</code>
+      <code>$mbStringSupport</code>
+      <code>$pcreUnicodeSupport</code>
+      <code>$pcreUnicodeSupport</code>
+    </MissingConstructor>
+  </file>
+  <file src="src/NamingStrategy/UnderscoreNamingStrategy/UnderscoreToCamelCaseFilter.php">
+    <MissingClosureParamType occurrences="4">
+      <code>$matches</code>
+      <code>$matches</code>
+      <code>$matches</code>
+      <code>$value</code>
+    </MissingClosureParamType>
+    <MixedArgument occurrences="5">
+      <code>$matches[2]</code>
+      <code>$matches[2]</code>
+      <code>$matches[2]</code>
+      <code>$value</code>
+      <code>$value[0]</code>
+    </MixedArgument>
+    <MixedArgumentTypeCoercion occurrences="1">
+      <code>$pcreInfo-&gt;replacement</code>
+    </MixedArgumentTypeCoercion>
+    <MixedArrayAccess occurrences="4">
+      <code>$matches[2]</code>
+      <code>$matches[2]</code>
+      <code>$matches[2]</code>
+      <code>$value[0]</code>
+    </MixedArrayAccess>
+    <MixedInferredReturnType occurrences="1">
+      <code>string</code>
+    </MixedInferredReturnType>
+    <MixedReturnStatement occurrences="1">
+      <code>$lcFirstFunction($filtered)</code>
+    </MixedReturnStatement>
+  </file>
+  <file src="src/ObjectProperty.php">
+    <DeprecatedClass occurrences="1">
+      <code>ObjectProperty::class</code>
+    </DeprecatedClass>
+  </file>
+  <file src="src/ObjectPropertyHydrator.php">
+    <MixedArgument occurrences="1">
+      <code>$name</code>
+    </MixedArgument>
+    <MixedArgumentTypeCoercion occurrences="1">
+      <code>$name</code>
+    </MixedArgumentTypeCoercion>
+    <MixedAssignment occurrences="5">
+      <code>$data[$name]</code>
+      <code>$extracted</code>
+      <code>$name</code>
+      <code>$value</code>
+      <code>$value</code>
+    </MixedAssignment>
+  </file>
+  <file src="src/Reflection.php">
+    <DeprecatedClass occurrences="1">
+      <code>Reflection::class</code>
+    </DeprecatedClass>
+  </file>
+  <file src="src/ReflectionHydrator.php">
+    <MixedArgument occurrences="1">
+      <code>$propertyName</code>
+    </MixedArgument>
+    <MixedArgumentTypeCoercion occurrences="1">
+      <code>$key</code>
+    </MixedArgumentTypeCoercion>
+    <MixedAssignment occurrences="4">
+      <code>$propertyName</code>
+      <code>$result[$propertyName]</code>
+      <code>$value</code>
+      <code>$value</code>
+    </MixedAssignment>
+  </file>
+  <file src="src/StandaloneHydratorPluginManager.php">
+    <DeprecatedClass occurrences="8">
+      <code>ArraySerializable::class</code>
+      <code>ClassMethods::class</code>
+      <code>ObjectProperty::class</code>
+      <code>Reflection::class</code>
+      <code>\Zend\Hydrator\ArraySerializable::class</code>
+      <code>\Zend\Hydrator\ClassMethods::class</code>
+      <code>\Zend\Hydrator\ObjectProperty::class</code>
+      <code>\Zend\Hydrator\Reflection::class</code>
+    </DeprecatedClass>
+    <DuplicateArrayKey occurrences="4">
+      <code>\Zend\Hydrator\ArraySerializable::class =&gt; ArraySerializableHydrator::class</code>
+      <code>\Zend\Hydrator\ClassMethods::class =&gt; ClassMethodsHydrator::class</code>
+      <code>\Zend\Hydrator\ObjectProperty::class =&gt; ObjectPropertyHydrator::class</code>
+      <code>\Zend\Hydrator\Reflection::class =&gt; ReflectionHydrator::class</code>
+    </DuplicateArrayKey>
+    <InvalidStringClass occurrences="1">
+      <code>new $class()</code>
+    </InvalidStringClass>
+    <MissingClosureReturnType occurrences="1">
+      <code>function (ContainerInterface $container, string $class) {</code>
+    </MissingClosureReturnType>
+    <MixedAssignment occurrences="1">
+      <code>$instance</code>
+    </MixedAssignment>
+  </file>
+  <file src="src/Strategy/BooleanStrategy.php">
+    <DocblockTypeContradiction occurrences="7">
+      <code>! is_int($falseValue) &amp;&amp; ! is_string($falseValue)</code>
+      <code>! is_int($trueValue) &amp;&amp; ! is_string($trueValue)</code>
+      <code>! is_string($value) &amp;&amp; ! is_int($value)</code>
+      <code>is_bool($value)</code>
+      <code>is_int($value)</code>
+      <code>is_string($falseValue)</code>
+      <code>is_string($trueValue)</code>
+    </DocblockTypeContradiction>
+    <MoreSpecificImplementedParamType occurrences="2">
+      <code>$value</code>
+      <code>$value</code>
+    </MoreSpecificImplementedParamType>
+  </file>
+  <file src="src/Strategy/CollectionStrategy.php">
+    <ArgumentTypeCoercion occurrences="1">
+      <code>$this-&gt;objectClassName</code>
+    </ArgumentTypeCoercion>
+    <DocblockTypeContradiction occurrences="2">
+      <code>is_array($value)</code>
+      <code>is_array($value)</code>
+    </DocblockTypeContradiction>
+    <MixedArgument occurrences="2">
+      <code>$data</code>
+      <code>$object</code>
+    </MixedArgument>
+    <MoreSpecificImplementedParamType occurrences="2">
+      <code>$value</code>
+      <code>$value</code>
+    </MoreSpecificImplementedParamType>
+  </file>
+  <file src="src/Strategy/DateTimeImmutableFormatterStrategy.php">
+    <MixedAssignment occurrences="1">
+      <code>$hydrated</code>
+    </MixedAssignment>
+  </file>
+  <file src="src/Strategy/ExplodeStrategy.php">
+    <DocblockTypeContradiction occurrences="2">
+      <code>is_array($value)</code>
+      <code>is_string($value)</code>
+    </DocblockTypeContradiction>
+    <MoreSpecificImplementedParamType occurrences="2">
+      <code>$value</code>
+      <code>$value</code>
+    </MoreSpecificImplementedParamType>
+    <RedundantConditionGivenDocblockType occurrences="1">
+      <code>is_string($value)</code>
+    </RedundantConditionGivenDocblockType>
+  </file>
+  <file src="src/Strategy/HydratorStrategy.php">
+    <ArgumentTypeCoercion occurrences="1">
+      <code>$this-&gt;objectClassName</code>
+    </ArgumentTypeCoercion>
+    <DocblockTypeContradiction occurrences="1">
+      <code>gettype($value)</code>
+    </DocblockTypeContradiction>
+    <MixedInferredReturnType occurrences="1">
+      <code>object|string|null</code>
+    </MixedInferredReturnType>
+    <MixedReturnStatement occurrences="1">
+      <code>$value</code>
+    </MixedReturnStatement>
+    <MoreSpecificImplementedParamType occurrences="1">
+      <code>$value</code>
+    </MoreSpecificImplementedParamType>
+    <RedundantConditionGivenDocblockType occurrences="1">
+      <code>is_object($value)</code>
+    </RedundantConditionGivenDocblockType>
+  </file>
+  <file src="src/Strategy/SerializableStrategy.php">
+    <DocblockTypeContradiction occurrences="2">
+      <code>iterator_to_array($serializerOptions)</code>
+      <code>null === $this-&gt;serializer</code>
+    </DocblockTypeContradiction>
+    <MixedArgument occurrences="2">
+      <code>$serializerOptions</code>
+      <code>$value</code>
+    </MixedArgument>
+    <RedundantConditionGivenDocblockType occurrences="1">
+      <code>is_array($serializerOptions)</code>
+    </RedundantConditionGivenDocblockType>
+  </file>
+  <file src="src/Strategy/StrategyChain.php">
+    <MixedAssignment occurrences="2">
+      <code>$value</code>
+      <code>$value</code>
+    </MixedAssignment>
+    <MixedPropertyTypeCoercion occurrences="1">
+      <code>array_reverse($extractionStrategies)</code>
+    </MixedPropertyTypeCoercion>
+  </file>
+  <file src="test/Aggregate/AggregateHydratorFunctionalTest.php">
+    <MissingClosureReturnType occurrences="2">
+      <code>function (ExtractEvent $event) {</code>
+      <code>function (HydrateEvent $event) use ($swappedObject) {</code>
+    </MissingClosureReturnType>
+    <MissingParamType occurrences="3">
+      <code>$data</code>
+      <code>$object</code>
+      <code>$object</code>
+    </MissingParamType>
+    <MissingReturnType occurrences="7">
+      <code>testEmptyAggregate</code>
+      <code>testExtractWithMultipleHydrators</code>
+      <code>testHydrateWithMultipleHydrators</code>
+      <code>testSingleHydratorExtraction</code>
+      <code>testSingleHydratorHydration</code>
+      <code>testStoppedPropagationInExtraction</code>
+      <code>testStoppedPropagationInHydration</code>
+    </MissingReturnType>
+    <MixedArgument occurrences="5">
+      <code>$blueprint</code>
+      <code>$blueprint</code>
+      <code>$data</code>
+      <code>$object</code>
+      <code>$object</code>
+    </MixedArgument>
+    <MixedAssignment occurrences="2">
+      <code>$blueprint</code>
+      <code>$blueprint</code>
+    </MixedAssignment>
+    <MixedClone occurrences="2">
+      <code>clone $object</code>
+      <code>clone $object</code>
+    </MixedClone>
+    <PropertyNotSetInConstructor occurrences="3">
+      <code>$hydrator</code>
+      <code>AggregateHydratorFunctionalTest</code>
+      <code>AggregateHydratorFunctionalTest</code>
+    </PropertyNotSetInConstructor>
+  </file>
+  <file src="test/Aggregate/AggregateHydratorTest.php">
+    <MissingReturnType occurrences="4">
+      <code>testAdd</code>
+      <code>testExtract</code>
+      <code>testGetSetManager</code>
+      <code>testHydrate</code>
+    </MissingReturnType>
+    <PropertyNotSetInConstructor occurrences="4">
+      <code>$eventManager</code>
+      <code>$hydrator</code>
+      <code>AggregateHydratorTest</code>
+      <code>AggregateHydratorTest</code>
+    </PropertyNotSetInConstructor>
+  </file>
+  <file src="test/Aggregate/ExtractEventTest.php">
+    <MissingReturnType occurrences="1">
+      <code>testEvent</code>
+    </MissingReturnType>
+    <PropertyNotSetInConstructor occurrences="2">
+      <code>ExtractEventTest</code>
+      <code>ExtractEventTest</code>
+    </PropertyNotSetInConstructor>
+  </file>
+  <file src="test/Aggregate/HydrateEventTest.php">
+    <MissingReturnType occurrences="1">
+      <code>testEvent</code>
+    </MissingReturnType>
+    <PropertyNotSetInConstructor occurrences="2">
+      <code>HydrateEventTest</code>
+      <code>HydrateEventTest</code>
+    </PropertyNotSetInConstructor>
+  </file>
+  <file src="test/Aggregate/HydratorListenerTest.php">
+    <InternalMethod occurrences="2">
+      <code>onExtract</code>
+      <code>onHydrate</code>
+    </InternalMethod>
+    <MissingReturnType occurrences="3">
+      <code>testAttach</code>
+      <code>testOnExtract</code>
+      <code>testOnHydrate</code>
+    </MissingReturnType>
+    <MixedMethodCall occurrences="6">
+      <code>method</code>
+      <code>method</code>
+      <code>will</code>
+      <code>will</code>
+      <code>with</code>
+      <code>with</code>
+    </MixedMethodCall>
+    <PropertyNotSetInConstructor occurrences="4">
+      <code>$hydrator</code>
+      <code>$listener</code>
+      <code>HydratorListenerTest</code>
+      <code>HydratorListenerTest</code>
+    </PropertyNotSetInConstructor>
+    <UndefinedDocblockClass occurrences="3">
+      <code>HydratorInterface|\PHPUnit_Framework_MockObject_MockObject</code>
+    </UndefinedDocblockClass>
+    <UndefinedInterfaceMethod occurrences="2">
+      <code>expects</code>
+      <code>expects</code>
+    </UndefinedInterfaceMethod>
+  </file>
+  <file src="test/ArraySerializableHydratorTest.php">
+    <InvalidArgument occurrences="2">
+      <code>'thisIsNotAnObject'</code>
+      <code>'thisIsNotAnObject'</code>
+    </InvalidArgument>
+    <MissingParamType occurrences="3">
+      <code>$expected</code>
+      <code>$start</code>
+      <code>$submit</code>
+    </MissingParamType>
+    <MissingReturnType occurrences="9">
+      <code>arrayDataProvider</code>
+      <code>testCanExtractFromArraySerializableObject</code>
+      <code>testCanHydrateToArraySerializableObject</code>
+      <code>testExtractArrayObject</code>
+      <code>testHydrationWillReplaceNestedArrayData</code>
+      <code>testHydratorExtractThrowsExceptionOnNonObjectParameter</code>
+      <code>testHydratorHydrateThrowsExceptionOnNonObjectParameter</code>
+      <code>testWillPreserveOriginalPropsAtHydration</code>
+      <code>testWillReplaceArrayIfNoGetArrayCopy</code>
+    </MissingReturnType>
+    <MixedMethodCall occurrences="3">
+      <code>getArrayCopy</code>
+      <code>getArrayCopy</code>
+      <code>getData</code>
+    </MixedMethodCall>
+    <PropertyNotSetInConstructor occurrences="3">
+      <code>$hydrator</code>
+      <code>ArraySerializableHydratorTest</code>
+      <code>ArraySerializableHydratorTest</code>
+    </PropertyNotSetInConstructor>
+  </file>
+  <file src="test/ArraySerializableTest.php">
+    <DeprecatedClass occurrences="1">
+      <code>new ArraySerializable()</code>
+    </DeprecatedClass>
+    <MissingClosureParamType occurrences="2">
+      <code>$errno</code>
+      <code>$errstr</code>
+    </MissingClosureParamType>
+    <MissingReturnType occurrences="1">
+      <code>testTriggerUserDeprecatedError</code>
+    </MissingReturnType>
+    <PropertyNotSetInConstructor occurrences="2">
+      <code>ArraySerializableTest</code>
+      <code>ArraySerializableTest</code>
+    </PropertyNotSetInConstructor>
+    <RedundantCondition occurrences="1">
+      <code>assertInstanceOf</code>
+    </RedundantCondition>
+  </file>
+  <file src="test/ClassMethodsHydratorTest.php">
+    <InvalidArgument occurrences="4">
+      <code>$options</code>
+      <code>'invalid options'</code>
+      <code>'non-object'</code>
+      <code>'non-object'</code>
+    </InvalidArgument>
+    <MissingReturnType occurrences="7">
+      <code>testCanExtractFromMethodsWithOptionalParameters</code>
+      <code>testCanHydratedPromiscuousInstances</code>
+      <code>testExtractClassWithoutAnyMethod</code>
+      <code>testExtractNonObjectThrowsTypeError</code>
+      <code>testHydrateNonObjectThrowsTypeError</code>
+      <code>testSetOptionsFromTraversable</code>
+      <code>testSetOptionsThrowsException</code>
+    </MissingReturnType>
+    <MixedMethodCall occurrences="3">
+      <code>getArrayCopy</code>
+      <code>getFooBar</code>
+      <code>getFooBar</code>
+    </MixedMethodCall>
+    <PropertyNotSetInConstructor occurrences="3">
+      <code>$hydrator</code>
+      <code>ClassMethodsHydratorTest</code>
+      <code>ClassMethodsHydratorTest</code>
+    </PropertyNotSetInConstructor>
+  </file>
+  <file src="test/ClassMethodsTest.php">
+    <DeprecatedClass occurrences="1">
+      <code>new ClassMethods()</code>
+    </DeprecatedClass>
+    <MissingClosureParamType occurrences="2">
+      <code>$errno</code>
+      <code>$errstr</code>
+    </MissingClosureParamType>
+    <MissingReturnType occurrences="1">
+      <code>testTriggerUserDeprecatedError</code>
+    </MissingReturnType>
+    <PropertyNotSetInConstructor occurrences="2">
+      <code>ClassMethodsTest</code>
+      <code>ClassMethodsTest</code>
+    </PropertyNotSetInConstructor>
+    <RedundantCondition occurrences="1">
+      <code>assertInstanceOf</code>
+    </RedundantCondition>
+  </file>
+  <file src="test/DelegatingHydratorFactoryTest.php">
+    <MissingReturnType occurrences="4">
+      <code>testFactoryCreatesHydratorPluginManagerToSeedDelegatingHydratorAsFallback</code>
+      <code>testFactoryUsesContainerToSeedDelegatingHydratorWhenItIsAHydratorPluginManager</code>
+      <code>testFactoryUsesHydratorManagerServiceFromContainerToSeedDelegatingHydratorWhenAvailable</code>
+      <code>testFactoryUsesHydratorPluginManagerServiceFromContainerToSeedDelegatingHydratorWhenAvailable</code>
+    </MissingReturnType>
+    <MixedAssignment occurrences="1">
+      <code>$hydrators</code>
+    </MixedAssignment>
+    <PropertyNotSetInConstructor occurrences="2">
+      <code>DelegatingHydratorFactoryTest</code>
+      <code>DelegatingHydratorFactoryTest</code>
+    </PropertyNotSetInConstructor>
+    <RedundantCondition occurrences="4">
+      <code>assertInstanceOf</code>
+      <code>assertInstanceOf</code>
+      <code>assertInstanceOf</code>
+      <code>assertInstanceOf</code>
+    </RedundantCondition>
+    <TooManyArguments occurrences="4">
+      <code>$factory</code>
+      <code>$factory</code>
+      <code>$factory</code>
+      <code>$factory</code>
+    </TooManyArguments>
+  </file>
+  <file src="test/DelegatingHydratorTest.php">
+    <MissingReturnType occurrences="2">
+      <code>testExtract</code>
+      <code>testHydrate</code>
+    </MissingReturnType>
+    <PropertyNotSetInConstructor occurrences="5">
+      <code>$hydrator</code>
+      <code>$hydrators</code>
+      <code>$object</code>
+      <code>DelegatingHydratorTest</code>
+      <code>DelegatingHydratorTest</code>
+    </PropertyNotSetInConstructor>
+  </file>
+  <file src="test/Filter/FilterCompositeTest.php">
+    <MissingClosureReturnType occurrences="1">
+      <code>static function () {</code>
+    </MissingClosureReturnType>
+    <MissingParamType occurrences="1">
+      <code>$value</code>
+    </MissingParamType>
+    <MissingReturnType occurrences="6">
+      <code>generateFilters</code>
+      <code>providerCompositionFiltering</code>
+      <code>testCompositionFiltering</code>
+      <code>testConstructWithInvalidFilter</code>
+      <code>testFilters</code>
+      <code>testNoFilters</code>
+    </MissingReturnType>
+    <MixedArgument occurrences="2">
+      <code>$andFilters</code>
+      <code>$orFilters</code>
+    </MixedArgument>
+    <MixedArgumentTypeCoercion occurrences="7">
+      <code>$andFilters</code>
+      <code>$andFilters</code>
+      <code>$andFilters</code>
+      <code>$name</code>
+      <code>$orFilters</code>
+      <code>$orFilters</code>
+      <code>$orFilters</code>
+    </MixedArgumentTypeCoercion>
+    <MixedAssignment occurrences="4">
+      <code>$andFilters</code>
+      <code>$orFilters</code>
+      <code>$value</code>
+      <code>$value</code>
+    </MixedAssignment>
+    <MixedInferredReturnType occurrences="1">
+      <code>bool</code>
+    </MixedInferredReturnType>
+    <MixedReturnStatement occurrences="1">
+      <code>$this-&gt;value</code>
+    </MixedReturnStatement>
+    <PropertyNotSetInConstructor occurrences="2">
+      <code>FilterCompositeTest</code>
+      <code>FilterCompositeTest</code>
+    </PropertyNotSetInConstructor>
+    <UndefinedThisPropertyAssignment occurrences="1">
+      <code>$this-&gt;value</code>
+    </UndefinedThisPropertyAssignment>
+    <UndefinedThisPropertyFetch occurrences="1">
+      <code>$this-&gt;value</code>
+    </UndefinedThisPropertyFetch>
+  </file>
+  <file src="test/Filter/MethodMatchFilterTest.php">
+    <MissingParamType occurrences="2">
+      <code>$expected</code>
+      <code>$methodName</code>
+    </MissingParamType>
+    <MissingReturnType occurrences="2">
+      <code>providerFilter</code>
+      <code>testFilter</code>
+    </MissingReturnType>
+    <MixedArgument occurrences="1">
+      <code>$methodName</code>
+    </MixedArgument>
+    <PropertyNotSetInConstructor occurrences="2">
+      <code>MethodMatchFilterTest</code>
+      <code>MethodMatchFilterTest</code>
+    </PropertyNotSetInConstructor>
+  </file>
+  <file src="test/Filter/NumberOfParameterFilterTest.php">
+    <MissingParamType occurrences="1">
+      <code>$parameter</code>
+    </MissingParamType>
+    <MissingReturnType occurrences="5">
+      <code>methodWithNoParameters</code>
+      <code>methodWithOptionalParameters</code>
+      <code>testArityOne</code>
+      <code>testArityZero</code>
+      <code>testFilterPropertyDoesNotExist</code>
+    </MissingReturnType>
+    <PropertyNotSetInConstructor occurrences="2">
+      <code>NumberOfParameterFilterTest</code>
+      <code>NumberOfParameterFilterTest</code>
+    </PropertyNotSetInConstructor>
+  </file>
+  <file src="test/Filter/OptionalParametersFilterTest.php">
+    <MissingParamType occurrences="6">
+      <code>$otherParameter</code>
+      <code>$otherParameter</code>
+      <code>$parameter</code>
+      <code>$parameter</code>
+      <code>$parameter</code>
+      <code>$parameter</code>
+    </MissingParamType>
+    <MissingReturnType occurrences="8">
+      <code>methodWithMultipleMandatoryParameters</code>
+      <code>methodWithMultipleOptionalParameters</code>
+      <code>methodWithSingleMandatoryParameter</code>
+      <code>methodWithSingleOptionalParameter</code>
+      <code>methodWithoutParameters</code>
+      <code>testMethods</code>
+      <code>testMethodsOnSubsequentCalls</code>
+      <code>testTriggersExceptionOnUnknownMethod</code>
+    </MissingReturnType>
+    <PropertyNotSetInConstructor occurrences="3">
+      <code>$filter</code>
+      <code>OptionalParametersFilterTest</code>
+      <code>OptionalParametersFilterTest</code>
+    </PropertyNotSetInConstructor>
+  </file>
+  <file src="test/HydratorAwareTraitTest.php">
+    <ArgumentTypeCoercion occurrences="2">
+      <code>'\Laminas\Hydrator\AbstractHydrator'</code>
+      <code>'\Laminas\Hydrator\AbstractHydrator'</code>
+    </ArgumentTypeCoercion>
+    <MissingReturnType occurrences="2">
+      <code>testGetHydrator</code>
+      <code>testSetHydrator</code>
+    </MissingReturnType>
+    <MixedMethodCall occurrences="6">
+      <code>getHydrator</code>
+      <code>getHydrator</code>
+      <code>getHydrator</code>
+      <code>getHydrator</code>
+      <code>setHydrator</code>
+      <code>setHydrator</code>
+    </MixedMethodCall>
+    <PropertyNotSetInConstructor occurrences="2">
+      <code>HydratorAwareTraitTest</code>
+      <code>HydratorAwareTraitTest</code>
+    </PropertyNotSetInConstructor>
+  </file>
+  <file src="test/HydratorClosureStrategyTest.php">
+    <MissingClosureParamType occurrences="4">
+      <code>$value</code>
+      <code>$value</code>
+      <code>$value</code>
+      <code>$value</code>
+    </MissingClosureParamType>
+    <MissingReturnType occurrences="7">
+      <code>testAddingStrategy</code>
+      <code>testCheckStrategyEmpty</code>
+      <code>testCheckStrategyNotEmpty</code>
+      <code>testExtractingObjects</code>
+      <code>testHydratingObjects</code>
+      <code>testRemovingStrategy</code>
+      <code>testRetrieveStrategy</code>
+    </MissingReturnType>
+    <MixedArgument occurrences="4">
+      <code>$value</code>
+      <code>$value</code>
+      <code>$value</code>
+      <code>$value</code>
+    </MixedArgument>
+    <PropertyNotSetInConstructor occurrences="3">
+      <code>$hydrator</code>
+      <code>HydratorClosureStrategyTest</code>
+      <code>HydratorClosureStrategyTest</code>
+    </PropertyNotSetInConstructor>
+    <UndefinedInterfaceMethod occurrences="17">
+      <code>addStrategy</code>
+      <code>addStrategy</code>
+      <code>addStrategy</code>
+      <code>addStrategy</code>
+      <code>addStrategy</code>
+      <code>addStrategy</code>
+      <code>addStrategy</code>
+      <code>addStrategy</code>
+      <code>getStrategy</code>
+      <code>hasStrategy</code>
+      <code>hasStrategy</code>
+      <code>hasStrategy</code>
+      <code>hasStrategy</code>
+      <code>hasStrategy</code>
+      <code>hasStrategy</code>
+      <code>hasStrategy</code>
+      <code>removeStrategy</code>
+    </UndefinedInterfaceMethod>
+    <UndefinedPropertyFetch occurrences="1">
+      <code>$entity-&gt;field3</code>
+    </UndefinedPropertyFetch>
+  </file>
+  <file src="test/HydratorObjectPropertyTest.php">
+    <MissingClosureParamType occurrences="2">
+      <code>$property</code>
+      <code>$property</code>
+    </MissingClosureParamType>
+    <MissingReturnType occurrences="1">
+      <code>testMultipleInvocationsWithDifferentFiltersFindsAllProperties</code>
+    </MissingReturnType>
+    <PropertyNotSetInConstructor occurrences="3">
+      <code>$hydrator</code>
+      <code>HydratorObjectPropertyTest</code>
+      <code>HydratorObjectPropertyTest</code>
+    </PropertyNotSetInConstructor>
+  </file>
+  <file src="test/HydratorPluginManagerCompatibilityTest.php">
+    <InvalidReturnType occurrences="1">
+      <code>getV2InvalidPluginException</code>
+    </InvalidReturnType>
+    <PropertyNotSetInConstructor occurrences="2">
+      <code>HydratorPluginManagerCompatibilityTest</code>
+      <code>HydratorPluginManagerCompatibilityTest</code>
+    </PropertyNotSetInConstructor>
+  </file>
+  <file src="test/HydratorPluginManagerFactoryTest.php">
+    <MissingClosureParamType occurrences="1">
+      <code>$container</code>
+    </MissingClosureParamType>
+    <MissingClosureReturnType occurrences="1">
+      <code>function ($container) use ($hydrator) {</code>
+    </MissingClosureReturnType>
+    <MissingReturnType occurrences="6">
+      <code>testConfiguresHydratorServicesWhenFound</code>
+      <code>testDoesNotConfigureHydratorServicesWhenConfigServiceDoesNotContainHydratorsConfig</code>
+      <code>testDoesNotConfigureHydratorServicesWhenConfigServiceNotPresent</code>
+      <code>testDoesNotConfigureHydratorServicesWhenServiceListenerPresent</code>
+      <code>testFactoryConfiguresPluginManagerUnderContainerInterop</code>
+      <code>testFactoryReturnsPluginManager</code>
+    </MissingReturnType>
+    <PropertyNotSetInConstructor occurrences="2">
+      <code>HydratorPluginManagerFactoryTest</code>
+      <code>HydratorPluginManagerFactoryTest</code>
+    </PropertyNotSetInConstructor>
+    <RedundantCondition occurrences="5">
+      <code>assertInstanceOf</code>
+      <code>assertInstanceOf</code>
+      <code>assertInstanceOf</code>
+      <code>assertInstanceOf</code>
+      <code>assertInstanceOf</code>
+    </RedundantCondition>
+  </file>
+  <file src="test/HydratorStrategyTest.php">
+    <MissingParamType occurrences="2">
+      <code>$formFieldKey</code>
+      <code>$underscoreSeparatedKeys</code>
+    </MissingParamType>
+    <MissingPropertyType occurrences="2">
+      <code>$strategy-&gt;data</code>
+      <code>$strategy-&gt;object</code>
+    </MissingPropertyType>
+    <MissingReturnType occurrences="11">
+      <code>testAddingStrategy</code>
+      <code>testCheckStrategyEmpty</code>
+      <code>testCheckStrategyNotEmpty</code>
+      <code>testContextAwarenessExtract</code>
+      <code>testContextAwarenessHydrate</code>
+      <code>testExtractingObjects</code>
+      <code>testHydratingObjects</code>
+      <code>testRemovingStrategy</code>
+      <code>testRetrieveStrategy</code>
+      <code>testWhenUsingUnderscoreSeparatedKeysHydratorStrategyIsAlwaysConsideredUnderscoreSeparatedToo</code>
+      <code>underscoreHandlingDataProvider</code>
+    </MissingReturnType>
+    <MixedArgument occurrences="5">
+      <code>$attributes['entities']</code>
+      <code>$attributes['entities']</code>
+      <code>$entities</code>
+      <code>$formFieldKey</code>
+      <code>$underscoreSeparatedKeys</code>
+    </MixedArgument>
+    <MixedArrayAssignment occurrences="1">
+      <code>$attributes['entities'][]</code>
+    </MixedArrayAssignment>
+    <MixedAssignment occurrences="2">
+      <code>$entities</code>
+      <code>$value</code>
+    </MixedAssignment>
+    <PropertyNotSetInConstructor occurrences="3">
+      <code>$hydrator</code>
+      <code>HydratorStrategyTest</code>
+      <code>HydratorStrategyTest</code>
+    </PropertyNotSetInConstructor>
+    <UndefinedInterfaceMethod occurrences="17">
+      <code>addStrategy</code>
+      <code>addStrategy</code>
+      <code>addStrategy</code>
+      <code>addStrategy</code>
+      <code>addStrategy</code>
+      <code>addStrategy</code>
+      <code>addStrategy</code>
+      <code>addStrategy</code>
+      <code>getStrategy</code>
+      <code>hasStrategy</code>
+      <code>hasStrategy</code>
+      <code>hasStrategy</code>
+      <code>hasStrategy</code>
+      <code>hasStrategy</code>
+      <code>hasStrategy</code>
+      <code>hasStrategy</code>
+      <code>removeStrategy</code>
+    </UndefinedInterfaceMethod>
+  </file>
+  <file src="test/HydratorTest.php">
+    <MissingClosureParamType occurrences="3">
+      <code>$property</code>
+      <code>$property</code>
+      <code>$property</code>
+    </MissingClosureParamType>
+    <MissingParamType occurrences="2">
+      <code>$hydrator</code>
+      <code>$serializable</code>
+    </MissingParamType>
+    <MissingReturnType occurrences="22">
+      <code>filterProvider</code>
+      <code>testArraySerializableFilter</code>
+      <code>testHydratorClassMethodsCamelCase</code>
+      <code>testHydratorClassMethodsCamelCaseWithSetterMissing</code>
+      <code>testHydratorClassMethodsDefaultBehaviorIsConvertUnderscoreToCamelCase</code>
+      <code>testHydratorClassMethodsIgnoresInvalidValues</code>
+      <code>testHydratorClassMethodsManipulateFilter</code>
+      <code>testHydratorClassMethodsOptions</code>
+      <code>testHydratorClassMethodsTitleCase</code>
+      <code>testHydratorClassMethodsUnderscore</code>
+      <code>testHydratorClassMethodsUnderscoreWithUnderscoreUpperCasedHydrateDataKeys</code>
+      <code>testHydratorClassMethodsWithCustomFilter</code>
+      <code>testHydratorClassMethodsWithInvalidNumberOfParameters</code>
+      <code>testHydratorClassMethodsWithMagicMethodSetter</code>
+      <code>testHydratorClassMethodsWithMagicMethodSetterAndMethodExistsCheck</code>
+      <code>testHydratorClassMethodsWithProtectedSetter</code>
+      <code>testHydratorReflection</code>
+      <code>testInitiateValues</code>
+      <code>testObjectBasedFilters</code>
+      <code>testRetrieveWildStrategyAndOther</code>
+      <code>testUseWildStrategyAndOther</code>
+      <code>testUseWildStrategyByDefault</code>
+    </MissingReturnType>
+    <MixedArgument occurrences="2">
+      <code>$property</code>
+      <code>$property</code>
+    </MixedArgument>
+    <MixedMethodCall occurrences="10">
+      <code>addFilter</code>
+      <code>addFilter</code>
+      <code>extract</code>
+      <code>extract</code>
+      <code>extract</code>
+      <code>extract</code>
+      <code>getFooBar</code>
+      <code>getFooBarBaz</code>
+      <code>removeFilter</code>
+      <code>removeFilter</code>
+    </MixedMethodCall>
+    <PropertyNotSetInConstructor occurrences="8">
+      <code>$classMethodsCamelCase</code>
+      <code>$classMethodsCamelCaseMissing</code>
+      <code>$classMethodsInvalidParameter</code>
+      <code>$classMethodsTitleCase</code>
+      <code>$classMethodsUnderscore</code>
+      <code>$reflection</code>
+      <code>HydratorTest</code>
+      <code>HydratorTest</code>
+    </PropertyNotSetInConstructor>
+  </file>
+  <file src="test/HydratorTestTrait.php">
+    <MissingReturnType occurrences="2">
+      <code>testExtractWithNamingStrategyAndStrategy</code>
+      <code>testHydrateWithNamingStrategyAndStrategy</code>
+    </MissingReturnType>
+    <MixedMethodCall occurrences="1">
+      <code>getValue</code>
+    </MixedMethodCall>
+  </file>
+  <file src="test/Iterator/HydratingArrayIteratorTest.php">
+    <MissingReturnType occurrences="3">
+      <code>testHydratesObjectAndClonesOnCurrent</code>
+      <code>testThrowingInvalidArgumentExceptionWhenSettingPrototypeToInvalidClass</code>
+      <code>testUsingStringForObjectName</code>
+    </MissingReturnType>
+    <PropertyNotSetInConstructor occurrences="2">
+      <code>HydratingArrayIteratorTest</code>
+      <code>HydratingArrayIteratorTest</code>
+    </PropertyNotSetInConstructor>
+  </file>
+  <file src="test/Iterator/HydratingIteratorIteratorTest.php">
+    <MissingReturnType occurrences="3">
+      <code>testHydratesObjectAndClonesOnCurrent</code>
+      <code>testThrowingInvalidArgumentExceptionWhenSettingPrototypeToInvalidClass</code>
+      <code>testUsingStringForObjectName</code>
+    </MissingReturnType>
+    <PropertyNotSetInConstructor occurrences="2">
+      <code>HydratingIteratorIteratorTest</code>
+      <code>HydratingIteratorIteratorTest</code>
+    </PropertyNotSetInConstructor>
+  </file>
+  <file src="test/NamingStrategy/CompositeNamingStrategyTest.php">
+    <MissingReturnType occurrences="4">
+      <code>testExtract</code>
+      <code>testGetSameNameWhenNoNamingStrategyExistsForTheName</code>
+      <code>testHydrate</code>
+      <code>testUseDefaultNamingStrategy</code>
+    </MissingReturnType>
+    <PropertyNotSetInConstructor occurrences="2">
+      <code>CompositeNamingStrategyTest</code>
+      <code>CompositeNamingStrategyTest</code>
+    </PropertyNotSetInConstructor>
+  </file>
+  <file src="test/NamingStrategy/IdentityNamingStrategyTest.php">
+    <MissingReturnType occurrences="2">
+      <code>testExtract</code>
+      <code>testHydrate</code>
+    </MissingReturnType>
+    <PropertyNotSetInConstructor occurrences="2">
+      <code>IdentityNamingStrategyTest</code>
+      <code>IdentityNamingStrategyTest</code>
+    </PropertyNotSetInConstructor>
+  </file>
+  <file src="test/NamingStrategy/MapNamingStrategyTest.php">
+    <MissingReturnType occurrences="11">
+      <code>testExtractReturnsVerbatimWhenEmptyExtractionMapProvided</code>
+      <code>testExtractUsesFlippedHydrationMapWhenOnlyHydrationMapProvided</code>
+      <code>testExtractUsesProvidedExtractionMap</code>
+      <code>testExtractionMapConstructorRaisesExceptionWhenFlippingHydrationMapForInvalidKeys</code>
+      <code>testExtractionMapConstructorRaisesExceptionWhenFlippingHydrationMapForInvalidValues</code>
+      <code>testHydrateAndExtractUseAsymmetricMapProvided</code>
+      <code>testHydrateReturnsVerbatimWhenEmptyHydrationMapProvided</code>
+      <code>testHydrateUsesFlippedExtractionMapOnlyExtractionMapProvided</code>
+      <code>testHydrateUsesProvidedHydrationMap</code>
+      <code>testHydrationMapConstructorRaisesExceptionWhenFlippingExtractionMapForInvalidKeys</code>
+      <code>testHydrationMapConstructorRaisesExceptionWhenFlippingExtractionMapForInvalidValues</code>
+    </MissingReturnType>
+    <MixedArgumentTypeCoercion occurrences="4">
+      <code>[$invalidKey =&gt; 'foo']</code>
+      <code>[$invalidKey =&gt; 'foo']</code>
+      <code>['foo' =&gt; $invalidValue]</code>
+      <code>['foo' =&gt; $invalidValue]</code>
+    </MixedArgumentTypeCoercion>
+    <PropertyNotSetInConstructor occurrences="2">
+      <code>MapNamingStrategyTest</code>
+      <code>MapNamingStrategyTest</code>
+    </PropertyNotSetInConstructor>
+  </file>
+  <file src="test/NamingStrategy/UnderscoreNamingStrategy/CamelCaseToUnderscoreFilterTest.php">
+    <InternalClass occurrences="3">
+      <code>new CamelCaseToUnderscoreFilter()</code>
+      <code>new CamelCaseToUnderscoreFilter()</code>
+      <code>new CamelCaseToUnderscoreFilter()</code>
+    </InternalClass>
+    <InternalMethod occurrences="3">
+      <code>filter</code>
+      <code>filter</code>
+      <code>filter</code>
+    </InternalMethod>
+    <MissingReturnType occurrences="6">
+      <code>nonUnicodeProvider</code>
+      <code>testFilterUnderscoresNonUnicodeStrings</code>
+      <code>testFilterUnderscoresUnicodeStrings</code>
+      <code>testFilterUnderscoresUnicodeStringsWithoutMbStrings</code>
+      <code>unicodeProvider</code>
+      <code>unicodeProviderWithoutMbStrings</code>
+    </MissingReturnType>
+    <PropertyNotSetInConstructor occurrences="2">
+      <code>CamelCaseToUnderscoreFilterTest</code>
+      <code>CamelCaseToUnderscoreFilterTest</code>
+    </PropertyNotSetInConstructor>
+  </file>
+  <file src="test/NamingStrategy/UnderscoreNamingStrategy/UnderscoreToCamelCaseFilterTest.php">
+    <InternalClass occurrences="3">
+      <code>new UnderscoreToCamelCaseFilter()</code>
+      <code>new UnderscoreToCamelCaseFilter()</code>
+      <code>new UnderscoreToCamelCaseFilter()</code>
+    </InternalClass>
+    <InternalMethod occurrences="3">
+      <code>filter</code>
+      <code>filter</code>
+      <code>filter</code>
+    </InternalMethod>
+    <MissingReturnType occurrences="6">
+      <code>nonUnicodeProvider</code>
+      <code>testFilterCamelCasesNonUnicodeStrings</code>
+      <code>testFilterCamelCasesUnicodeStrings</code>
+      <code>testFilterCamelCasesUnicodeStringsWithoutMbStrings</code>
+      <code>unicodeProvider</code>
+      <code>unicodeWithoutMbStringsProvider</code>
+    </MissingReturnType>
+    <PropertyNotSetInConstructor occurrences="2">
+      <code>UnderscoreToCamelCaseFilterTest</code>
+      <code>UnderscoreToCamelCaseFilterTest</code>
+    </PropertyNotSetInConstructor>
+  </file>
+  <file src="test/NamingStrategy/UnderscoreNamingStrategyTest.php">
+    <MissingReturnType occurrences="3">
+      <code>testNameExtractsToUnderscore</code>
+      <code>testNameHydratesToCamelCase</code>
+      <code>testNameHydratesToStudlyCaps</code>
+    </MissingReturnType>
+    <PropertyNotSetInConstructor occurrences="2">
+      <code>UnderscoreNamingStrategyTest</code>
+      <code>UnderscoreNamingStrategyTest</code>
+    </PropertyNotSetInConstructor>
+  </file>
+  <file src="test/ObjectPropertyHydratorTest.php">
+    <InvalidArgument occurrences="2">
+      <code>'thisIsNotAnObject'</code>
+      <code>'thisIsNotAnObject'</code>
+    </InvalidArgument>
+    <MissingReturnType occurrences="10">
+      <code>testCanExtractFromGenericClass</code>
+      <code>testCanExtractFromStdClass</code>
+      <code>testCanHydrateAdditionalPropertiesToStdClass</code>
+      <code>testCanHydrateGenericClassNonExistingProperties</code>
+      <code>testCanHydrateGenericClassPublicProperties</code>
+      <code>testCanHydrateStdClass</code>
+      <code>testHydratorExtractThrowsExceptionOnNonObjectParameter</code>
+      <code>testHydratorHydrateThrowsExceptionOnNonObjectParameter</code>
+      <code>testSkipsPublicStaticClassPropertiesExtraction</code>
+      <code>testSkipsPublicStaticClassPropertiesHydration</code>
+    </MissingReturnType>
+    <MixedMethodCall occurrences="6">
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+    </MixedMethodCall>
+    <PropertyNotSetInConstructor occurrences="3">
+      <code>$hydrator</code>
+      <code>ObjectPropertyHydratorTest</code>
+      <code>ObjectPropertyHydratorTest</code>
+    </PropertyNotSetInConstructor>
+  </file>
+  <file src="test/ObjectPropertyTest.php">
+    <DeprecatedClass occurrences="1">
+      <code>new ObjectProperty()</code>
+    </DeprecatedClass>
+    <MissingClosureParamType occurrences="2">
+      <code>$errno</code>
+      <code>$errstr</code>
+    </MissingClosureParamType>
+    <MissingReturnType occurrences="1">
+      <code>testTriggerUserDeprecatedError</code>
+    </MissingReturnType>
+    <PropertyNotSetInConstructor occurrences="2">
+      <code>ObjectPropertyTest</code>
+      <code>ObjectPropertyTest</code>
+    </PropertyNotSetInConstructor>
+    <RedundantCondition occurrences="1">
+      <code>assertInstanceOf</code>
+    </RedundantCondition>
+  </file>
+  <file src="test/ReflectionHydratorTest.php">
+    <InvalidArgument occurrences="2">
+      <code>$argument</code>
+      <code>$argument</code>
+    </InvalidArgument>
+    <MissingReturnType occurrences="4">
+      <code>testCanExtract</code>
+      <code>testCanHydrate</code>
+      <code>testExtractRaisesExceptionForInvalidInput</code>
+      <code>testHydrateRaisesExceptionForInvalidArgument</code>
+    </MissingReturnType>
+    <PropertyNotSetInConstructor occurrences="3">
+      <code>$hydrator</code>
+      <code>ReflectionHydratorTest</code>
+      <code>ReflectionHydratorTest</code>
+    </PropertyNotSetInConstructor>
+  </file>
+  <file src="test/ReflectionTest.php">
+    <DeprecatedClass occurrences="1">
+      <code>new Reflection()</code>
+    </DeprecatedClass>
+    <MissingClosureParamType occurrences="2">
+      <code>$errno</code>
+      <code>$errstr</code>
+    </MissingClosureParamType>
+    <MissingReturnType occurrences="1">
+      <code>testTriggerUserDeprecatedError</code>
+    </MissingReturnType>
+    <PropertyNotSetInConstructor occurrences="2">
+      <code>ReflectionTest</code>
+      <code>ReflectionTest</code>
+    </PropertyNotSetInConstructor>
+    <RedundantCondition occurrences="1">
+      <code>assertInstanceOf</code>
+    </RedundantCondition>
+  </file>
+  <file src="test/StandaloneHydratorPluginManagerFactoryTest.php">
+    <DeprecatedClass occurrences="8">
+      <code>ArraySerializable::class</code>
+      <code>ArraySerializable::class</code>
+      <code>ClassMethods::class</code>
+      <code>ClassMethods::class</code>
+      <code>ObjectProperty::class</code>
+      <code>ObjectProperty::class</code>
+      <code>Reflection::class</code>
+      <code>Reflection::class</code>
+    </DeprecatedClass>
+    <MissingReturnType occurrences="2">
+      <code>assertDefaultServices</code>
+      <code>testCreatesPluginManagerWithDefaultServices</code>
+    </MissingReturnType>
+    <MixedArgument occurrences="1">
+      <code>$manager</code>
+    </MixedArgument>
+    <MixedAssignment occurrences="1">
+      <code>$manager</code>
+    </MixedAssignment>
+    <MixedFunctionCall occurrences="1">
+      <code>($this-&gt;factory)($this-&gt;container)</code>
+    </MixedFunctionCall>
+    <PropertyNotSetInConstructor occurrences="2">
+      <code>StandaloneHydratorPluginManagerFactoryTest</code>
+      <code>StandaloneHydratorPluginManagerFactoryTest</code>
+    </PropertyNotSetInConstructor>
+    <UndefinedThisPropertyAssignment occurrences="2">
+      <code>$this-&gt;container</code>
+      <code>$this-&gt;factory</code>
+    </UndefinedThisPropertyAssignment>
+    <UndefinedThisPropertyFetch occurrences="2">
+      <code>$this-&gt;container</code>
+      <code>$this-&gt;factory</code>
+    </UndefinedThisPropertyFetch>
+  </file>
+  <file src="test/StandaloneHydratorPluginManagerTest.php">
+    <ArgumentTypeCoercion occurrences="1">
+      <code>$expectedType</code>
+    </ArgumentTypeCoercion>
+    <DeprecatedClass occurrences="4">
+      <code>Hydrator\ArraySerializable::class</code>
+      <code>Hydrator\ClassMethods::class</code>
+      <code>Hydrator\ObjectProperty::class</code>
+      <code>Hydrator\Reflection::class</code>
+    </DeprecatedClass>
+    <MissingReturnType occurrences="6">
+      <code>testDelegatingHydratorFactoryIsInitialized</code>
+      <code>testGetRaisesExceptionForUnknownService</code>
+      <code>testGetReturnsExpectedTypesForKnownServices</code>
+      <code>testHasReturnsFalseForUnknownNames</code>
+      <code>testHasReturnsTrueForKnownServices</code>
+      <code>testInstantiationInitializesFactoriesForHydratorsWithoutConstructorArguments</code>
+    </MissingReturnType>
+    <MixedArgument occurrences="6">
+      <code>$data</code>
+      <code>$factories</code>
+      <code>$key</code>
+      <code>$key</code>
+      <code>$this-&gt;manager</code>
+      <code>$this-&gt;manager</code>
+    </MixedArgument>
+    <MixedArrayAccess occurrences="2">
+      <code>$factories[$class]</code>
+      <code>$factories[Hydrator\DelegatingHydrator::class]</code>
+    </MixedArrayAccess>
+    <MixedAssignment occurrences="5">
+      <code>$class</code>
+      <code>$data</code>
+      <code>$factories</code>
+      <code>$factories</code>
+      <code>$instance</code>
+    </MixedAssignment>
+    <MixedMethodCall occurrences="4">
+      <code>get</code>
+      <code>get</code>
+      <code>has</code>
+      <code>has</code>
+    </MixedMethodCall>
+    <PropertyNotSetInConstructor occurrences="2">
+      <code>StandaloneHydratorPluginManagerTest</code>
+      <code>StandaloneHydratorPluginManagerTest</code>
+    </PropertyNotSetInConstructor>
+    <UndefinedThisPropertyAssignment occurrences="1">
+      <code>$this-&gt;manager</code>
+    </UndefinedThisPropertyAssignment>
+    <UndefinedThisPropertyFetch occurrences="6">
+      <code>$this-&gt;manager</code>
+      <code>$this-&gt;manager</code>
+      <code>$this-&gt;manager</code>
+      <code>$this-&gt;manager</code>
+      <code>$this-&gt;manager</code>
+      <code>$this-&gt;manager</code>
+    </UndefinedThisPropertyFetch>
+  </file>
+  <file src="test/Strategy/BooleanStrategyTest.php">
+    <InvalidArgument occurrences="1">
+      <code>new \stdClass()</code>
+    </InvalidArgument>
+    <InvalidScalarArgument occurrences="2">
+      <code>5</code>
+      <code>true</code>
+    </InvalidScalarArgument>
+    <MissingReturnType occurrences="12">
+      <code>testConstructorWithValidInteger</code>
+      <code>testConstructorWithValidString</code>
+      <code>testExceptionOnWrongFalseValueInConstructor</code>
+      <code>testExceptionOnWrongTrueValueInConstructor</code>
+      <code>testExtractInteger</code>
+      <code>testExtractString</code>
+      <code>testExtractThrowsExceptionOnUnknownValue</code>
+      <code>testHydrateBool</code>
+      <code>testHydrateInteger</code>
+      <code>testHydrateInvalidArgument</code>
+      <code>testHydrateString</code>
+      <code>testHydrateUnexpectedValueThrowsException</code>
+    </MissingReturnType>
+    <PossiblyFalseArgument occurrences="1">
+      <code>false</code>
+    </PossiblyFalseArgument>
+    <PropertyNotSetInConstructor occurrences="2">
+      <code>BooleanStrategyTest</code>
+      <code>BooleanStrategyTest</code>
+    </PropertyNotSetInConstructor>
+  </file>
+  <file src="test/Strategy/CollectionStrategyTest.php">
+    <ArgumentTypeCoercion occurrences="1">
+      <code>$expectedExceptionType</code>
+    </ArgumentTypeCoercion>
+    <MissingClosureParamType occurrences="1">
+      <code>$data</code>
+    </MissingClosureParamType>
+    <MissingClosureReturnType occurrences="2">
+      <code>function ($data) {</code>
+      <code>function (TestAsset\User $value) {</code>
+    </MissingClosureReturnType>
+    <MissingReturnType occurrences="7">
+      <code>testConstructorRejectsInvalidObjectClassName</code>
+      <code>testExtractRejectsInvalidObject</code>
+      <code>testExtractRejectsInvalidValue</code>
+      <code>testExtractUsesHydratorToExtractValues</code>
+      <code>testHydrateRejectsInvalidValue</code>
+      <code>testHydrateUsesHydratorToHydrateValues</code>
+      <code>testImplementsStrategyInterface</code>
+    </MissingReturnType>
+    <MixedArgument occurrences="4">
+      <code>$data</code>
+      <code>$objectClassName</code>
+      <code>$value</code>
+      <code>$value</code>
+    </MixedArgument>
+    <MixedMethodCall occurrences="5">
+      <code>hydrate</code>
+      <code>method</code>
+      <code>method</code>
+      <code>willReturnCallback</code>
+      <code>willReturnCallback</code>
+    </MixedMethodCall>
+    <PossiblyInvalidArgument occurrences="6">
+      <code>$hydrator</code>
+      <code>$hydrator</code>
+      <code>$this-&gt;createHydratorMock()</code>
+      <code>$this-&gt;createHydratorMock()</code>
+      <code>$this-&gt;createHydratorMock()</code>
+      <code>$this-&gt;createHydratorMock()</code>
+    </PossiblyInvalidArgument>
+    <PropertyNotSetInConstructor occurrences="2">
+      <code>CollectionStrategyTest</code>
+      <code>CollectionStrategyTest</code>
+    </PropertyNotSetInConstructor>
+    <UndefinedDocblockClass occurrences="3">
+      <code>$hydrator</code>
+      <code>$hydrator</code>
+      <code>\PHPUnit_Framework_MockObject_MockObject|HydratorInterface</code>
+    </UndefinedDocblockClass>
+    <UndefinedInterfaceMethod occurrences="2">
+      <code>expects</code>
+      <code>expects</code>
+    </UndefinedInterfaceMethod>
+  </file>
+  <file src="test/Strategy/DateTimeFormatterStrategyTest.php">
+    <MissingReturnType occurrences="13">
+      <code>formatsWithSpecialCharactersProvider</code>
+      <code>testAcceptsCreateFromFormatSpecialCharacters</code>
+      <code>testCanExtractAnyDateTimeInterface</code>
+      <code>testCanExtractIfNotDateTime</code>
+      <code>testCanExtractWithCreateFromFormatEscapedSpecialCharacters</code>
+      <code>testCanExtractWithCreateFromFormatSpecialCharacters</code>
+      <code>testCanHydrateWithDateTimeFallback</code>
+      <code>testCanHydrateWithInvalidDateTime</code>
+      <code>testExtract</code>
+      <code>testGetNullWithInvalidDateOnHydration</code>
+      <code>testHydrate</code>
+      <code>testHydrateRaisesExceptionIfValueIsInvalid</code>
+      <code>testReturnsValueVerbatimUnderSpecificConditions</code>
+    </MissingReturnType>
+    <MixedAssignment occurrences="6">
+      <code>$date</code>
+      <code>$date</code>
+      <code>$date</code>
+      <code>$extracted</code>
+      <code>$extracted</code>
+      <code>$hydrated</code>
+    </MixedAssignment>
+    <MixedMethodCall occurrences="6">
+      <code>format</code>
+      <code>format</code>
+      <code>getName</code>
+      <code>getName</code>
+      <code>getTimezone</code>
+      <code>getTimezone</code>
+    </MixedMethodCall>
+    <PropertyNotSetInConstructor occurrences="2">
+      <code>DateTimeFormatterStrategyTest</code>
+      <code>DateTimeFormatterStrategyTest</code>
+    </PropertyNotSetInConstructor>
+  </file>
+  <file src="test/Strategy/DateTimeImmutableFormatterStrategyTest.php">
+    <MixedMethodCall occurrences="1">
+      <code>format</code>
+    </MixedMethodCall>
+    <PropertyNotSetInConstructor occurrences="3">
+      <code>$strategy</code>
+      <code>DateTimeImmutableFormatterStrategyTest</code>
+      <code>DateTimeImmutableFormatterStrategyTest</code>
+    </PropertyNotSetInConstructor>
+  </file>
+  <file src="test/Strategy/ExplodeStrategyTest.php">
+    <InvalidArgument occurrences="5">
+      <code>''</code>
+      <code>[]</code>
+      <code>[]</code>
+      <code>new \stdClass()</code>
+      <code>new \stdClass()</code>
+    </InvalidArgument>
+    <MissingReturnType occurrences="10">
+      <code>testExtract</code>
+      <code>testExtractWithInvalidObjectType</code>
+      <code>testGetEmptyArrayWhenHydratingNullValue</code>
+      <code>testGetExceptionWithEmptyDelimiter</code>
+      <code>testGetExceptionWithInvalidArgumentOnExtraction</code>
+      <code>testGetExceptionWithInvalidDelimiter</code>
+      <code>testHydrateWithExplodeLimit</code>
+      <code>testHydrateWithInvalidObjectType</code>
+      <code>testHydrateWithInvalidScalarType</code>
+      <code>testHydration</code>
+    </MissingReturnType>
+    <MixedArgument occurrences="1">
+      <code>$value</code>
+    </MixedArgument>
+    <PropertyNotSetInConstructor occurrences="2">
+      <code>ExplodeStrategyTest</code>
+      <code>ExplodeStrategyTest</code>
+    </PropertyNotSetInConstructor>
+  </file>
+  <file src="test/Strategy/HydratorStrategyTest.php">
+    <ArgumentTypeCoercion occurrences="1">
+      <code>$expectedExceptionType</code>
+    </ArgumentTypeCoercion>
+    <MissingClosureParamType occurrences="1">
+      <code>$data</code>
+    </MissingClosureParamType>
+    <MissingClosureReturnType occurrences="2">
+      <code>static function ($data) {</code>
+      <code>static function (TestAsset\User $value) {</code>
+    </MissingClosureReturnType>
+    <MixedArgument occurrences="4">
+      <code>$data</code>
+      <code>$object</code>
+      <code>$objectClassName</code>
+      <code>$value</code>
+    </MixedArgument>
+    <MixedMethodCall occurrences="5">
+      <code>hydrate</code>
+      <code>method</code>
+      <code>method</code>
+      <code>willReturnCallback</code>
+      <code>willReturnCallback</code>
+    </MixedMethodCall>
+    <PossiblyInvalidArgument occurrences="7">
+      <code>$hydrator</code>
+      <code>$hydrator</code>
+      <code>$this-&gt;createHydratorMock()</code>
+      <code>$this-&gt;createHydratorMock()</code>
+      <code>$this-&gt;createHydratorMock()</code>
+      <code>$this-&gt;createHydratorMock()</code>
+      <code>$this-&gt;createHydratorMock()</code>
+    </PossiblyInvalidArgument>
+    <PossiblyUndefinedMethod occurrences="2">
+      <code>expects</code>
+      <code>expects</code>
+    </PossiblyUndefinedMethod>
+    <PropertyNotSetInConstructor occurrences="2">
+      <code>HydratorStrategyTest</code>
+      <code>HydratorStrategyTest</code>
+    </PropertyNotSetInConstructor>
+  </file>
+  <file src="test/Strategy/SerializableStrategyTest.php">
+    <MissingReturnType occurrences="5">
+      <code>testCanSerialize</code>
+      <code>testCanUnserialize</code>
+      <code>testCannotUseBadArgumentSerializer</code>
+      <code>testUseBadSerializerObject</code>
+      <code>testUseBadSerializerString</code>
+    </MissingReturnType>
+    <MixedAssignment occurrences="2">
+      <code>$serialized</code>
+      <code>$serialized</code>
+    </MixedAssignment>
+    <PossiblyFalseArgument occurrences="1">
+      <code>false</code>
+    </PossiblyFalseArgument>
+    <PropertyNotSetInConstructor occurrences="2">
+      <code>SerializableStrategyTest</code>
+      <code>SerializableStrategyTest</code>
+    </PropertyNotSetInConstructor>
+  </file>
+  <file src="test/Strategy/StrategyChainTest.php">
+    <MissingClosureParamType occurrences="12">
+      <code>$value</code>
+      <code>$value</code>
+      <code>$value</code>
+      <code>$value</code>
+      <code>$value</code>
+      <code>$value</code>
+      <code>$value</code>
+      <code>$value</code>
+      <code>$value</code>
+      <code>$value</code>
+      <code>$value</code>
+      <code>$value</code>
+    </MissingClosureParamType>
+    <MissingClosureReturnType occurrences="12">
+      <code>function ($value) {</code>
+      <code>function ($value) {</code>
+      <code>function ($value) {</code>
+      <code>function ($value) {</code>
+      <code>function ($value) {</code>
+      <code>function ($value) {</code>
+      <code>function ($value) {</code>
+      <code>function ($value) {</code>
+      <code>function ($value) {</code>
+      <code>function ($value) {</code>
+      <code>function ($value) {</code>
+      <code>function ($value) {</code>
+    </MissingClosureReturnType>
+    <MissingReturnType occurrences="3">
+      <code>testEmptyStrategyChainReturnsOriginalValue</code>
+      <code>testExtract</code>
+      <code>testHydrate</code>
+    </MissingReturnType>
+    <MixedOperand occurrences="12">
+      <code>$value</code>
+      <code>$value</code>
+      <code>$value</code>
+      <code>$value</code>
+      <code>$value</code>
+      <code>$value</code>
+      <code>$value</code>
+      <code>$value</code>
+      <code>$value</code>
+      <code>$value</code>
+      <code>$value</code>
+      <code>$value</code>
+    </MixedOperand>
+    <PropertyNotSetInConstructor occurrences="2">
+      <code>StrategyChainTest</code>
+      <code>StrategyChainTest</code>
+    </PropertyNotSetInConstructor>
+  </file>
+  <file src="test/TestAsset/AggregateObject.php">
+    <MissingReturnType occurrences="2">
+      <code>exchangeArray</code>
+      <code>setMaintainer</code>
+    </MissingReturnType>
+  </file>
+  <file src="test/TestAsset/ArrayObjectIterator.php">
+    <InvalidReturnStatement occurrences="1">
+      <code>next($this-&gt;var)</code>
+    </InvalidReturnStatement>
+    <MissingParamType occurrences="1">
+      <code>$array</code>
+    </MissingParamType>
+    <MissingPropertyType occurrences="1">
+      <code>$var</code>
+    </MissingPropertyType>
+    <MixedArgument occurrences="5">
+      <code>$this-&gt;var</code>
+      <code>$this-&gt;var</code>
+      <code>$this-&gt;var</code>
+      <code>$this-&gt;var</code>
+      <code>$this-&gt;var</code>
+    </MixedArgument>
+    <MixedInferredReturnType occurrences="1">
+      <code>next</code>
+    </MixedInferredReturnType>
+    <MixedReturnStatement occurrences="1">
+      <code>current($this-&gt;var)</code>
+    </MixedReturnStatement>
+    <RedundantConditionGivenDocblockType occurrences="1">
+      <code>$key !== false</code>
+    </RedundantConditionGivenDocblockType>
+  </file>
+  <file src="test/TestAsset/ArrayObjectObjectVars.php">
+    <MissingPropertyType occurrences="3">
+      <code>$private</code>
+      <code>$protected</code>
+      <code>$public</code>
+    </MissingPropertyType>
+  </file>
+  <file src="test/TestAsset/ArraySerializable.php">
+    <MissingPropertyType occurrences="1">
+      <code>$data</code>
+    </MissingPropertyType>
+    <MixedInferredReturnType occurrences="1">
+      <code>array</code>
+    </MixedInferredReturnType>
+    <MixedReturnStatement occurrences="1">
+      <code>$this-&gt;data</code>
+    </MixedReturnStatement>
+  </file>
+  <file src="test/TestAsset/ArraySerializableNoGetArrayCopy.php">
+    <MissingPropertyType occurrences="1">
+      <code>$data</code>
+    </MissingPropertyType>
+    <MissingReturnType occurrences="1">
+      <code>getData</code>
+    </MissingReturnType>
+  </file>
+  <file src="test/TestAsset/ClassMethodsCamelCase.php">
+    <MissingParamType occurrences="6">
+      <code>$value</code>
+      <code>$value</code>
+      <code>$value</code>
+      <code>$value</code>
+      <code>$value</code>
+      <code>$value</code>
+    </MissingParamType>
+    <MissingPropertyType occurrences="6">
+      <code>$fooBar</code>
+      <code>$fooBarBaz</code>
+      <code>$hasBar</code>
+      <code>$hasFoo</code>
+      <code>$isBar</code>
+      <code>$isFoo</code>
+    </MissingPropertyType>
+    <MissingReturnType occurrences="12">
+      <code>getFooBar</code>
+      <code>getFooBarBaz</code>
+      <code>getHasFoo</code>
+      <code>getIsFoo</code>
+      <code>hasBar</code>
+      <code>isBar</code>
+      <code>setFooBar</code>
+      <code>setFooBarBaz</code>
+      <code>setHasBar</code>
+      <code>setHasFoo</code>
+      <code>setIsBar</code>
+      <code>setIsFoo</code>
+    </MissingReturnType>
+  </file>
+  <file src="test/TestAsset/ClassMethodsCamelCaseMissing.php">
+    <MissingParamType occurrences="1">
+      <code>$value</code>
+    </MissingParamType>
+    <MissingPropertyType occurrences="2">
+      <code>$fooBar</code>
+      <code>$fooBarBaz</code>
+    </MissingPropertyType>
+    <MissingReturnType occurrences="3">
+      <code>getFooBar</code>
+      <code>getFooBarBaz</code>
+      <code>setFooBar</code>
+    </MissingReturnType>
+  </file>
+  <file src="test/TestAsset/ClassMethodsFilterProviderInterface.php">
+    <MissingParamType occurrences="1">
+      <code>$foo</code>
+    </MissingParamType>
+    <MissingReturnType occurrences="6">
+      <code>getBar</code>
+      <code>getEventManager</code>
+      <code>getFoo</code>
+      <code>getServiceManager</code>
+      <code>hasFooBar</code>
+      <code>isScalar</code>
+    </MissingReturnType>
+  </file>
+  <file src="test/TestAsset/ClassMethodsInvalidParameter.php">
+    <MissingParamType occurrences="3">
+      <code>$alias</code>
+      <code>$bar</code>
+      <code>$foo</code>
+    </MissingParamType>
+    <MissingReturnType occurrences="6">
+      <code>getFoo</code>
+      <code>getTest</code>
+      <code>hasAlias</code>
+      <code>hasBar</code>
+      <code>isBla</code>
+      <code>isTest</code>
+    </MissingReturnType>
+  </file>
+  <file src="test/TestAsset/ClassMethodsMagicMethodSetter.php">
+    <MissingParamType occurrences="2">
+      <code>$args</code>
+      <code>$method</code>
+    </MissingParamType>
+    <MissingPropertyType occurrences="1">
+      <code>$foo</code>
+    </MissingPropertyType>
+    <MissingReturnType occurrences="1">
+      <code>getFoo</code>
+    </MissingReturnType>
+    <MixedArgument occurrences="2">
+      <code>$method</code>
+      <code>$method</code>
+    </MixedArgument>
+    <MixedArrayAccess occurrences="1">
+      <code>$args[0]</code>
+    </MixedArrayAccess>
+  </file>
+  <file src="test/TestAsset/ClassMethodsOptionalParameters.php">
+    <MissingReturnType occurrences="1">
+      <code>setFoo</code>
+    </MissingReturnType>
+  </file>
+  <file src="test/TestAsset/ClassMethodsProtectedSetter.php">
+    <MissingParamType occurrences="2">
+      <code>$bar</code>
+      <code>$foo</code>
+    </MissingParamType>
+    <MissingPropertyType occurrences="2">
+      <code>$bar</code>
+      <code>$foo</code>
+    </MissingPropertyType>
+    <MissingReturnType occurrences="3">
+      <code>getBar</code>
+      <code>setBar</code>
+      <code>setFoo</code>
+    </MissingReturnType>
+  </file>
+  <file src="test/TestAsset/ClassMethodsTitleCase.php">
+    <MissingParamType occurrences="6">
+      <code>$HasBar</code>
+      <code>$HasFoo</code>
+      <code>$IsBar</code>
+      <code>$IsFoo</code>
+      <code>$value</code>
+      <code>$value</code>
+    </MissingParamType>
+    <MissingPropertyType occurrences="6">
+      <code>$FooBar</code>
+      <code>$FooBarBaz</code>
+      <code>$HasBar</code>
+      <code>$HasFoo</code>
+      <code>$IsBar</code>
+      <code>$IsFoo</code>
+    </MissingPropertyType>
+    <MissingReturnType occurrences="12">
+      <code>getFooBar</code>
+      <code>getFooBarBaz</code>
+      <code>getHasBar</code>
+      <code>getHasFoo</code>
+      <code>getIsBar</code>
+      <code>getIsFoo</code>
+      <code>setFooBar</code>
+      <code>setFooBarBaz</code>
+      <code>setHasBar</code>
+      <code>setHasFoo</code>
+      <code>setIsBar</code>
+      <code>setIsFoo</code>
+    </MissingReturnType>
+  </file>
+  <file src="test/TestAsset/ClassMethodsUnderscore.php">
+    <MissingParamType occurrences="6">
+      <code>$value</code>
+      <code>$value</code>
+      <code>$value</code>
+      <code>$value</code>
+      <code>$value</code>
+      <code>$value</code>
+    </MissingParamType>
+    <MissingPropertyType occurrences="6">
+      <code>$foo_bar</code>
+      <code>$foo_bar_baz</code>
+      <code>$has_bar</code>
+      <code>$has_foo</code>
+      <code>$is_bar</code>
+      <code>$is_foo</code>
+    </MissingPropertyType>
+    <MissingReturnType occurrences="12">
+      <code>getFooBar</code>
+      <code>getFooBarBaz</code>
+      <code>getHasFoo</code>
+      <code>getIsFoo</code>
+      <code>hasBar</code>
+      <code>isBar</code>
+      <code>setFooBar</code>
+      <code>setFooBarBaz</code>
+      <code>setHasBar</code>
+      <code>setHasFoo</code>
+      <code>setIsBar</code>
+      <code>setIsFoo</code>
+    </MissingReturnType>
+  </file>
+  <file src="test/TestAsset/ClassWithoutAnyMethod.php">
+    <MissingPropertyType occurrences="1">
+      <code>$foo</code>
+    </MissingPropertyType>
+  </file>
+  <file src="test/TestAsset/HydratorClosureStrategyEntity.php">
+    <MissingParamType occurrences="2">
+      <code>$field1</code>
+      <code>$field2</code>
+    </MissingParamType>
+    <MissingPropertyType occurrences="2">
+      <code>$field1</code>
+      <code>$field2</code>
+    </MissingPropertyType>
+  </file>
+  <file src="test/TestAsset/HydratorStrategy.php">
+    <MissingParamType occurrences="1">
+      <code>$field1</code>
+    </MissingParamType>
+    <MissingReturnType occurrences="1">
+      <code>findEntity</code>
+    </MissingReturnType>
+    <MixedAssignment occurrences="7">
+      <code>$entity</code>
+      <code>$field1</code>
+      <code>$instance</code>
+      <code>$result</code>
+      <code>$result</code>
+      <code>$result[]</code>
+      <code>$result[]</code>
+    </MixedAssignment>
+    <MixedMethodCall occurrences="2">
+      <code>getField1</code>
+      <code>getField1</code>
+    </MixedMethodCall>
+  </file>
+  <file src="test/TestAsset/HydratorStrategyContextAware.php">
+    <MissingPropertyType occurrences="2">
+      <code>$data</code>
+      <code>$object</code>
+    </MissingPropertyType>
+  </file>
+  <file src="test/TestAsset/HydratorStrategyEntityA.php">
+    <MissingParamType occurrences="2">
+      <code>$data</code>
+      <code>$entities</code>
+    </MissingParamType>
+    <MissingPropertyType occurrences="1">
+      <code>$entities</code>
+    </MissingPropertyType>
+    <MissingReturnType occurrences="5">
+      <code>addEntity</code>
+      <code>getArrayCopy</code>
+      <code>getEntities</code>
+      <code>populate</code>
+      <code>setEntities</code>
+    </MissingReturnType>
+    <MixedArrayAssignment occurrences="1">
+      <code>$this-&gt;entities[]</code>
+    </MixedArrayAssignment>
+    <MixedAssignment occurrences="1">
+      <code>$value</code>
+    </MixedAssignment>
+  </file>
+  <file src="test/TestAsset/HydratorStrategyEntityB.php">
+    <MissingParamType occurrences="4">
+      <code>$field1</code>
+      <code>$field2</code>
+      <code>$value</code>
+      <code>$value</code>
+    </MissingParamType>
+    <MissingPropertyType occurrences="2">
+      <code>$field1</code>
+      <code>$field2</code>
+    </MissingPropertyType>
+    <MissingReturnType occurrences="4">
+      <code>getField1</code>
+      <code>getField2</code>
+      <code>setField1</code>
+      <code>setField2</code>
+    </MissingReturnType>
+  </file>
+  <file src="test/TestAsset/ObjectProperty.php">
+    <MissingPropertyType occurrences="5">
+      <code>$bar</code>
+      <code>$blubb</code>
+      <code>$foo</code>
+      <code>$quin</code>
+      <code>$quo</code>
+    </MissingPropertyType>
+    <MissingReturnType occurrences="1">
+      <code>get</code>
+    </MissingReturnType>
+  </file>
+  <file src="test/TestAsset/Reflection.php">
+    <MissingPropertyType occurrences="3">
+      <code>$foo</code>
+      <code>$fooBar</code>
+      <code>$fooBarBaz</code>
+    </MissingPropertyType>
+    <MissingReturnType occurrences="2">
+      <code>getFooBar</code>
+      <code>getFooBarBaz</code>
+    </MissingReturnType>
+  </file>
+  <file src="test/TestAsset/ReflectionFilter.php">
+    <MissingPropertyType occurrences="4">
+      <code>$bar</code>
+      <code>$blubb</code>
+      <code>$foo</code>
+      <code>$quo</code>
+    </MissingPropertyType>
+  </file>
+  <file src="test/TestAsset/SimpleEntity.php">
+    <MissingPropertyType occurrences="1">
+      <code>$value</code>
+    </MissingPropertyType>
+  </file>
+  <file src="test/TestAsset/User.php">
+    <MissingConstructor occurrences="1">
+      <code>$name</code>
+    </MissingConstructor>
+  </file>
+</files>

--- a/psalm.xml.dist
+++ b/psalm.xml.dist
@@ -1,0 +1,30 @@
+<?xml version="1.0"?>
+<psalm
+    totallyTyped="true"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns="https://getpsalm.org/schema/config"
+    xsi:schemaLocation="https://getpsalm.org/schema/config vendor/vimeo/psalm/config.xsd"
+    errorBaseline="psalm-baseline.xml"
+>
+    <projectFiles>
+        <directory name="src"/>
+        <directory name="test"/>
+        <ignoreFiles>
+            <directory name="vendor"/>
+        </ignoreFiles>
+    </projectFiles>
+
+    <issueHandlers>
+        <InternalMethod>
+            <errorLevel type="suppress">
+                <referencedMethod name="PHPUnit\Framework\MockObject\Builder\InvocationMocker::method"/>
+            </errorLevel>
+            <errorLevel type="suppress">
+                <referencedMethod name="PHPUnit\Framework\MockObject\Builder\InvocationMocker::willReturn"/>
+            </errorLevel>
+            <errorLevel type="suppress">
+                <referencedMethod name="PHPUnit\Framework\MockObject\Builder\InvocationMocker::with"/>
+            </errorLevel>
+        </InternalMethod>
+    </issueHandlers>
+</psalm>


### PR DESCRIPTION
Adds Psalm integration into the QA workflow.

Variations from the recommendation in #28:

- Configuration file is `psalm.xml.dist`, not `.psalm.xml.dist`.
- Does NOT use phpunit plugin in configuration (caused Psalm to raise an exception, even when I had it installed).
- Does NOT scan bin directory (this repo does not have one).
- Removes previous phpstan integration (this _was_ part of the brief, but I thought I'd call it out).

Fixes #28
