### PR TITLE
Improve code base per Psalm suggestions

### DIFF
--- a/phpcs.xml
+++ b/phpcs.xml
@@ -10,6 +10,12 @@
         <exclude-pattern>src/Reflection.php</exclude-pattern>
     </rule>
 
+    <rule ref="Generic.Files.LineLength.TooLong">
+        <exclude-pattern>test/DelegatingHydratorFactoryTest.php</exclude-pattern>
+        <exclude-pattern>test/Filter/FilterCompositeTest.php</exclude-pattern>
+        <exclude-pattern>test/NamingStrategy/MapNamingStrategyTest.php</exclude-pattern>
+    </rule>
+
     <!-- Paths to check -->
     <file>src</file>
     <file>test</file>

--- a/src/StandaloneHydratorPluginManager.php
+++ b/src/StandaloneHydratorPluginManager.php
@@ -74,7 +74,7 @@ final class StandaloneHydratorPluginManager implements HydratorPluginManagerInte
 
     public function __construct()
     {
-        $invokableFactory = function (ContainerInterface $container, string $class) {
+        $invokableFactory = function (ContainerInterface $container, string $class): object {
             return new $class();
         };
 

--- a/test/Aggregate/AggregateHydratorFunctionalTest.php
+++ b/test/Aggregate/AggregateHydratorFunctionalTest.php
@@ -41,8 +41,10 @@ class AggregateHydratorFunctionalTest extends TestCase
 
     /**
      * Verifies that no interaction happens when the aggregate hydrator is empty
+     *
+     * @return void
      */
-    public function testEmptyAggregate()
+    public function testEmptyAggregate(): void
     {
         $object = new ArrayObject(['zaphod' => 'beeblebrox']);
 
@@ -54,10 +56,12 @@ class AggregateHydratorFunctionalTest extends TestCase
 
     /**
      * @dataProvider getHydratorSet
-     *
+
      * Verifies that using a single hydrator will have the aggregate hydrator behave like that single hydrator
+     *
+     * @return void
      */
-    public function testSingleHydratorExtraction(HydratorInterface $comparisonHydrator, $object)
+    public function testSingleHydratorExtraction(HydratorInterface $comparisonHydrator, $object): void
     {
         $blueprint = clone $object;
 
@@ -68,10 +72,12 @@ class AggregateHydratorFunctionalTest extends TestCase
 
     /**
      * @dataProvider getHydratorSet
-     *
+
      * Verifies that using a single hydrator will have the aggregate hydrator behave like that single hydrator
+     *
+     * @return void
      */
-    public function testSingleHydratorHydration(HydratorInterface $comparisonHydrator, $object, $data)
+    public function testSingleHydratorHydration(HydratorInterface $comparisonHydrator, $object, $data): void
     {
         $blueprint = clone $object;
 
@@ -89,8 +95,10 @@ class AggregateHydratorFunctionalTest extends TestCase
 
     /**
      * Verifies that multiple hydrators in an aggregate merge the extracted data
+     *
+     * @return void
      */
-    public function testExtractWithMultipleHydrators()
+    public function testExtractWithMultipleHydrators(): void
     {
         $this->hydrator->add(new ClassMethodsHydrator());
         $this->hydrator->add(new ArraySerializableHydrator());
@@ -107,8 +115,10 @@ class AggregateHydratorFunctionalTest extends TestCase
 
     /**
      * Verifies that multiple hydrators in an aggregate merge the extracted data
+     *
+     * @return void
      */
-    public function testHydrateWithMultipleHydrators()
+    public function testHydrateWithMultipleHydrators(): void
     {
         $this->hydrator->add(new ClassMethodsHydrator());
         $this->hydrator->add(new ArraySerializableHydrator());
@@ -130,11 +140,13 @@ class AggregateHydratorFunctionalTest extends TestCase
     /**
      * Verifies that stopping propagation within a listener in the hydrator allows modifying how the
      * hydrator behaves
+     *
+     * @return void
      */
-    public function testStoppedPropagationInExtraction()
+    public function testStoppedPropagationInExtraction(): void
     {
         $object   = new ArrayObject(['president' => 'Zaphod']);
-        $callback = function (ExtractEvent $event) {
+        $callback = function (ExtractEvent $event): void {
             $event->setExtractedData(['Ravenous Bugblatter Beast of Traal']);
             $event->stopPropagation();
         };
@@ -148,12 +160,14 @@ class AggregateHydratorFunctionalTest extends TestCase
     /**
      * Verifies that stopping propagation within a listener in the hydrator allows modifying how the
      * hydrator behaves
+     *
+     * @return void
      */
-    public function testStoppedPropagationInHydration()
+    public function testStoppedPropagationInHydration(): void
     {
         $object        = new ArrayObject();
         $swappedObject = new stdClass();
-        $callback = function (HydrateEvent $event) use ($swappedObject) {
+        $callback = function (HydrateEvent $event) use ($swappedObject): void {
             $event->setHydratedObject($swappedObject);
             $event->stopPropagation();
         };

--- a/test/Aggregate/AggregateHydratorTest.php
+++ b/test/Aggregate/AggregateHydratorTest.php
@@ -47,8 +47,10 @@ class AggregateHydratorTest extends TestCase
 
     /**
      * @covers \Laminas\Hydrator\Aggregate\AggregateHydrator::add
+     *
+     * @return void
      */
-    public function testAdd()
+    public function testAdd(): void
     {
         $attached = $this->createMock(HydratorInterface::class);
 
@@ -65,8 +67,10 @@ class AggregateHydratorTest extends TestCase
 
     /**
      * @covers \Laminas\Hydrator\Aggregate\AggregateHydrator::hydrate
+     *
+     * @return void
      */
-    public function testHydrate()
+    public function testHydrate(): void
     {
         $object = new stdClass();
 
@@ -80,8 +84,10 @@ class AggregateHydratorTest extends TestCase
 
     /**
      * @covers \Laminas\Hydrator\Aggregate\AggregateHydrator::extract
+     *
+     * @return void
      */
-    public function testExtract()
+    public function testExtract(): void
     {
         $object = new stdClass();
 
@@ -96,8 +102,10 @@ class AggregateHydratorTest extends TestCase
     /**
      * @covers \Laminas\Hydrator\Aggregate\AggregateHydrator::getEventManager
      * @covers \Laminas\Hydrator\Aggregate\AggregateHydrator::setEventManager
+     *
+     * @return void
      */
-    public function testGetSetManager()
+    public function testGetSetManager(): void
     {
         $hydrator     = new AggregateHydrator();
         $eventManager = $this->createMock(EventManager::class);

--- a/test/Aggregate/ExtractEventTest.php
+++ b/test/Aggregate/ExtractEventTest.php
@@ -21,8 +21,10 @@ class ExtractEventTest extends TestCase
 {
     /**
      * @covers \Laminas\Hydrator\Aggregate\ExtractEvent
+     *
+     * @return void
      */
-    public function testEvent()
+    public function testEvent(): void
     {
         $target    = new stdClass();
         $object1   = new stdClass();

--- a/test/Aggregate/HydrateEventTest.php
+++ b/test/Aggregate/HydrateEventTest.php
@@ -21,8 +21,10 @@ class HydrateEventTest extends TestCase
 {
     /**
      * @covers \Laminas\Hydrator\Aggregate\HydrateEvent
+     *
+     * @return void
      */
-    public function testEvent()
+    public function testEvent(): void
     {
         $target    = new stdClass();
         $hydrated1 = new stdClass();

--- a/test/Aggregate/HydratorListenerTest.php
+++ b/test/Aggregate/HydratorListenerTest.php
@@ -46,8 +46,10 @@ class HydratorListenerTest extends TestCase
 
     /**
      * @covers \Laminas\Hydrator\Aggregate\HydratorListener::attach
+     *
+     * @return void
      */
-    public function testAttach()
+    public function testAttach(): void
     {
         $eventManager = $this->createMock(EventManagerInterface::class);
 
@@ -67,8 +69,10 @@ class HydratorListenerTest extends TestCase
 
     /**
      * @covers \Laminas\Hydrator\Aggregate\HydratorListener::onHydrate
+     *
+     * @return void
      */
-    public function testOnHydrate()
+    public function testOnHydrate(): void
     {
         $object   = new stdClass();
         $hydrated = new stdClass();
@@ -94,8 +98,10 @@ class HydratorListenerTest extends TestCase
 
     /**
      * @covers \Laminas\Hydrator\Aggregate\HydratorListener::onExtract
+     *
+     * @return void
      */
-    public function testOnExtract()
+    public function testOnExtract(): void
     {
         $object = new stdClass();
         $data   = ['foo' => 'bar'];

--- a/test/ArraySerializableHydratorTest.php
+++ b/test/ArraySerializableHydratorTest.php
@@ -42,8 +42,10 @@ class ArraySerializableHydratorTest extends TestCase
 
     /**
      * Verify that we get an exception when trying to extract on a non-object
+     *
+     * @return void
      */
-    public function testHydratorExtractThrowsExceptionOnNonObjectParameter()
+    public function testHydratorExtractThrowsExceptionOnNonObjectParameter(): void
     {
         $this->expectException(TypeError::class);
         $this->expectExceptionMessage('object');
@@ -52,8 +54,10 @@ class ArraySerializableHydratorTest extends TestCase
 
     /**
      * Verify that we get an exception when trying to hydrate a non-object
+     *
+     * @return void
      */
-    public function testHydratorHydrateThrowsExceptionOnNonObjectParameter()
+    public function testHydratorHydrateThrowsExceptionOnNonObjectParameter(): void
     {
         $this->expectException(TypeError::class);
         $this->expectExceptionMessage('object');
@@ -62,8 +66,10 @@ class ArraySerializableHydratorTest extends TestCase
 
     /**
      * Verifies that we can extract from an ArraySerializableInterface
+     *
+     * @return void
      */
-    public function testCanExtractFromArraySerializableObject()
+    public function testCanExtractFromArraySerializableObject(): void
     {
         $this->assertSame(
             [
@@ -78,8 +84,10 @@ class ArraySerializableHydratorTest extends TestCase
 
     /**
      * Verifies we can hydrate an ArraySerializableInterface
+     *
+     * @return void
      */
-    public function testCanHydrateToArraySerializableObject()
+    public function testCanHydrateToArraySerializableObject(): void
     {
         $data = [
             'foo'   => 'bar1',
@@ -98,8 +106,10 @@ class ArraySerializableHydratorTest extends TestCase
      * existing properties should get overwritten
      *
      * @group 65
+     *
+     * @return void
      */
-    public function testWillPreserveOriginalPropsAtHydration()
+    public function testWillPreserveOriginalPropsAtHydration(): void
     {
         $original = new ArraySerializableAsset();
 
@@ -119,8 +129,10 @@ class ArraySerializableHydratorTest extends TestCase
      * by the to-be hydrated object, simply exchange the array
      *
      * @group 65
+     *
+     * @return void
      */
-    public function testWillReplaceArrayIfNoGetArrayCopy()
+    public function testWillReplaceArrayIfNoGetArrayCopy(): void
     {
         $original = new \LaminasTest\Hydrator\TestAsset\ArraySerializableNoGetArrayCopy();
 
@@ -134,7 +146,12 @@ class ArraySerializableHydratorTest extends TestCase
         $this->assertSame($expected, $actual->getData());
     }
 
-    public function arrayDataProvider()
+    /**
+     * @return string[][][]
+     *
+     * @psalm-return array<string, array{0: string[], 1: string[], 2: string[]}>
+     */
+    public function arrayDataProvider(): array
     {
         // @codingStandardsIgnoreStart
         return [
@@ -154,9 +171,12 @@ class ArraySerializableHydratorTest extends TestCase
      * submitted value should _replace_ the original.
      *
      * @group 66
+     *
      * @dataProvider arrayDataProvider
+     *
+     * @return void
      */
-    public function testHydrationWillReplaceNestedArrayData($start, $submit, $expected)
+    public function testHydrationWillReplaceNestedArrayData($start, $submit, $expected): void
     {
         $original = new ArraySerializableAsset();
         $original->exchangeArray([
@@ -172,7 +192,7 @@ class ArraySerializableHydratorTest extends TestCase
         $this->assertSame($expected, $final['tags']);
     }
 
-    public function testExtractArrayObject()
+    public function testExtractArrayObject(): void
     {
         $arrayObject = new ArrayObject([
             'value1',

--- a/test/ArraySerializableTest.php
+++ b/test/ArraySerializableTest.php
@@ -16,7 +16,7 @@ use PHPUnit\Framework\TestCase;
 
 class ArraySerializableTest extends TestCase
 {
-    public function testTriggerUserDeprecatedError()
+    public function testTriggerUserDeprecatedError(): void
     {
         $test = (object) ['message' => false];
 

--- a/test/ClassMethodsTest.php
+++ b/test/ClassMethodsTest.php
@@ -16,7 +16,7 @@ use PHPUnit\Framework\TestCase;
 
 class ClassMethodsTest extends TestCase
 {
-    public function testTriggerUserDeprecatedError()
+    public function testTriggerUserDeprecatedError(): void
     {
         $test = (object) ['message' => false];
 

--- a/test/DelegatingHydratorFactoryTest.php
+++ b/test/DelegatingHydratorFactoryTest.php
@@ -22,7 +22,7 @@ use ReflectionProperty;
  */
 class DelegatingHydratorFactoryTest extends TestCase
 {
-    public function testFactoryUsesContainerToSeedDelegatingHydratorWhenItIsAHydratorPluginManager()
+    public function testFactoryUsesContainerToSeedDelegatingHydratorWhenItIsAHydratorPluginManager(): void
     {
         $hydrators = $this->createMock(HydratorPluginManager::class);
         $factory = new DelegatingHydratorFactory();
@@ -31,8 +31,9 @@ class DelegatingHydratorFactoryTest extends TestCase
         $this->assertInstanceOf(DelegatingHydrator::class, $hydrator);
     }
 
-    public function testFactoryUsesHydratorPluginManagerServiceFromContainerToSeedDelegatingHydratorWhenAvailable()
+    public function testFactoryUsesHydratorPluginManagerServiceFromContainerToSeedDelegatingHydratorWhenAvailable(): void
     {
+        // phpcs:enable
         $hydrators = $this->createMock(HydratorPluginManager::class);
         $container = $this->createMock(ContainerInterface::class);
         $container->expects($this->once())->method('has')->with(HydratorPluginManager::class)->willReturn(true);
@@ -44,7 +45,7 @@ class DelegatingHydratorFactoryTest extends TestCase
         $this->assertInstanceOf(DelegatingHydrator::class, $hydrator);
     }
 
-    public function testFactoryUsesHydratorManagerServiceFromContainerToSeedDelegatingHydratorWhenAvailable()
+    public function testFactoryUsesHydratorManagerServiceFromContainerToSeedDelegatingHydratorWhenAvailable(): void
     {
         $hydrators = $this->createMock(HydratorPluginManager::class);
         $container = $this->createMock(ContainerInterface::class);
@@ -69,7 +70,7 @@ class DelegatingHydratorFactoryTest extends TestCase
         $this->assertInstanceOf(DelegatingHydrator::class, $hydrator);
     }
 
-    public function testFactoryCreatesHydratorPluginManagerToSeedDelegatingHydratorAsFallback()
+    public function testFactoryCreatesHydratorPluginManagerToSeedDelegatingHydratorAsFallback(): void
     {
         $hydrators = $this->createMock(HydratorPluginManager::class);
         $container = $this->createMock(ContainerInterface::class);

--- a/test/DelegatingHydratorTest.php
+++ b/test/DelegatingHydratorTest.php
@@ -49,7 +49,7 @@ class DelegatingHydratorTest extends TestCase
         $this->object = new ArrayObject;
     }
 
-    public function testExtract()
+    public function testExtract(): void
     {
         $hydrator = $this->createMock(HydratorInterface::class);
         $hydrator->expects($this->once())->method('extract')->with($this->object)->willReturn(['foo' => 'bar']);
@@ -63,7 +63,7 @@ class DelegatingHydratorTest extends TestCase
         $this->assertEquals(['foo' => 'bar'], $this->hydrator->extract($this->object));
     }
 
-    public function testHydrate()
+    public function testHydrate(): void
     {
         $hydrator = $this->createMock(HydratorInterface::class);
         $hydrator->expects($this->once())->method('hydrate')->with(['foo' => 'bar'])->willReturn($this->object);

--- a/test/Filter/FilterCompositeTest.php
+++ b/test/Filter/FilterCompositeTest.php
@@ -30,8 +30,10 @@ class FilterCompositeTest extends TestCase
 {
     /**
      * @dataProvider validFiltersProvider
+     *
+     * @return void
      */
-    public function testFilters(array $orFilters, array $andFilters)
+    public function testFilters(array $orFilters, array $andFilters): void
     {
         $filter = new FilterComposite($orFilters, $andFilters);
 
@@ -62,7 +64,10 @@ class FilterCompositeTest extends TestCase
 
     public function invalidFiltersProvider() : array
     {
-        $callback = static function () {
+        $callback = /**
+         * @return true
+         */
+        static function (): bool {
             return true;
         };
 
@@ -97,8 +102,10 @@ class FilterCompositeTest extends TestCase
 
     /**
      * @dataProvider invalidFiltersProvider
+     *
+     * @return void
      */
-    public function testConstructWithInvalidFilter(array $orFilters, array $andFilters, string $expectedKey)
+    public function testConstructWithInvalidFilter(array $orFilters, array $andFilters, string $expectedKey): void
     {
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage(sprintf(
@@ -110,7 +117,7 @@ class FilterCompositeTest extends TestCase
         new FilterComposite($orFilters, $andFilters);
     }
 
-    public function testNoFilters()
+    public function testNoFilters(): void
     {
         $filter = new FilterComposite();
         self::assertTrue($filter->filter('any_value'));
@@ -135,7 +142,12 @@ class FilterCompositeTest extends TestCase
         return $filters;
     }
 
-    private function generateFilters(array $orCompositionFilters, array $andCompositionFilters, bool $expected)
+    /**
+     * @return \Generator
+     *
+     * @psalm-return \Generator<int, array{orFilters: array, andFilters: array, expected: bool}, mixed, void>
+     */
+    private function generateFilters(array $orCompositionFilters, array $andCompositionFilters, bool $expected): \Generator
     {
         foreach ($orCompositionFilters as $orFilters) {
             foreach ($andCompositionFilters as $andFilters) {
@@ -148,7 +160,12 @@ class FilterCompositeTest extends TestCase
         }
     }
 
-    public function providerCompositionFiltering()
+    /**
+     * @return \Generator
+     *
+     * @psalm-return \Generator<mixed, mixed, mixed, void>
+     */
+    public function providerCompositionFiltering(): \Generator
     {
         $orCompositionFilters = [
             'truthy' => [
@@ -202,8 +219,10 @@ class FilterCompositeTest extends TestCase
 
     /**
      * @dataProvider providerCompositionFiltering
+     *
+     * @return void
      */
-    public function testCompositionFiltering(array $orFilters, array $andFilters, bool $expected)
+    public function testCompositionFiltering(array $orFilters, array $andFilters, bool $expected): void
     {
         $filter = new FilterComposite($orFilters, $andFilters);
         self::assertSame($expected, $filter->filter('any_value'));

--- a/test/Filter/MethodMatchFilterTest.php
+++ b/test/Filter/MethodMatchFilterTest.php
@@ -15,7 +15,12 @@ use PHPUnit\Framework\TestCase;
 
 class MethodMatchFilterTest extends TestCase
 {
-    public function providerFilter()
+    /**
+     * @return (bool|string)[][]
+     *
+     * @psalm-return list<array{0: string, 1: bool}>
+     */
+    public function providerFilter(): array
     {
         return [
             ['foo', true,],
@@ -27,8 +32,10 @@ class MethodMatchFilterTest extends TestCase
 
     /**
      * @dataProvider providerFilter
+     *
+     * @return void
      */
-    public function testFilter($methodName, $expected)
+    public function testFilter($methodName, $expected): void
     {
         $testedInstance = new MethodMatchFilter('foo', false);
         self::assertEquals($expected, $testedInstance->filter($methodName));

--- a/test/Filter/NumberOfParameterFilterTest.php
+++ b/test/Filter/NumberOfParameterFilterTest.php
@@ -23,8 +23,10 @@ class NumberOfParameterFilterTest extends TestCase
 {
     /**
      * @group 6083
+     *
+     * @return void
      */
-    public function testArityZero()
+    public function testArityZero(): void
     {
         $filter = new NumberOfParameterFilter();
         $this->assertTrue($filter->filter(__CLASS__ . '::methodWithNoParameters'));
@@ -33,8 +35,10 @@ class NumberOfParameterFilterTest extends TestCase
 
     /**
      * @group 6083
+     *
+     * @return void
      */
-    public function testArityOne()
+    public function testArityOne(): void
     {
         $filter = new NumberOfParameterFilter(1);
         $this->assertFalse($filter->filter(__CLASS__ . '::methodWithNoParameters'));
@@ -43,8 +47,10 @@ class NumberOfParameterFilterTest extends TestCase
 
     /**
      * Verifies an InvalidArgumentException is thrown for a method that doesn't exist
+     *
+     * @return void
      */
-    public function testFilterPropertyDoesNotExist()
+    public function testFilterPropertyDoesNotExist(): void
     {
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage(
@@ -56,15 +62,19 @@ class NumberOfParameterFilterTest extends TestCase
 
     /**
      * Test asset method
+     *
+     * @return void
      */
-    public function methodWithOptionalParameters($parameter = 'foo')
+    public function methodWithOptionalParameters($parameter = 'foo'): void
     {
     }
 
     /**
      * Test asset method
+     *
+     * @return void
      */
-    public function methodWithNoParameters()
+    public function methodWithNoParameters(): void
     {
     }
 }

--- a/test/Filter/OptionalParametersFilterTest.php
+++ b/test/Filter/OptionalParametersFilterTest.php
@@ -41,8 +41,10 @@ class OptionalParametersFilterTest extends TestCase
      * @param bool   $expectedResult
      *
      * @dataProvider methodProvider
+     *
+     * @return void
      */
-    public function testMethods($method, $expectedResult)
+    public function testMethods($method, $expectedResult): void
     {
         $this->assertSame($expectedResult, $this->filter->filter($method));
     }
@@ -55,15 +57,17 @@ class OptionalParametersFilterTest extends TestCase
      * @param bool   $expectedResult
      *
      * @dataProvider methodProvider
+     *
+     * @return void
      */
-    public function testMethodsOnSubsequentCalls($method, $expectedResult)
+    public function testMethodsOnSubsequentCalls($method, $expectedResult): void
     {
         for ($i = 0; $i < 5; $i += 1) {
             $this->assertSame($expectedResult, $this->filter->filter($method));
         }
     }
 
-    public function testTriggersExceptionOnUnknownMethod()
+    public function testTriggersExceptionOnUnknownMethod(): void
     {
         $this->expectException(InvalidArgumentException::class);
         $this->filter->filter(__CLASS__ . '::' . 'nonExistingMethod');
@@ -87,36 +91,46 @@ class OptionalParametersFilterTest extends TestCase
 
     /**
      * Test asset method
+     *
+     * @return void
      */
-    public function methodWithoutParameters()
+    public function methodWithoutParameters(): void
     {
     }
 
     /**
      * Test asset method
+     *
+     * @return void
      */
-    public function methodWithSingleMandatoryParameter($parameter)
+    public function methodWithSingleMandatoryParameter($parameter): void
     {
     }
 
     /**
      * Test asset method
+     *
+     * @return void
      */
-    public function methodWithSingleOptionalParameter($parameter = null)
+    public function methodWithSingleOptionalParameter($parameter = null): void
     {
     }
 
     /**
      * Test asset method
+     *
+     * @return void
      */
-    public function methodWithMultipleMandatoryParameters($parameter, $otherParameter)
+    public function methodWithMultipleMandatoryParameters($parameter, $otherParameter): void
     {
     }
 
     /**
      * Test asset method
+     *
+     * @return void
      */
-    public function methodWithMultipleOptionalParameters($parameter = null, $otherParameter = null)
+    public function methodWithMultipleOptionalParameters($parameter = null, $otherParameter = null): void
     {
     }
 }

--- a/test/HydratorAwareTraitTest.php
+++ b/test/HydratorAwareTraitTest.php
@@ -17,7 +17,7 @@ use PHPUnit\Framework\TestCase;
  */
 class HydratorAwareTraitTest extends TestCase
 {
-    public function testSetHydrator()
+    public function testSetHydrator(): void
     {
         $object = $this->getObjectForTrait('\Laminas\Hydrator\HydratorAwareTrait');
 
@@ -30,7 +30,7 @@ class HydratorAwareTraitTest extends TestCase
         $this->assertSame($hydrator, $object->getHydrator());
     }
 
-    public function testGetHydrator()
+    public function testGetHydrator(): void
     {
         $object = $this->getObjectForTrait('\Laminas\Hydrator\HydratorAwareTrait');
 

--- a/test/HydratorClosureStrategyTest.php
+++ b/test/HydratorClosureStrategyTest.php
@@ -31,7 +31,7 @@ class HydratorClosureStrategyTest extends TestCase
         $this->hydrator = new ObjectPropertyHydrator();
     }
 
-    public function testAddingStrategy()
+    public function testAddingStrategy(): void
     {
         $this->assertFalse($this->hydrator->hasStrategy('myStrategy'));
 
@@ -40,19 +40,19 @@ class HydratorClosureStrategyTest extends TestCase
         $this->assertTrue($this->hydrator->hasStrategy('myStrategy'));
     }
 
-    public function testCheckStrategyEmpty()
+    public function testCheckStrategyEmpty(): void
     {
         $this->assertFalse($this->hydrator->hasStrategy('myStrategy'));
     }
 
-    public function testCheckStrategyNotEmpty()
+    public function testCheckStrategyNotEmpty(): void
     {
         $this->hydrator->addStrategy('myStrategy', new ClosureStrategy());
 
         $this->assertTrue($this->hydrator->hasStrategy('myStrategy'));
     }
 
-    public function testRemovingStrategy()
+    public function testRemovingStrategy(): void
     {
         $this->assertFalse($this->hydrator->hasStrategy('myStrategy'));
 
@@ -63,7 +63,7 @@ class HydratorClosureStrategyTest extends TestCase
         $this->assertFalse($this->hydrator->hasStrategy('myStrategy'));
     }
 
-    public function testRetrieveStrategy()
+    public function testRetrieveStrategy(): void
     {
         $strategy = new ClosureStrategy();
         $this->hydrator->addStrategy('myStrategy', $strategy);
@@ -71,7 +71,7 @@ class HydratorClosureStrategyTest extends TestCase
         $this->assertEquals($strategy, $this->hydrator->getStrategy('myStrategy'));
     }
 
-    public function testExtractingObjects()
+    public function testExtractingObjects(): void
     {
         $this->hydrator->addStrategy('field1', new ClosureStrategy(
             function ($value) {
@@ -93,7 +93,7 @@ class HydratorClosureStrategyTest extends TestCase
         $this->assertEquals('hello, world!', $values['field2']);
     }
 
-    public function testHydratingObjects()
+    public function testHydratingObjects(): void
     {
         $this->hydrator->addStrategy('field2', new ClosureStrategy(
             null,

--- a/test/HydratorObjectPropertyTest.php
+++ b/test/HydratorObjectPropertyTest.php
@@ -25,7 +25,7 @@ class HydratorObjectPropertyTest extends TestCase
         $this->hydrator = new ObjectPropertyHydrator();
     }
 
-    public function testMultipleInvocationsWithDifferentFiltersFindsAllProperties()
+    public function testMultipleInvocationsWithDifferentFiltersFindsAllProperties(): void
     {
         $instance = (object) [];
 

--- a/test/HydratorPluginManagerCompatibilityTest.php
+++ b/test/HydratorPluginManagerCompatibilityTest.php
@@ -25,6 +25,9 @@ class HydratorPluginManagerCompatibilityTest extends TestCase
         return new HydratorPluginManager(new ServiceManager());
     }
 
+    /**
+     * @return void
+     */
     protected function getV2InvalidPluginException()
     {
         // no-op

--- a/test/HydratorPluginManagerFactoryTest.php
+++ b/test/HydratorPluginManagerFactoryTest.php
@@ -20,7 +20,7 @@ use PHPUnit\Framework\TestCase;
 
 class HydratorPluginManagerFactoryTest extends TestCase
 {
-    public function testFactoryReturnsPluginManager()
+    public function testFactoryReturnsPluginManager(): void
     {
         $container = $this->createMock(ContainerInterface::class);
         $factory = new HydratorPluginManagerFactory();
@@ -31,8 +31,10 @@ class HydratorPluginManagerFactoryTest extends TestCase
 
     /**
      * @depends testFactoryReturnsPluginManager
+     *
+     * @return void
      */
-    public function testFactoryConfiguresPluginManagerUnderContainerInterop()
+    public function testFactoryConfiguresPluginManagerUnderContainerInterop(): void
     {
         $container = $this->createMock(ContainerInterface::class);
         $hydrator = $this->createMock(HydratorInterface::class);
@@ -46,7 +48,7 @@ class HydratorPluginManagerFactoryTest extends TestCase
         $this->assertSame($hydrator, $hydrators->get('test'));
     }
 
-    public function testConfiguresHydratorServicesWhenFound()
+    public function testConfiguresHydratorServicesWhenFound(): void
     {
         $hydrator = $this->createMock(HydratorInterface::class);
         $config = [
@@ -55,7 +57,8 @@ class HydratorPluginManagerFactoryTest extends TestCase
                     'test' => ReflectionHydrator::class,
                 ],
                 'factories' => [
-                    'test-too' => function ($container) use ($hydrator) {
+                    /** @psalm-return \PHPUnit\Framework\MockObject\MockObject&HydratorInterface */
+                    'test-too' => function ($container) use ($hydrator): HydratorInterface {
                         return $hydrator;
                     },
                 ],
@@ -90,7 +93,7 @@ class HydratorPluginManagerFactoryTest extends TestCase
         $this->assertSame($hydrator, $hydrators->get('test-too'));
     }
 
-    public function testDoesNotConfigureHydratorServicesWhenServiceListenerPresent()
+    public function testDoesNotConfigureHydratorServicesWhenServiceListenerPresent(): void
     {
         $container = $this->createMock(ServiceLocatorInterface::class);
         $container
@@ -116,7 +119,7 @@ class HydratorPluginManagerFactoryTest extends TestCase
         $this->assertFalse($hydrators->has('test-too'));
     }
 
-    public function testDoesNotConfigureHydratorServicesWhenConfigServiceNotPresent()
+    public function testDoesNotConfigureHydratorServicesWhenConfigServiceNotPresent(): void
     {
         $container = $this->createMock(ServiceLocatorInterface::class);
         $container
@@ -140,7 +143,7 @@ class HydratorPluginManagerFactoryTest extends TestCase
         $this->assertInstanceOf(HydratorPluginManager::class, $hydrators);
     }
 
-    public function testDoesNotConfigureHydratorServicesWhenConfigServiceDoesNotContainHydratorsConfig()
+    public function testDoesNotConfigureHydratorServicesWhenConfigServiceDoesNotContainHydratorsConfig(): void
     {
         $container = $this->createMock(ServiceLocatorInterface::class);
         $container

--- a/test/HydratorStrategyTest.php
+++ b/test/HydratorStrategyTest.php
@@ -29,7 +29,7 @@ class HydratorStrategyTest extends TestCase
         $this->hydrator = new ClassMethodsHydrator();
     }
 
-    public function testAddingStrategy()
+    public function testAddingStrategy(): void
     {
         $this->assertFalse($this->hydrator->hasStrategy('myStrategy'));
 
@@ -38,19 +38,19 @@ class HydratorStrategyTest extends TestCase
         $this->assertTrue($this->hydrator->hasStrategy('myStrategy'));
     }
 
-    public function testCheckStrategyEmpty()
+    public function testCheckStrategyEmpty(): void
     {
         $this->assertFalse($this->hydrator->hasStrategy('myStrategy'));
     }
 
-    public function testCheckStrategyNotEmpty()
+    public function testCheckStrategyNotEmpty(): void
     {
         $this->hydrator->addStrategy('myStrategy', new TestAsset\HydratorStrategy());
 
         $this->assertTrue($this->hydrator->hasStrategy('myStrategy'));
     }
 
-    public function testRemovingStrategy()
+    public function testRemovingStrategy(): void
     {
         $this->assertFalse($this->hydrator->hasStrategy('myStrategy'));
 
@@ -61,7 +61,7 @@ class HydratorStrategyTest extends TestCase
         $this->assertFalse($this->hydrator->hasStrategy('myStrategy'));
     }
 
-    public function testRetrieveStrategy()
+    public function testRetrieveStrategy(): void
     {
         $strategy = new TestAsset\HydratorStrategy();
         $this->hydrator->addStrategy('myStrategy', $strategy);
@@ -69,7 +69,7 @@ class HydratorStrategyTest extends TestCase
         $this->assertEquals($strategy, $this->hydrator->getStrategy('myStrategy'));
     }
 
-    public function testExtractingObjects()
+    public function testExtractingObjects(): void
     {
         $this->hydrator->addStrategy('entities', new TestAsset\HydratorStrategy());
 
@@ -83,7 +83,7 @@ class HydratorStrategyTest extends TestCase
         $this->assertContains(222, $attributes['entities']);
     }
 
-    public function testHydratingObjects()
+    public function testHydratingObjects(): void
     {
         $this->hydrator->addStrategy('entities', new TestAsset\HydratorStrategy());
 
@@ -102,11 +102,13 @@ class HydratorStrategyTest extends TestCase
 
     /**
      * @dataProvider underscoreHandlingDataProvider
+     *
+     * @return void
      */
     public function testWhenUsingUnderscoreSeparatedKeysHydratorStrategyIsAlwaysConsideredUnderscoreSeparatedToo(
         $underscoreSeparatedKeys,
         $formFieldKey
-    ) {
+    ): void {
         $hydrator = new ClassMethodsHydrator($underscoreSeparatedKeys);
 
         $strategy = $this->createMock(StrategyInterface::class);
@@ -135,7 +137,12 @@ class HydratorStrategyTest extends TestCase
         $hydrator->hydrate($attributes, $entity);
     }
 
-    public function underscoreHandlingDataProvider()
+    /**
+     * @return (bool|string)[][]
+     *
+     * @psalm-return array{0: array{0: true, 1: string}, 1: array{0: false, 1: string}}
+     */
+    public function underscoreHandlingDataProvider(): array
     {
         return [
             [true, 'foo_bar'],
@@ -143,7 +150,7 @@ class HydratorStrategyTest extends TestCase
         ];
     }
 
-    public function testContextAwarenessExtract()
+    public function testContextAwarenessExtract(): void
     {
         $strategy = new TestAsset\HydratorStrategyContextAware();
         $this->hydrator->addStrategy('field2', $strategy);
@@ -154,7 +161,7 @@ class HydratorStrategyTest extends TestCase
         $this->assertEquals($entityB, $strategy->object);
     }
 
-    public function testContextAwarenessHydrate()
+    public function testContextAwarenessHydrate(): void
     {
         $strategy = new TestAsset\HydratorStrategyContextAware();
         $this->hydrator->addStrategy('field2', $strategy);

--- a/test/HydratorTest.php
+++ b/test/HydratorTest.php
@@ -78,7 +78,7 @@ class HydratorTest extends TestCase
         $this->classMethodsInvalidParameter = new ClassMethodsInvalidParameter();
     }
 
-    public function testInitiateValues()
+    public function testInitiateValues(): void
     {
         self::assertSame('1', $this->classMethodsCamelCase->getFooBar());
         self::assertSame('2', $this->classMethodsCamelCase->getFooBarBaz());
@@ -102,7 +102,7 @@ class HydratorTest extends TestCase
         self::assertSame(true, $this->classMethodsUnderscore->hasBar());
     }
 
-    public function testHydratorReflection()
+    public function testHydratorReflection(): void
     {
         $hydrator = new ReflectionHydrator();
         $datas    = $hydrator->extract($this->reflection);
@@ -119,7 +119,7 @@ class HydratorTest extends TestCase
         self::assertSame('baz', $test->getFooBarBaz());
     }
 
-    public function testHydratorClassMethodsCamelCase()
+    public function testHydratorClassMethodsCamelCase(): void
     {
         $hydrator = new ClassMethodsHydrator(false);
         $datas = $hydrator->extract($this->classMethodsCamelCase);
@@ -155,7 +155,7 @@ class HydratorTest extends TestCase
         self::assertSame(false, $test->hasBar());
     }
 
-    public function testHydratorClassMethodsTitleCase()
+    public function testHydratorClassMethodsTitleCase(): void
     {
         $hydrator = new ClassMethodsHydrator(false);
         $datas = $hydrator->extract($this->classMethodsTitleCase);
@@ -191,7 +191,7 @@ class HydratorTest extends TestCase
         self::assertSame(false, $test->getHasBar());
     }
 
-    public function testHydratorClassMethodsUnderscore()
+    public function testHydratorClassMethodsUnderscore(): void
     {
         $hydrator = new ClassMethodsHydrator(true);
         $datas = $hydrator->extract($this->classMethodsUnderscore);
@@ -231,7 +231,7 @@ class HydratorTest extends TestCase
         self::assertSame(false, $test->hasBar());
     }
 
-    public function testHydratorClassMethodsUnderscoreWithUnderscoreUpperCasedHydrateDataKeys()
+    public function testHydratorClassMethodsUnderscoreWithUnderscoreUpperCasedHydrateDataKeys(): void
     {
         $hydrator = new ClassMethodsHydrator(true);
         $datas = $hydrator->extract($this->classMethodsUnderscore);
@@ -255,7 +255,7 @@ class HydratorTest extends TestCase
         self::assertSame(false, $test->hasBar());
     }
 
-    public function testHydratorClassMethodsOptions()
+    public function testHydratorClassMethodsOptions(): void
     {
         $hydrator = new ClassMethodsHydrator();
         self::assertTrue($hydrator->getUnderscoreSeparatedKeys());
@@ -265,7 +265,7 @@ class HydratorTest extends TestCase
         self::assertTrue($hydrator->getUnderscoreSeparatedKeys());
     }
 
-    public function testHydratorClassMethodsIgnoresInvalidValues()
+    public function testHydratorClassMethodsIgnoresInvalidValues(): void
     {
         $hydrator = new ClassMethodsHydrator(true);
         $data = [
@@ -277,7 +277,7 @@ class HydratorTest extends TestCase
         self::assertSame($this->classMethodsUnderscore, $test);
     }
 
-    public function testHydratorClassMethodsDefaultBehaviorIsConvertUnderscoreToCamelCase()
+    public function testHydratorClassMethodsDefaultBehaviorIsConvertUnderscoreToCamelCase(): void
     {
         $hydrator = new ClassMethodsHydrator();
         $datas = $hydrator->extract($this->classMethodsUnderscore);
@@ -291,7 +291,7 @@ class HydratorTest extends TestCase
         self::assertSame('bar', $test->getFooBarBaz());
     }
 
-    public function testRetrieveWildStrategyAndOther()
+    public function testRetrieveWildStrategyAndOther(): void
     {
         $hydrator = new ClassMethodsHydrator();
         $hydrator->addStrategy('default', new DefaultStrategy());
@@ -302,7 +302,7 @@ class HydratorTest extends TestCase
         self::assertInstanceOf(SerializableStrategy::class, $serializable);
     }
 
-    public function testUseWildStrategyByDefault()
+    public function testUseWildStrategyByDefault(): void
     {
         $hydrator = new ClassMethodsHydrator();
         $datas = $hydrator->extract($this->classMethodsUnderscore);
@@ -315,7 +315,7 @@ class HydratorTest extends TestCase
         self::assertSame('s:1:"1";', $datas['foo_bar']);
     }
 
-    public function testUseWildStrategyAndOther()
+    public function testUseWildStrategyAndOther(): void
     {
         $hydrator = new ClassMethodsHydrator();
         $datas = $hydrator->extract($this->classMethodsUnderscore);
@@ -328,7 +328,7 @@ class HydratorTest extends TestCase
         self::assertSame('s:1:"2";', $datas['foo_bar_baz']);
     }
 
-    public function testHydratorClassMethodsCamelCaseWithSetterMissing()
+    public function testHydratorClassMethodsCamelCaseWithSetterMissing(): void
     {
         $hydrator = new ClassMethodsHydrator(false);
 
@@ -343,7 +343,7 @@ class HydratorTest extends TestCase
         self::assertSame('2', $test->getFooBarBaz());
     }
 
-    public function testHydratorClassMethodsManipulateFilter()
+    public function testHydratorClassMethodsManipulateFilter(): void
     {
         $hydrator = new ClassMethodsHydrator(false);
         $datas = $hydrator->extract($this->classMethodsCamelCase);
@@ -367,7 +367,7 @@ class HydratorTest extends TestCase
         self::assertArrayNotHaskey('hasBar', $datas); //method is hasBar
     }
 
-    public function testHydratorClassMethodsWithCustomFilter()
+    public function testHydratorClassMethodsWithCustomFilter(): void
     {
         $hydrator = new ClassMethodsHydrator(false);
         $datas = $hydrator->extract($this->classMethodsCamelCase);
@@ -391,8 +391,10 @@ class HydratorTest extends TestCase
 
     /**
      * @dataProvider filterProvider
+     *
+     * @return void
      */
-    public function testArraySerializableFilter($hydrator, $serializable)
+    public function testArraySerializableFilter($hydrator, $serializable): void
     {
         self::assertSame(
             [
@@ -449,7 +451,10 @@ class HydratorTest extends TestCase
         );
     }
 
-    public function filterProvider()
+    /**
+     * @psalm-return list<array{0: \Laminas\Hydrator\HydratorInterface, 1: object}>
+     */
+    public function filterProvider(): array
     {
         return [
             [new ObjectPropertyHydrator(), new ObjectPropertyAsset],
@@ -458,7 +463,7 @@ class HydratorTest extends TestCase
         ];
     }
 
-    public function testHydratorClassMethodsWithInvalidNumberOfParameters()
+    public function testHydratorClassMethodsWithInvalidNumberOfParameters(): void
     {
         $hydrator = new ClassMethodsHydrator(false);
         $datas = $hydrator->extract($this->classMethodsInvalidParameter);
@@ -468,7 +473,7 @@ class HydratorTest extends TestCase
         self::assertFalse($datas['isBla']);
     }
 
-    public function testObjectBasedFilters()
+    public function testObjectBasedFilters(): void
     {
         $hydrator = new ClassMethodsHydrator(false);
         $foo = new ClassMethodsFilterProviderInterface();
@@ -478,7 +483,7 @@ class HydratorTest extends TestCase
         self::assertSame('foo', $data['bar']);
     }
 
-    public function testHydratorClassMethodsWithProtectedSetter()
+    public function testHydratorClassMethodsWithProtectedSetter(): void
     {
         $hydrator = new ClassMethodsHydrator(false);
         $object = new ClassMethodsProtectedSetter();
@@ -488,7 +493,7 @@ class HydratorTest extends TestCase
         self::assertSame('BAR', $data['bar']);
     }
 
-    public function testHydratorClassMethodsWithMagicMethodSetter()
+    public function testHydratorClassMethodsWithMagicMethodSetter(): void
     {
         $hydrator = new ClassMethodsHydrator(false);
         $object = new ClassMethodsMagicMethodSetter();
@@ -498,7 +503,7 @@ class HydratorTest extends TestCase
         self::assertSame('bar', $data['foo']);
     }
 
-    public function testHydratorClassMethodsWithMagicMethodSetterAndMethodExistsCheck()
+    public function testHydratorClassMethodsWithMagicMethodSetterAndMethodExistsCheck(): void
     {
         $hydrator = new ClassMethodsHydrator(false, true);
         $object = new ClassMethodsMagicMethodSetter();

--- a/test/HydratorTestTrait.php
+++ b/test/HydratorTestTrait.php
@@ -19,7 +19,7 @@ use function sprintf;
 
 trait HydratorTestTrait
 {
-    public function testHydrateWithNamingStrategyAndStrategy()
+    public function testHydrateWithNamingStrategyAndStrategy(): void
     {
         $namingStrategy = $this->createMock(NamingStrategyInterface::class);
         $namingStrategy
@@ -48,7 +48,7 @@ trait HydratorTestTrait
         );
     }
 
-    public function testExtractWithNamingStrategyAndStrategy()
+    public function testExtractWithNamingStrategyAndStrategy(): void
     {
         $entity = new SimpleEntity();
         $entity->setValue('foo');

--- a/test/Iterator/HydratingArrayIteratorTest.php
+++ b/test/Iterator/HydratingArrayIteratorTest.php
@@ -21,7 +21,7 @@ use PHPUnit\Framework\TestCase;
  */
 class HydratingArrayIteratorTest extends TestCase
 {
-    public function testHydratesObjectAndClonesOnCurrent()
+    public function testHydratesObjectAndClonesOnCurrent(): void
     {
         $data = [
             ['foo' => 'bar'],
@@ -44,7 +44,7 @@ class HydratingArrayIteratorTest extends TestCase
         $this->assertEquals(new ArrayObject($data[1]), $hydratingIterator->current());
     }
 
-    public function testUsingStringForObjectName()
+    public function testUsingStringForObjectName(): void
     {
         $data = [
             ['foo' => 'bar'],
@@ -56,7 +56,7 @@ class HydratingArrayIteratorTest extends TestCase
         $this->assertEquals(new ArrayObject($data[0]), $hydratingIterator->current());
     }
 
-    public function testThrowingInvalidArgumentExceptionWhenSettingPrototypeToInvalidClass()
+    public function testThrowingInvalidArgumentExceptionWhenSettingPrototypeToInvalidClass(): void
     {
         $this->expectException(InvalidArgumentException::class);
         $hydratingIterator = new HydratingArrayIterator(new ArraySerializableHydrator(), [], 'not a real class');

--- a/test/Iterator/HydratingIteratorIteratorTest.php
+++ b/test/Iterator/HydratingIteratorIteratorTest.php
@@ -22,7 +22,7 @@ use PHPUnit\Framework\TestCase;
  */
 class HydratingIteratorIteratorTest extends TestCase
 {
-    public function testHydratesObjectAndClonesOnCurrent()
+    public function testHydratesObjectAndClonesOnCurrent(): void
     {
         $data = [
             ['foo' => 'bar'],
@@ -46,7 +46,7 @@ class HydratingIteratorIteratorTest extends TestCase
         $this->assertEquals(new ArrayObject($data[1]), $hydratingIterator->current());
     }
 
-    public function testUsingStringForObjectName()
+    public function testUsingStringForObjectName(): void
     {
         $data = [
             ['foo' => 'bar'],
@@ -60,7 +60,7 @@ class HydratingIteratorIteratorTest extends TestCase
         $this->assertEquals(new ArrayObject($data[0]), $hydratingIterator->current());
     }
 
-    public function testThrowingInvalidArgumentExceptionWhenSettingPrototypeToInvalidClass()
+    public function testThrowingInvalidArgumentExceptionWhenSettingPrototypeToInvalidClass(): void
     {
         $this->expectException(InvalidArgumentException::class);
         $hydratingIterator = new HydratingIteratorIterator(

--- a/test/NamingStrategy/CompositeNamingStrategyTest.php
+++ b/test/NamingStrategy/CompositeNamingStrategyTest.php
@@ -21,7 +21,7 @@ use PHPUnit\Framework\TestCase;
  */
 class CompositeNamingStrategyTest extends TestCase
 {
-    public function testGetSameNameWhenNoNamingStrategyExistsForTheName()
+    public function testGetSameNameWhenNoNamingStrategyExistsForTheName(): void
     {
         $compositeNamingStrategy = new CompositeNamingStrategy([
             'foo' => $this->createMock(NamingStrategyInterface::class)
@@ -31,7 +31,7 @@ class CompositeNamingStrategyTest extends TestCase
         $this->assertEquals('bar', $compositeNamingStrategy->extract('bar'));
     }
 
-    public function testUseDefaultNamingStrategy()
+    public function testUseDefaultNamingStrategy(): void
     {
         /* @var $defaultNamingStrategy NamingStrategyInterface|\PHPUnit_Framework_MockObject_MockObject*/
         $defaultNamingStrategy = $this->createMock(NamingStrategyInterface::class);
@@ -52,7 +52,7 @@ class CompositeNamingStrategyTest extends TestCase
         $this->assertEquals('foo', $compositeNamingStrategy->extract('Foo'));
     }
 
-    public function testHydrate()
+    public function testHydrate(): void
     {
         $fooNamingStrategy = $this->createMock(NamingStrategyInterface::class);
         $fooNamingStrategy->expects($this->once())
@@ -63,7 +63,7 @@ class CompositeNamingStrategyTest extends TestCase
         $this->assertEquals('FOO', $compositeNamingStrategy->hydrate('foo'));
     }
 
-    public function testExtract()
+    public function testExtract(): void
     {
         $fooNamingStrategy = $this->createMock(NamingStrategyInterface::class);
         $fooNamingStrategy->expects($this->once())

--- a/test/NamingStrategy/IdentityNamingStrategyTest.php
+++ b/test/NamingStrategy/IdentityNamingStrategyTest.php
@@ -24,8 +24,10 @@ class IdentityNamingStrategyTest extends TestCase
      * @dataProvider getTestedNames
      *
      * @param string $name
+     *
+     * @return void
      */
-    public function testHydrate($name)
+    public function testHydrate($name): void
     {
         $namingStrategy = new IdentityNamingStrategy();
 
@@ -36,8 +38,10 @@ class IdentityNamingStrategyTest extends TestCase
      * @dataProvider getTestedNames
      *
      * @param string $name
+     *
+     * @return void
      */
-    public function testExtract($name)
+    public function testExtract($name): void
     {
         $namingStrategy = new IdentityNamingStrategy();
 

--- a/test/NamingStrategy/MapNamingStrategyTest.php
+++ b/test/NamingStrategy/MapNamingStrategyTest.php
@@ -10,7 +10,6 @@ declare(strict_types=1);
 
 namespace LaminasTest\Hydrator\NamingStrategy;
 
-use Error;
 use Laminas\Hydrator\Exception;
 use Laminas\Hydrator\NamingStrategy\MapNamingStrategy;
 use PHPUnit\Framework\TestCase;
@@ -44,9 +43,12 @@ class MapNamingStrategyTest extends TestCase
 
     /**
      * @dataProvider invalidMapValues
+     *
      * @param mixed $invalidValue
+     *
+     * @return void
      */
-    public function testExtractionMapConstructorRaisesExceptionWhenFlippingHydrationMapForInvalidValues($invalidValue)
+    public function testExtractionMapConstructorRaisesExceptionWhenFlippingHydrationMapForInvalidValues($invalidValue): void
     {
         $this->expectException(Exception\InvalidArgumentException::class);
         $this->expectExceptionMessage('can not be flipped');
@@ -56,9 +58,12 @@ class MapNamingStrategyTest extends TestCase
 
     /**
      * @dataProvider invalidKeyValues
+     *
      * @param mixed $invalidKey
+     *
+     * @return void
      */
-    public function testExtractionMapConstructorRaisesExceptionWhenFlippingHydrationMapForInvalidKeys($invalidKey)
+    public function testExtractionMapConstructorRaisesExceptionWhenFlippingHydrationMapForInvalidKeys($invalidKey): void
     {
         $this->expectException(Exception\InvalidArgumentException::class);
         $this->expectExceptionMessage('can not be flipped');
@@ -68,9 +73,12 @@ class MapNamingStrategyTest extends TestCase
 
     /**
      * @dataProvider invalidMapValues
+     *
      * @param mixed $invalidValue
+     *
+     * @return void
      */
-    public function testHydrationMapConstructorRaisesExceptionWhenFlippingExtractionMapForInvalidValues($invalidValue)
+    public function testHydrationMapConstructorRaisesExceptionWhenFlippingExtractionMapForInvalidValues($invalidValue): void
     {
         $this->expectException(Exception\InvalidArgumentException::class);
         $this->expectExceptionMessage('can not be flipped');
@@ -80,9 +88,12 @@ class MapNamingStrategyTest extends TestCase
 
     /**
      * @dataProvider invalidKeyValues
+     *
      * @param mixed $invalidKey
+     *
+     * @return void
      */
-    public function testHydrationMapConstructorRaisesExceptionWhenFlippingExtractionMapForInvalidKeys($invalidKey)
+    public function testHydrationMapConstructorRaisesExceptionWhenFlippingExtractionMapForInvalidKeys($invalidKey): void
     {
         $this->expectException(Exception\InvalidArgumentException::class);
         $this->expectExceptionMessage('can not be flipped');
@@ -90,43 +101,43 @@ class MapNamingStrategyTest extends TestCase
         MapNamingStrategy::createFromHydrationMap([$invalidKey => 'foo']);
     }
 
-    public function testExtractReturnsVerbatimWhenEmptyExtractionMapProvided()
+    public function testExtractReturnsVerbatimWhenEmptyExtractionMapProvided(): void
     {
         $strategy = MapNamingStrategy::createFromExtractionMap([]);
         $this->assertEquals('some_stuff', $strategy->extract('some_stuff'));
     }
 
-    public function testHydrateReturnsVerbatimWhenEmptyHydrationMapProvided()
+    public function testHydrateReturnsVerbatimWhenEmptyHydrationMapProvided(): void
     {
         $strategy = MapNamingStrategy::createFromHydrationMap([]);
         $this->assertEquals('some_stuff', $strategy->hydrate('some_stuff'));
     }
 
-    public function testExtractUsesProvidedExtractionMap()
+    public function testExtractUsesProvidedExtractionMap(): void
     {
         $strategy = MapNamingStrategy::createFromExtractionMap(['stuff3' => 'stuff4']);
         $this->assertEquals('stuff4', $strategy->extract('stuff3'));
     }
 
-    public function testExtractUsesFlippedHydrationMapWhenOnlyHydrationMapProvided()
+    public function testExtractUsesFlippedHydrationMapWhenOnlyHydrationMapProvided(): void
     {
         $strategy = MapNamingStrategy::createFromHydrationMap(['stuff3' => 'stuff4']);
         $this->assertEquals('stuff3', $strategy->extract('stuff4'));
     }
 
-    public function testHydrateUsesProvidedHydrationMap()
+    public function testHydrateUsesProvidedHydrationMap(): void
     {
         $strategy = MapNamingStrategy::createFromHydrationMap(['stuff3' => 'stuff4']);
         $this->assertEquals('stuff4', $strategy->hydrate('stuff3'));
     }
 
-    public function testHydrateUsesFlippedExtractionMapOnlyExtractionMapProvided()
+    public function testHydrateUsesFlippedExtractionMapOnlyExtractionMapProvided(): void
     {
         $strategy = MapNamingStrategy::createFromExtractionMap(['foo' => 'bar']);
         $this->assertEquals('foo', $strategy->hydrate('bar'));
     }
 
-    public function testHydrateAndExtractUseAsymmetricMapProvided()
+    public function testHydrateAndExtractUseAsymmetricMapProvided(): void
     {
         $strategy = MapNamingStrategy::createFromAsymmetricMap(['foo' => 'bar'], ['bat' => 'baz']);
         $this->assertEquals('bar', $strategy->extract('foo'));

--- a/test/NamingStrategy/UnderscoreNamingStrategy/CamelCaseToUnderscoreFilterTest.php
+++ b/test/NamingStrategy/UnderscoreNamingStrategy/CamelCaseToUnderscoreFilterTest.php
@@ -25,10 +25,13 @@ class CamelCaseToUnderscoreFilterTest extends TestCase
 {
     /**
      * @dataProvider nonUnicodeProvider
+     *
      * @param string $string
      * @param string $expected
+     *
+     * @return void
      */
-    public function testFilterUnderscoresNonUnicodeStrings($string, $expected)
+    public function testFilterUnderscoresNonUnicodeStrings($string, $expected): void
     {
         $filter   = new CamelCaseToUnderscoreFilter();
 
@@ -45,10 +48,13 @@ class CamelCaseToUnderscoreFilterTest extends TestCase
 
     /**
      * @dataProvider unicodeProvider
+     *
      * @param string $string
      * @param string $expected
+     *
+     * @return void
      */
-    public function testFilterUnderscoresUnicodeStrings($string, $expected)
+    public function testFilterUnderscoresUnicodeStrings($string, $expected): void
     {
         if (! extension_loaded('mbstring')) {
             $this->markTestSkipped('Extension mbstring not available');
@@ -64,10 +70,13 @@ class CamelCaseToUnderscoreFilterTest extends TestCase
 
     /**
      * @dataProvider unicodeProviderWithoutMbStrings
+     *
      * @param string $string
      * @param string $expected
+     *
+     * @return void
      */
-    public function testFilterUnderscoresUnicodeStringsWithoutMbStrings($string, $expected)
+    public function testFilterUnderscoresUnicodeStringsWithoutMbStrings($string, $expected): void
     {
         $filter   = new CamelCaseToUnderscoreFilter();
 
@@ -82,7 +91,12 @@ class CamelCaseToUnderscoreFilterTest extends TestCase
         $this->assertEquals($expected, $filtered);
     }
 
-    public function nonUnicodeProvider()
+    /**
+     * @return string[][]
+     *
+     * @psalm-return array<string, array{0: string, 1: string}>
+     */
+    public function nonUnicodeProvider(): array
     {
         return [
             'upcased first letter' => [
@@ -112,7 +126,12 @@ class CamelCaseToUnderscoreFilterTest extends TestCase
         ];
     }
 
-    public function unicodeProvider()
+    /**
+     * @return string[][]
+     *
+     * @psalm-return array<string, array{0: string, 1: string}>
+     */
+    public function unicodeProvider(): array
     {
         return [
             'upcased first letter' => [
@@ -142,7 +161,12 @@ class CamelCaseToUnderscoreFilterTest extends TestCase
         ];
     }
 
-    public function unicodeProviderWithoutMbStrings()
+    /**
+     * @return string[][]
+     *
+     * @psalm-return array<string, array{0: string, 1: string}>
+     */
+    public function unicodeProviderWithoutMbStrings(): array
     {
         return [
             'upcased first letter' => [

--- a/test/NamingStrategy/UnderscoreNamingStrategy/UnderscoreToCamelCaseFilterTest.php
+++ b/test/NamingStrategy/UnderscoreNamingStrategy/UnderscoreToCamelCaseFilterTest.php
@@ -25,10 +25,13 @@ class UnderscoreToCamelCaseFilterTest extends TestCase
 {
     /**
      * @dataProvider nonUnicodeProvider
+     *
      * @param string $string
      * @param string $expected
+     *
+     * @return void
      */
-    public function testFilterCamelCasesNonUnicodeStrings($string, $expected)
+    public function testFilterCamelCasesNonUnicodeStrings($string, $expected): void
     {
         $filter   = new UnderscoreToCamelCaseFilter();
 
@@ -43,7 +46,12 @@ class UnderscoreToCamelCaseFilterTest extends TestCase
         $this->assertEquals($expected, $filtered);
     }
 
-    public function nonUnicodeProvider()
+    /**
+     * @return string[][]
+     *
+     * @psalm-return array<string, array{0: string, 1: string}>
+     */
+    public function nonUnicodeProvider(): array
     {
         return [
             'one word' => [
@@ -67,10 +75,13 @@ class UnderscoreToCamelCaseFilterTest extends TestCase
 
     /**
      * @dataProvider unicodeProvider
+     *
      * @param string $string
      * @param string $expected
+     *
+     * @return void
      */
-    public function testFilterCamelCasesUnicodeStrings($string, $expected)
+    public function testFilterCamelCasesUnicodeStrings($string, $expected): void
     {
         if (! extension_loaded('mbstring')) {
             $this->markTestSkipped('Extension mbstring not available');
@@ -83,7 +94,12 @@ class UnderscoreToCamelCaseFilterTest extends TestCase
         $this->assertEquals($expected, $filtered);
     }
 
-    public function unicodeProvider()
+    /**
+     * @return string[][]
+     *
+     * @psalm-return array<string, array{0: string, 1: string}>
+     */
+    public function unicodeProvider(): array
     {
         return [
             'uppercase first letter' => [
@@ -115,13 +131,16 @@ class UnderscoreToCamelCaseFilterTest extends TestCase
 
     /**
      * @dataProvider unicodeWithoutMbStringsProvider
+     *
      * @param string $string
      * @param string $expected
+     *
+     * @return void
      */
     public function testFilterCamelCasesUnicodeStringsWithoutMbStrings(
         $string,
         $expected
-    ) {
+    ): void {
 
         $filter   = new UnderscoreToCamelCaseFilter();
 
@@ -134,7 +153,12 @@ class UnderscoreToCamelCaseFilterTest extends TestCase
         $this->assertEquals($expected, $filtered);
     }
 
-    public function unicodeWithoutMbStringsProvider()
+    /**
+     * @return string[][]
+     *
+     * @psalm-return array<string, array{0: string, 1: string}>
+     */
+    public function unicodeWithoutMbStringsProvider(): array
     {
         return [
             'multiple words' => [

--- a/test/NamingStrategy/UnderscoreNamingStrategyTest.php
+++ b/test/NamingStrategy/UnderscoreNamingStrategyTest.php
@@ -20,13 +20,13 @@ use PHPUnit\Framework\TestCase;
  */
 class UnderscoreNamingStrategyTest extends TestCase
 {
-    public function testNameHydratesToCamelCase()
+    public function testNameHydratesToCamelCase(): void
     {
         $strategy = new UnderscoreNamingStrategy();
         $this->assertEquals('fooBarBaz', $strategy->hydrate('foo_bar_baz'));
     }
 
-    public function testNameExtractsToUnderscore()
+    public function testNameExtractsToUnderscore(): void
     {
         $strategy = new UnderscoreNamingStrategy();
         $this->assertEquals('foo_bar_baz', $strategy->extract('fooBarBaz'));
@@ -35,8 +35,10 @@ class UnderscoreNamingStrategyTest extends TestCase
     /**
      * @group 6422
      * @group 6420
+     *
+     * @return void
      */
-    public function testNameHydratesToStudlyCaps()
+    public function testNameHydratesToStudlyCaps(): void
     {
         $strategy = new UnderscoreNamingStrategy();
 

--- a/test/ObjectPropertyTest.php
+++ b/test/ObjectPropertyTest.php
@@ -16,7 +16,7 @@ use PHPUnit\Framework\TestCase;
 
 class ObjectPropertyTest extends TestCase
 {
-    public function testTriggerUserDeprecatedError()
+    public function testTriggerUserDeprecatedError(): void
     {
         $test = (object) ['message' => false];
 

--- a/test/ReflectionTest.php
+++ b/test/ReflectionTest.php
@@ -16,7 +16,7 @@ use PHPUnit\Framework\TestCase;
 
 class ReflectionTest extends TestCase
 {
-    public function testTriggerUserDeprecatedError()
+    public function testTriggerUserDeprecatedError(): void
     {
         $test = (object) ['message' => false];
 

--- a/test/StandaloneHydratorPluginManagerFactoryTest.php
+++ b/test/StandaloneHydratorPluginManagerFactoryTest.php
@@ -41,7 +41,7 @@ class StandaloneHydratorPluginManagerFactoryTest extends TestCase
     public function assertDefaultServices(
         StandaloneHydratorPluginManager $manager,
         string $message = self::MESSAGE_DEFAULT_SERVICES
-    ) {
+    ): void {
         $this->assertTrue($manager->has('ArraySerializable'), sprintf($message, 'ArraySerializable'));
         $this->assertTrue($manager->has('ArraySerializableHydrator'), sprintf($message, 'ArraySerializableHydrator'));
         $this->assertTrue($manager->has(ArraySerializable::class), sprintf($message, ArraySerializable::class));
@@ -72,7 +72,7 @@ class StandaloneHydratorPluginManagerFactoryTest extends TestCase
         $this->assertTrue($manager->has(ReflectionHydrator::class), sprintf($message, ReflectionHydrator::class));
     }
 
-    public function testCreatesPluginManagerWithDefaultServices()
+    public function testCreatesPluginManagerWithDefaultServices(): void
     {
         $manager = ($this->factory)($this->container);
         $this->assertDefaultServices($manager);

--- a/test/StandaloneHydratorPluginManagerTest.php
+++ b/test/StandaloneHydratorPluginManagerTest.php
@@ -54,8 +54,10 @@ class StandaloneHydratorPluginManagerTest extends TestCase
 
     /**
      * @dataProvider hydratorsWithoutConstructors
+     *
+     * @return void
      */
-    public function testInstantiationInitializesFactoriesForHydratorsWithoutConstructorArguments(string $class)
+    public function testInstantiationInitializesFactoriesForHydratorsWithoutConstructorArguments(string $class): void
     {
         $factories = $this->reflectProperty($this->manager, 'factories');
 
@@ -63,7 +65,7 @@ class StandaloneHydratorPluginManagerTest extends TestCase
         $this->assertInstanceOf(Closure::class, $factories[$class]);
     }
 
-    public function testDelegatingHydratorFactoryIsInitialized()
+    public function testDelegatingHydratorFactoryIsInitialized(): void
     {
         $factories = $this->reflectProperty($this->manager, 'factories');
         $this->assertInstanceOf(
@@ -72,7 +74,7 @@ class StandaloneHydratorPluginManagerTest extends TestCase
         );
     }
 
-    public function testHasReturnsFalseForUnknownNames()
+    public function testHasReturnsFalseForUnknownNames(): void
     {
         $this->assertFalse($this->manager->has('unknown-service-name'));
     }
@@ -94,13 +96,15 @@ class StandaloneHydratorPluginManagerTest extends TestCase
 
     /**
      * @dataProvider knownServices
+     *
+     * @return void
      */
-    public function testHasReturnsTrueForKnownServices(string $service)
+    public function testHasReturnsTrueForKnownServices(string $service): void
     {
         $this->assertTrue($this->manager->has($service));
     }
 
-    public function testGetRaisesExceptionForUnknownService()
+    public function testGetRaisesExceptionForUnknownService(): void
     {
         $this->expectException(Hydrator\Exception\MissingHydratorServiceException::class);
         $this->manager->get('unknown-service-name');
@@ -108,8 +112,10 @@ class StandaloneHydratorPluginManagerTest extends TestCase
 
     /**
      * @dataProvider knownServices
+     *
+     * @return void
      */
-    public function testGetReturnsExpectedTypesForKnownServices(string $service, string $expectedType)
+    public function testGetReturnsExpectedTypesForKnownServices(string $service, string $expectedType): void
     {
         $instance = $this->manager->get($service);
         $this->assertInstanceOf($expectedType, $instance);

--- a/test/Strategy/BooleanStrategyTest.php
+++ b/test/Strategy/BooleanStrategyTest.php
@@ -21,17 +21,17 @@ use PHPUnit\Framework\TestCase;
  */
 class BooleanStrategyTest extends TestCase
 {
-    public function testConstructorWithValidInteger()
+    public function testConstructorWithValidInteger(): void
     {
         $this->assertInstanceOf(BooleanStrategy::class, new BooleanStrategy(1, 0));
     }
 
-    public function testConstructorWithValidString()
+    public function testConstructorWithValidString(): void
     {
         $this->assertInstanceOf(BooleanStrategy::class, new BooleanStrategy('true', 'false'));
     }
 
-    public function testExceptionOnWrongTrueValueInConstructor()
+    public function testExceptionOnWrongTrueValueInConstructor(): void
     {
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('Expected int or string as $trueValue.');
@@ -39,7 +39,7 @@ class BooleanStrategyTest extends TestCase
         new BooleanStrategy(true, 0);
     }
 
-    public function testExceptionOnWrongFalseValueInConstructor()
+    public function testExceptionOnWrongFalseValueInConstructor(): void
     {
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('Expected int or string as $falseValue.');
@@ -47,14 +47,14 @@ class BooleanStrategyTest extends TestCase
         new BooleanStrategy(1, false);
     }
 
-    public function testExtractString()
+    public function testExtractString(): void
     {
         $hydrator = new BooleanStrategy('true', 'false');
         $this->assertEquals('true', $hydrator->extract(true));
         $this->assertEquals('false', $hydrator->extract(false));
     }
 
-    public function testExtractInteger()
+    public function testExtractInteger(): void
     {
         $hydrator = new BooleanStrategy(1, 0);
 
@@ -62,7 +62,7 @@ class BooleanStrategyTest extends TestCase
         $this->assertEquals(0, $hydrator->extract(false));
     }
 
-    public function testExtractThrowsExceptionOnUnknownValue()
+    public function testExtractThrowsExceptionOnUnknownValue(): void
     {
         $hydrator = new BooleanStrategy(1, 0);
 
@@ -72,28 +72,28 @@ class BooleanStrategyTest extends TestCase
         $hydrator->extract(5);
     }
 
-    public function testHydrateString()
+    public function testHydrateString(): void
     {
         $hydrator = new BooleanStrategy('true', 'false');
         $this->assertEquals(true, $hydrator->hydrate('true'));
         $this->assertEquals(false, $hydrator->hydrate('false'));
     }
 
-    public function testHydrateInteger()
+    public function testHydrateInteger(): void
     {
         $hydrator = new BooleanStrategy(1, 0);
         $this->assertEquals(true, $hydrator->hydrate(1));
         $this->assertEquals(false, $hydrator->hydrate(0));
     }
 
-    public function testHydrateBool()
+    public function testHydrateBool(): void
     {
         $hydrator = new BooleanStrategy(1, 0);
         $this->assertEquals(true, $hydrator->hydrate(true));
         $this->assertEquals(false, $hydrator->hydrate(false));
     }
 
-    public function testHydrateUnexpectedValueThrowsException()
+    public function testHydrateUnexpectedValueThrowsException(): void
     {
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('Unexpected value');
@@ -101,7 +101,7 @@ class BooleanStrategyTest extends TestCase
         $hydrator->hydrate(2);
     }
 
-    public function testHydrateInvalidArgument()
+    public function testHydrateInvalidArgument(): void
     {
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('Unable to hydrate');

--- a/test/Strategy/CollectionStrategyTest.php
+++ b/test/Strategy/CollectionStrategyTest.php
@@ -39,7 +39,7 @@ use function sprintf;
  */
 class CollectionStrategyTest extends TestCase
 {
-    public function testImplementsStrategyInterface()
+    public function testImplementsStrategyInterface(): void
     {
         $reflection = new ReflectionClass(CollectionStrategy::class);
 
@@ -54,12 +54,14 @@ class CollectionStrategyTest extends TestCase
      * @dataProvider providerInvalidObjectClassName
      *
      * @param mixed $objectClassName
+     *
+     * @return void
      */
     public function testConstructorRejectsInvalidObjectClassName(
         $objectClassName,
         string $expectedExceptionType,
         string $expectedExceptionMessage
-    ) {
+    ): void {
         $this->expectException($expectedExceptionType);
         $this->expectExceptionMessage($expectedExceptionMessage);
 
@@ -90,8 +92,10 @@ class CollectionStrategyTest extends TestCase
      * @dataProvider providerInvalidValueForExtraction
      *
      * @param mixed $value
+     *
+     * @return void
      */
-    public function testExtractRejectsInvalidValue($value)
+    public function testExtractRejectsInvalidValue($value): void
     {
         $strategy = new CollectionStrategy(
             $this->createHydratorMock(),
@@ -132,8 +136,10 @@ class CollectionStrategyTest extends TestCase
      * @dataProvider providerInvalidObjectForExtraction
      *
      * @param mixed $object
+     *
+     * @return void
      */
-    public function testExtractRejectsInvalidObject($object)
+    public function testExtractRejectsInvalidObject($object): void
     {
         $value = [$object];
 
@@ -173,7 +179,7 @@ class CollectionStrategyTest extends TestCase
         }
     }
 
-    public function testExtractUsesHydratorToExtractValues()
+    public function testExtractUsesHydratorToExtractValues(): void
     {
         $value = [
             new TestAsset\User(),
@@ -181,7 +187,12 @@ class CollectionStrategyTest extends TestCase
             new TestAsset\User(),
         ];
 
-        $extraction = function (TestAsset\User $value) {
+        $extraction = /**
+         * @return string[]
+         *
+         * @psalm-return array{value: string}
+         */
+        function (TestAsset\User $value): array {
             return [
                 'value' => spl_object_hash($value)
             ];
@@ -208,8 +219,10 @@ class CollectionStrategyTest extends TestCase
      * @dataProvider providerInvalidValueForHydration
      *
      * @param mixed $value
+     *
+     * @return void
      */
-    public function testHydrateRejectsInvalidValue($value)
+    public function testHydrateRejectsInvalidValue($value): void
     {
         $strategy = new CollectionStrategy(
             $this->createHydratorMock(),
@@ -246,7 +259,7 @@ class CollectionStrategyTest extends TestCase
         }
     }
 
-    public function testHydrateUsesHydratorToHydrateValues()
+    public function testHydrateUsesHydratorToHydrateValues(): void
     {
         $value = [
             ['name' => 'Suzie Q.'],

--- a/test/Strategy/DateTimeFormatterStrategyTest.php
+++ b/test/Strategy/DateTimeFormatterStrategyTest.php
@@ -25,7 +25,7 @@ use PHPUnit\Framework\TestCase;
 class DateTimeFormatterStrategyTest extends TestCase
 {
 
-    public function testHydrate()
+    public function testHydrate(): void
     {
         $strategy = new DateTimeFormatterStrategy('Y-m-d');
         $this->assertEquals('2014-04-26', $strategy->hydrate('2014-04-26')->format('Y-m-d'));
@@ -36,20 +36,20 @@ class DateTimeFormatterStrategyTest extends TestCase
         $this->assertEquals('Asia/Kathmandu', $date->getTimezone()->getName());
     }
 
-    public function testExtract()
+    public function testExtract(): void
     {
         $strategy = new DateTimeFormatterStrategy('d/m/Y');
         $this->assertEquals('26/04/2014', $strategy->extract(new \DateTime('2014-04-26')));
     }
 
-    public function testGetNullWithInvalidDateOnHydration()
+    public function testGetNullWithInvalidDateOnHydration(): void
     {
         $strategy = new DateTimeFormatterStrategy('Y-m-d');
         $this->assertEquals(null, $strategy->hydrate(null));
         $this->assertEquals(null, $strategy->hydrate(''));
     }
 
-    public function testCanExtractIfNotDateTime()
+    public function testCanExtractIfNotDateTime(): void
     {
         $strategy = new DateTimeFormatterStrategy();
         $date = $strategy->extract(new \stdClass);
@@ -57,13 +57,13 @@ class DateTimeFormatterStrategyTest extends TestCase
         $this->assertInstanceOf(\stdClass::class, $date);
     }
 
-    public function testCanHydrateWithInvalidDateTime()
+    public function testCanHydrateWithInvalidDateTime(): void
     {
         $strategy = new DateTimeFormatterStrategy('d/m/Y');
         $this->assertSame('foo bar baz', $strategy->hydrate('foo bar baz'));
     }
 
-    public function testCanExtractAnyDateTimeInterface()
+    public function testCanExtractAnyDateTimeInterface(): void
     {
         $dateMock = $this
             ->getMockBuilder(DateTime::class)
@@ -92,10 +92,13 @@ class DateTimeFormatterStrategyTest extends TestCase
 
     /**
      * @dataProvider formatsWithSpecialCharactersProvider
+     *
      * @param string $format
      * @param string $expectedValue
+     *
+     * @return void
      */
-    public function testAcceptsCreateFromFormatSpecialCharacters($format, $expectedValue)
+    public function testAcceptsCreateFromFormatSpecialCharacters($format, $expectedValue): void
     {
         $strategy = new DateTimeFormatterStrategy($format);
         $hydrated = $strategy->hydrate($expectedValue);
@@ -106,10 +109,13 @@ class DateTimeFormatterStrategyTest extends TestCase
 
     /**
      * @dataProvider formatsWithSpecialCharactersProvider
+     *
      * @param string $format
      * @param string $expectedValue
+     *
+     * @return void
      */
-    public function testCanExtractWithCreateFromFormatSpecialCharacters($format, $expectedValue)
+    public function testCanExtractWithCreateFromFormatSpecialCharacters($format, $expectedValue): void
     {
         $date      = DateTime::createFromFormat($format, $expectedValue);
         $strategy  = new DateTimeFormatterStrategy($format);
@@ -118,7 +124,7 @@ class DateTimeFormatterStrategyTest extends TestCase
         $this->assertEquals($expectedValue, $extracted);
     }
 
-    public function testCanExtractWithCreateFromFormatEscapedSpecialCharacters()
+    public function testCanExtractWithCreateFromFormatEscapedSpecialCharacters(): void
     {
         $date      = DateTime::createFromFormat('Y-m-d', '2018-02-05');
         $strategy  = new DateTimeFormatterStrategy('Y-m-d\\+');
@@ -126,7 +132,12 @@ class DateTimeFormatterStrategyTest extends TestCase
         $this->assertEquals('2018-02-05+', $extracted);
     }
 
-    public function formatsWithSpecialCharactersProvider()
+    /**
+     * @return string[][]
+     *
+     * @psalm-return array<string, array{0: string, 1: string}>
+     */
+    public function formatsWithSpecialCharactersProvider(): array
     {
         return [
             '!-prepended' => ['!Y-m-d', '2018-02-05'],
@@ -135,7 +146,7 @@ class DateTimeFormatterStrategyTest extends TestCase
         ];
     }
 
-    public function testCanHydrateWithDateTimeFallback()
+    public function testCanHydrateWithDateTimeFallback(): void
     {
         $strategy = new DateTimeFormatterStrategy('Y-m-d', null, true);
         $date = $strategy->hydrate('2018-09-06T12:10:30');
@@ -162,9 +173,12 @@ class DateTimeFormatterStrategyTest extends TestCase
 
     /**
      * @dataProvider invalidValuesForHydration
+     *
      * @param mixed $value
+     *
+     * @return void
      */
-    public function testHydrateRaisesExceptionIfValueIsInvalid($value)
+    public function testHydrateRaisesExceptionIfValueIsInvalid($value): void
     {
         $strategy = new DateTimeFormatterStrategy('Y-m-d');
 
@@ -184,9 +198,12 @@ class DateTimeFormatterStrategyTest extends TestCase
 
     /**
      * @dataProvider validUnhydratableValues
+     *
      * @param mixed $value
+     *
+     * @return void
      */
-    public function testReturnsValueVerbatimUnderSpecificConditions($value)
+    public function testReturnsValueVerbatimUnderSpecificConditions($value): void
     {
         $strategy = new DateTimeFormatterStrategy('Y-m-d');
         $hydrated = $strategy->hydrate($value);

--- a/test/Strategy/ExplodeStrategyTest.php
+++ b/test/Strategy/ExplodeStrategyTest.php
@@ -30,8 +30,10 @@ class ExplodeStrategyTest extends TestCase
      * @param string   $expected
      * @param string   $delimiter
      * @param string[] $extractValue
+     *
+     * @return void
      */
-    public function testExtract($expected, $delimiter, $extractValue)
+    public function testExtract($expected, $delimiter, $extractValue): void
     {
         $strategy = new ExplodeStrategy($delimiter);
 
@@ -42,7 +44,7 @@ class ExplodeStrategyTest extends TestCase
         }
     }
 
-    public function testGetExceptionWithInvalidArgumentOnExtraction()
+    public function testGetExceptionWithInvalidArgumentOnExtraction(): void
     {
         $strategy = new ExplodeStrategy();
 
@@ -51,28 +53,28 @@ class ExplodeStrategyTest extends TestCase
         $strategy->extract('');
     }
 
-    public function testGetEmptyArrayWhenHydratingNullValue()
+    public function testGetEmptyArrayWhenHydratingNullValue(): void
     {
         $strategy = new ExplodeStrategy();
 
         $this->assertSame([], $strategy->hydrate(null));
     }
 
-    public function testGetExceptionWithEmptyDelimiter()
+    public function testGetExceptionWithEmptyDelimiter(): void
     {
         $this->expectException(InvalidArgumentException::class);
 
         new ExplodeStrategy('');
     }
 
-    public function testGetExceptionWithInvalidDelimiter()
+    public function testGetExceptionWithInvalidDelimiter(): void
     {
         $this->expectException(TypeError::class);
 
         new ExplodeStrategy([]);
     }
 
-    public function testHydrateWithExplodeLimit()
+    public function testHydrateWithExplodeLimit(): void
     {
         $strategy = new ExplodeStrategy('-', 2);
         $this->assertSame(['foo', 'bar-baz-bat'], $strategy->hydrate('foo-bar-baz-bat'));
@@ -81,7 +83,7 @@ class ExplodeStrategyTest extends TestCase
         $this->assertSame(['foo', 'bar', 'baz-bat'], $strategy->hydrate('foo-bar-baz-bat'));
     }
 
-    public function testHydrateWithInvalidScalarType()
+    public function testHydrateWithInvalidScalarType(): void
     {
         $strategy = new ExplodeStrategy();
 
@@ -94,7 +96,7 @@ class ExplodeStrategyTest extends TestCase
         $strategy->hydrate([]);
     }
 
-    public function testHydrateWithInvalidObjectType()
+    public function testHydrateWithInvalidObjectType(): void
     {
         $strategy = new ExplodeStrategy();
 
@@ -107,7 +109,7 @@ class ExplodeStrategyTest extends TestCase
         $strategy->hydrate(new \stdClass());
     }
 
-    public function testExtractWithInvalidObjectType()
+    public function testExtractWithInvalidObjectType(): void
     {
         $strategy = new ExplodeStrategy();
 
@@ -126,8 +128,10 @@ class ExplodeStrategyTest extends TestCase
      * @param mixed    $value
      * @param string   $delimiter
      * @param string[] $expected
+     *
+     * @return void
      */
-    public function testHydration($value, $delimiter, array $expected)
+    public function testHydration($value, $delimiter, array $expected): void
     {
         $strategy = new ExplodeStrategy($delimiter);
 

--- a/test/Strategy/HydratorStrategyTest.php
+++ b/test/Strategy/HydratorStrategyTest.php
@@ -157,7 +157,12 @@ class HydratorStrategyTest extends TestCase
     {
         $value = new TestAsset\User();
 
-        $extraction = static function (TestAsset\User $value) {
+        $extraction = /**
+         * @return string[]
+         *
+         * @psalm-return array{value: string}
+         */
+        static function (TestAsset\User $value): array {
             return [
                 'value' => spl_object_hash($value),
             ];

--- a/test/Strategy/SerializableStrategyTest.php
+++ b/test/Strategy/SerializableStrategyTest.php
@@ -23,26 +23,26 @@ use function get_class;
  */
 class SerializableStrategyTest extends TestCase
 {
-    public function testCannotUseBadArgumentSerializer()
+    public function testCannotUseBadArgumentSerializer(): void
     {
         $this->expectException(InvalidArgumentException::class);
         $serializerStrategy = new SerializableStrategy(false);
     }
 
-    public function testUseBadSerializerObject()
+    public function testUseBadSerializerObject(): void
     {
         $serializer = Serializer::factory('phpserialize');
         $serializerStrategy = new SerializableStrategy($serializer);
         $this->assertEquals($serializer, $serializerStrategy->getSerializer());
     }
 
-    public function testUseBadSerializerString()
+    public function testUseBadSerializerString(): void
     {
         $serializerStrategy = new SerializableStrategy('phpserialize');
         $this->assertEquals(PhpSerialize::class, get_class($serializerStrategy->getSerializer()));
     }
 
-    public function testCanSerialize()
+    public function testCanSerialize(): void
     {
         $serializer = Serializer::factory('phpserialize');
         $serializerStrategy = new SerializableStrategy($serializer);
@@ -50,7 +50,7 @@ class SerializableStrategyTest extends TestCase
         $this->assertEquals($serialized, 's:3:"foo";');
     }
 
-    public function testCanUnserialize()
+    public function testCanUnserialize(): void
     {
         $serializer = Serializer::factory('phpserialize');
         $serializerStrategy = new SerializableStrategy($serializer);

--- a/test/Strategy/StrategyChainTest.php
+++ b/test/Strategy/StrategyChainTest.php
@@ -19,14 +19,14 @@ use PHPUnit\Framework\TestCase;
  */
 class StrategyChainTest extends TestCase
 {
-    public function testEmptyStrategyChainReturnsOriginalValue()
+    public function testEmptyStrategyChainReturnsOriginalValue(): void
     {
         $chain = new StrategyChain([]);
         $this->assertEquals('something', $chain->hydrate('something'));
         $this->assertEquals('something', $chain->extract('something'));
     }
 
-    public function testExtract()
+    public function testExtract(): void
     {
         $chain = new StrategyChain([
             new ClosureStrategy(
@@ -71,7 +71,7 @@ class StrategyChainTest extends TestCase
         $this->assertEquals(2, $chain->extract(30));
     }
 
-    public function testHydrate()
+    public function testHydrate(): void
     {
         $chain = new StrategyChain([
             new ClosureStrategy(

--- a/test/TestAsset/AggregateObject.php
+++ b/test/TestAsset/AggregateObject.php
@@ -36,8 +36,10 @@ class AggregateObject
 
     /**
      * @param string $maintainer
+     *
+     * @return void
      */
-    public function setMaintainer($maintainer)
+    public function setMaintainer($maintainer): void
     {
         $this->maintainer = $maintainer;
     }
@@ -52,8 +54,10 @@ class AggregateObject
 
     /**
      * @param array $data
+     *
+     * @return void
      */
-    public function exchangeArray(array $data)
+    public function exchangeArray(array $data): void
     {
         $this->arrayData = $data;
     }

--- a/test/TestAsset/ClassMethodsCamelCase.php
+++ b/test/TestAsset/ClassMethodsCamelCase.php
@@ -29,7 +29,7 @@ class ClassMethodsCamelCase
         return $this->fooBar;
     }
 
-    public function setFooBar($value)
+    public function setFooBar($value): self
     {
         $this->fooBar = $value;
         return $this;
@@ -40,7 +40,7 @@ class ClassMethodsCamelCase
         return $this->fooBarBaz;
     }
 
-    public function setFooBarBaz($value)
+    public function setFooBarBaz($value): self
     {
         $this->fooBarBaz = $value;
         return $this;
@@ -51,7 +51,7 @@ class ClassMethodsCamelCase
         return $this->isFoo;
     }
 
-    public function setIsFoo($value)
+    public function setIsFoo($value): self
     {
         $this->isFoo = $value;
         return $this;
@@ -62,7 +62,7 @@ class ClassMethodsCamelCase
         return $this->isBar;
     }
 
-    public function setIsBar($value)
+    public function setIsBar($value): self
     {
         $this->isBar = $value;
         return $this;
@@ -73,7 +73,7 @@ class ClassMethodsCamelCase
         return $this->hasFoo;
     }
 
-    public function setHasFoo($value)
+    public function setHasFoo($value): self
     {
         $this->hasFoo = $value;
         return $this;
@@ -84,7 +84,7 @@ class ClassMethodsCamelCase
         return $this->hasBar;
     }
 
-    public function setHasBar($value)
+    public function setHasBar($value): self
     {
         $this->hasBar = $value;
         return $this;

--- a/test/TestAsset/ClassMethodsCamelCaseMissing.php
+++ b/test/TestAsset/ClassMethodsCamelCaseMissing.php
@@ -21,7 +21,7 @@ class ClassMethodsCamelCaseMissing
         return $this->fooBar;
     }
 
-    public function setFooBar($value)
+    public function setFooBar($value): self
     {
         $this->fooBar = $value;
         return $this;

--- a/test/TestAsset/ClassMethodsFilterProviderInterface.php
+++ b/test/TestAsset/ClassMethodsFilterProviderInterface.php
@@ -18,32 +18,38 @@ use Laminas\Hydrator\Filter\MethodMatchFilter;
 
 class ClassMethodsFilterProviderInterface implements FilterProviderInterface
 {
-    public function getBar()
+    public function getBar(): string
     {
         return "foo";
     }
 
-    public function getFoo()
+    public function getFoo(): string
     {
         return "bar";
     }
 
-    public function isScalar($foo)
+    /**
+     * @return false
+     */
+    public function isScalar($foo): bool
     {
         return false;
     }
 
-    public function hasFooBar()
+    /**
+     * @return true
+     */
+    public function hasFooBar(): bool
     {
         return true;
     }
 
-    public function getServiceManager()
+    public function getServiceManager(): string
     {
         return "servicemanager";
     }
 
-    public function getEventManager()
+    public function getEventManager(): string
     {
         return "eventmanager";
     }

--- a/test/TestAsset/ClassMethodsInvalidParameter.php
+++ b/test/TestAsset/ClassMethodsInvalidParameter.php
@@ -27,17 +27,23 @@ class ClassMethodsInvalidParameter
         return $bar;
     }
 
-    public function hasBar()
+    /**
+     * @return true
+     */
+    public function hasBar(): bool
     {
         return true;
     }
 
-    public function getFoo()
+    public function getFoo(): string
     {
         return "Bar";
     }
 
-    public function isBla()
+    /**
+     * @return false
+     */
+    public function isBla(): bool
     {
         return false;
     }

--- a/test/TestAsset/ClassMethodsOptionalParameters.php
+++ b/test/TestAsset/ClassMethodsOptionalParameters.php
@@ -33,8 +33,10 @@ class ClassMethodsOptionalParameters
     /**
      * @param string $foo
      * @param mixed  $optional
+     *
+     * @return void
      */
-    public function setFoo($foo, $optional = null)
+    public function setFoo($foo, $optional = null): void
     {
         $this->foo = (string) $foo;
     }

--- a/test/TestAsset/ClassMethodsProtectedSetter.php
+++ b/test/TestAsset/ClassMethodsProtectedSetter.php
@@ -15,12 +15,12 @@ class ClassMethodsProtectedSetter
     protected $foo;
     protected $bar;
 
-    protected function setFoo($foo)
+    protected function setFoo($foo): void
     {
         $this->foo = $foo;
     }
 
-    public function setBar($bar)
+    public function setBar($bar): void
     {
         $this->bar = $bar;
     }

--- a/test/TestAsset/ClassMethodsTitleCase.php
+++ b/test/TestAsset/ClassMethodsTitleCase.php
@@ -29,7 +29,7 @@ class ClassMethodsTitleCase
         return $this->FooBar;
     }
 
-    public function setFooBar($value)
+    public function setFooBar($value): self
     {
         $this->FooBar = $value;
         return $this;
@@ -40,7 +40,7 @@ class ClassMethodsTitleCase
         return $this->FooBarBaz;
     }
 
-    public function setFooBarBaz($value)
+    public function setFooBarBaz($value): self
     {
         $this->FooBarBaz = $value;
         return $this;
@@ -51,7 +51,7 @@ class ClassMethodsTitleCase
         return $this->IsFoo;
     }
 
-    public function setIsFoo($IsFoo)
+    public function setIsFoo($IsFoo): self
     {
         $this->IsFoo = $IsFoo;
         return $this;
@@ -62,7 +62,7 @@ class ClassMethodsTitleCase
         return $this->IsBar;
     }
 
-    public function setIsBar($IsBar)
+    public function setIsBar($IsBar): self
     {
         $this->IsBar = $IsBar;
         return $this;
@@ -78,13 +78,13 @@ class ClassMethodsTitleCase
         return $this->HasBar;
     }
 
-    public function setHasFoo($HasFoo)
+    public function setHasFoo($HasFoo): self
     {
         $this->HasFoo = $HasFoo;
         return $this;
     }
 
-    public function setHasBar($HasBar)
+    public function setHasBar($HasBar): void
     {
         $this->HasBar = $HasBar;
     }

--- a/test/TestAsset/ClassMethodsUnderscore.php
+++ b/test/TestAsset/ClassMethodsUnderscore.php
@@ -29,7 +29,7 @@ class ClassMethodsUnderscore
         return $this->foo_bar;
     }
 
-    public function setFooBar($value)
+    public function setFooBar($value): self
     {
         $this->foo_bar = $value;
         return $this;
@@ -40,7 +40,7 @@ class ClassMethodsUnderscore
         return $this->foo_bar_baz;
     }
 
-    public function setFooBarBaz($value)
+    public function setFooBarBaz($value): self
     {
         $this->foo_bar_baz = $value;
         return $this;
@@ -51,7 +51,7 @@ class ClassMethodsUnderscore
         return $this->is_foo;
     }
 
-    public function setIsFoo($value)
+    public function setIsFoo($value): self
     {
         $this->is_foo = $value;
         return $this;
@@ -62,7 +62,7 @@ class ClassMethodsUnderscore
         return $this->is_bar;
     }
 
-    public function setIsBar($value)
+    public function setIsBar($value): self
     {
         $this->is_bar = $value;
         return $this;
@@ -73,7 +73,7 @@ class ClassMethodsUnderscore
         return $this->has_foo;
     }
 
-    public function setHasFoo($value)
+    public function setHasFoo($value): self
     {
         $this->has_foo = $value;
         return $this;
@@ -84,7 +84,7 @@ class ClassMethodsUnderscore
         return $this->has_bar;
     }
 
-    public function setHasBar($value)
+    public function setHasBar($value): self
     {
         $this->has_bar = $value;
         return $this;

--- a/test/TestAsset/HydratorStrategyEntityA.php
+++ b/test/TestAsset/HydratorStrategyEntityA.php
@@ -21,7 +21,7 @@ class HydratorStrategyEntityA
         $this->entities = [];
     }
 
-    public function addEntity(HydratorStrategyEntityB $entity)
+    public function addEntity(HydratorStrategyEntityB $entity): void
     {
         $this->entities[] = $entity;
     }
@@ -31,19 +31,24 @@ class HydratorStrategyEntityA
         return $this->entities;
     }
 
-    public function setEntities($entities)
+    public function setEntities($entities): void
     {
         $this->entities = $entities;
     }
 
     // Add the getArrayCopy method so we can test the ArraySerializable hydrator:
-    public function getArrayCopy()
+    /**
+     * @return array
+     *
+     * @psalm-return array<string, mixed>
+     */
+    public function getArrayCopy(): array
     {
         return get_object_vars($this);
     }
 
     // Add the populate method so we can test the ArraySerializable hydrator:
-    public function populate($data)
+    public function populate($data): void
     {
         foreach ($data as $name => $value) {
             $this->$name = $value;

--- a/test/TestAsset/HydratorStrategyEntityB.php
+++ b/test/TestAsset/HydratorStrategyEntityB.php
@@ -31,13 +31,13 @@ class HydratorStrategyEntityB
         return $this->field2;
     }
 
-    public function setField1($value)
+    public function setField1($value): self
     {
         $this->field1 = $value;
         return $this;
     }
 
-    public function setField2($value)
+    public function setField2($value): self
     {
         $this->field2 = $value;
         return $this;


### PR DESCRIPTION
This patch attempts to improve the code base further by auto-applying suggestions made by Psalm.
The initial iterations of the patch were created by running `psalm --alter --issues=MissingReturnType,MissingClosureReturnType,InvalidReturnType`.
From there, updated some autogenerated annotations, primarily in unit test data providers, to be more generic.
Finally, ran tests and coding standards, and revised accordingly.
