### PR TITLE
Provide v4 documentation

### DIFF
--- a/docs/book/v4/aggregate.md
+++ b/docs/book/v4/aggregate.md
@@ -1,0 +1,145 @@
+# AggregateHydrator
+
+`Laminas\Hydrator\Aggregate\AggregateHydrator` is an implementation of
+`Laminas\Hydrator\HydratorInterface` that composes multiple hydrators via event listeners.
+
+You typically want to use an aggregate hydrator when you want to hydrate or extract data from
+complex objects that implement multiple interfaces, and therefore need multiple hydrators to handle
+that in subsequent steps.
+
+## Installation requirements
+
+The `AggregateHydrator` depends on the laminas-eventmanager component, so be sure to have it
+installed before getting started:
+
+```bash
+$ composer require laminas/laminas-eventmanager
+```
+
+## Basic usage
+
+A simple use case may be hydrating a `BlogPost` object, which contains data for the user that
+created it, the time it was created, the current publishing status, etc:
+
+```php
+use Laminas\Hydrator\Aggregate\AggregateHydrator;
+
+$hydrator = new AggregateHydrator();
+
+// attach the various hydrators capable of handling simpler interfaces
+$hydrator->add(new My\BlogPostHydrator());
+$hydrator->add(new My\UserAwareObjectHydrator());
+$hydrator->add(new My\TimestampedObjectHydrator());
+$hydrator->add(new My\PublishableObjectHydrator());
+// ...
+
+// Now retrieve the BlogPost object
+// ...
+
+// you can now extract complex data from a blogpost
+$data = $hydrator->extract($blogPost);
+
+// or you can fill the object with complex data
+$blogPost = $hydrator->hydrate($data, $blogPost);
+```
+
+> ### Hydrator priorities
+>
+> `AggregateHydrator::add` has a second optional argument, `$priority`. If you
+> have two or more hydrators that conflict with each other for same data keys,
+> you may decide which one to execute first or last by passing a higher or lower
+> integer priority, respectively, to this argument.
+
+In order to work with this logic, each of the hydrators that are attached should
+ignore any unknown object type passed in:
+
+```php
+namespace My;
+
+use Laminas\Hydrator\HydratorInterface
+
+class BlogPostHydrator implements HydratorInterface
+{
+    public function hydrate($data, $object)
+    {
+        if (! $object instanceof BlogPost) {
+            return $object;
+        }
+
+        // ... continue hydration ...
+    }
+
+    public function extract($object)
+    {
+        if (! $object instanceof BlogPost) {
+            return array();
+        }
+
+        // ... continue extraction ...
+    }
+}
+```
+
+## Advanced use cases
+
+Since the `AggregateHydrator` is event-driven, you can use the `EventManager`
+API to tweak its behaviour.
+
+Common use cases include:
+
+- Removal of hydrated data keys (passwords/confidential information) depending
+  on business rules.
+- Caching of the hydration/extraction process.
+- Transformations on extracted data, for compatibility with third-party APIs.
+
+In the following example, a cache listener is introduced to speed up hydration, which can be
+very useful when the same data is requested multiple times:
+
+```php
+use Laminas\Hydrator\Aggregate\AggregateHydrator;
+use Laminas\Hydrator\Aggregate\ExtractEvent;
+use Laminas\Cache\Storage\Adapter\Memory;
+
+$hydrator = new AggregateHydrator();
+
+// Attach the various hydrators:
+$hydrator->add(new My\BlogPostHydrator());
+$hydrator->add(new My\UserAwareObjectHydrator());
+$hydrator->add(new My\TimestampedObjectHydrator());
+$hydrator->add(new My\PublishableObjectHydrator());
+// ...
+
+$cache             = new Memory();
+$cacheReadListener = function (ExtractEvent $event) use ($cache) {
+    $object = $event->getExtractionObject();
+
+    if (! $object instanceof BlogPost) {
+        return;
+    }
+
+    if ($cache->hasItem($object->getId())) {
+        $event->setExtractedData($cache->getItem($object->getId()));
+        $event->stopPropagation();
+    }
+};
+
+$cacheWriteListener = function (ExtractEvent $event) use ($cache) {
+    $object = $event->getExtractionObject();
+
+    if (! $object instanceof BlogPost) {
+        return;
+    }
+
+    $cache->setItem($object->getId(), $event->getExtractedData());
+};
+
+// Attaching a high priority listener executed before extraction logic:
+$eventManager = $hydrator->getEventManager();
+$eventManager()->attach(ExtractEvent::EVENT_EXTRACT, $cacheReadListener, 1000);
+
+// Attaching a low priority listener executed after extraction logic:
+$eventManager()->attach(ExtractEvent::EVENT_EXTRACT, $cacheWriteListener, -1000);
+```
+
+With an aggregate hydrator configured in this way, any
+`$hydrator->extract($blogPost)` operation will be cached.

--- a/docs/book/v4/filter.md
+++ b/docs/book/v4/filter.md
@@ -1,0 +1,361 @@
+# Laminas\\Hydrator\\Filter
+
+Hydrator filters allow you to manipulate the behavior of the `extract()`
+operation.  This is especially useful, if you want to omit some internals (e.g.
+`getServiceManager()`) from the array representation.
+
+It comes with a helpful `Composite` implementation, and several filters for
+common use cases. The filters are composed in the `AbstractHydrator`, so you can
+start using them immediately in any custom extensions you write that extend that
+class.
+
+```php
+namespace Laminas\Hydrator\Filter;
+
+interface FilterInterface
+{
+    /**
+     * Should return true, if the given filter does not match.
+     */
+    public function filter(string $property, ?object $instance = null) : bool;
+}
+```
+
+If it returns true, the key/value pairs will be in the extracted arrays - if it
+returns false, you'll not see them again.
+
+The `$instance` value will typically be passed by extractors when the `$object` they are extracting is an anonymous object.
+(The `ClassMethodsHydrator` uses this facility, as the Reflection API does not work on anonymous objects.)
+
+## Filter implementations
+
+### Laminas\\Hydrator\\Filter\\GetFilter
+
+This filter is used in the `ClassMethodsHydrator` to decide which getters will
+be extracted. It checks if the key to extract starts with `get` or the object
+contains a method beginning with `get` (e.g., `Laminas\Foo\Bar::getFoo`).
+
+### Laminas\\Hydrator\\Filter\\HasFilter
+
+This filter is used in the `ClassMethodsHydrator` to decide which `has` methods
+will be extracted. It checks if the key to extract begins with `has` or the
+object contains a method beginning with `has` (e.g., `Laminas\Foo\Bar::hasFoo`).
+
+### Laminas\\Hydrator\\Filter\\IsFilter
+
+This filter is used in the `ClassMethodsHydrator` to decide which `is` methods
+will be extracted. It checks if the key to extract begins with `is` or the
+object contains a method beginning with `is` (e.g., `Laminas\Foo\Bar::isFoo`).
+
+### Laminas\\Hydrator\\Filter\\MethodMatchFilter
+
+This filter allows you to omit methods during extraction that match the
+condition defined in the composite.  The name of the method is specified in the
+constructor of this filter; the second parameter decides whether to use white or
+blacklisting to decide (whitelisting retains only the matching method, blacklist
+omits any matching method). The default is blacklisting - pass `false` to change
+the behavior.
+
+### Laminas\\Hydrator\\Filter\\NumberOfParameterFilter
+
+This filter is used in the `ClassMethodsHydrator` to check the number of
+parameters. By convention, the `get`, `has` and `is` methods do not get any
+parameters - but it may happen. You can add your own number of required
+parameters, simply add the number to the constructor. The default value is 0. If
+the method has more or fewer parameters than what the filter accepts, it will be
+omitted.
+
+## Use FilterComposite for complex filters
+
+`FilterComposite` implements `FilterInterface` as well, so you can add it as a
+regular filter to the hydrator. One benefit of this implementation is that you
+can add the filters with a condition and accomplish complex requirements using
+different filters with different conditions. You can pass the following
+conditions to the 3rd parameter, when you add a filter:
+
+### Laminas\\Hydrator\\Filter\\FilterComposite::CONDITION\_OR
+
+At the given level of the composite, at least one filter set using
+`CONDITION_OR` must return true to extract the value.
+
+### Laminas\\Hydrator\\Filter\\FilterComposite::CONDITION\_AND
+
+At the given level of the composite, **all** filters set using `CONDITION_AND`
+must return true to extract the value.
+
+### FilterComposite Examples
+
+To illustrate how conditions apply when composing filters, consider the
+following set of filters:
+
+```php
+$composite = new FilterComposite();
+
+$composite->addFilter('one', $condition1);
+$composite->addFilter('two', $condition2);
+$composite->addFilter('three', $condition3);
+$composite->addFilter('four', $condition4, FilterComposite::CONDITION_AND);
+$composite->addFilter('five', $condition5, FilterComposite::CONDITION_AND);
+```
+
+The above is roughly equivalent to the following conditional:
+
+```php
+// This is what's happening internally
+if (
+     ($condition1
+        || $condition2
+        || $condition3
+     ) && ($condition4
+        && $condition5
+     )
+) {
+    // do extraction
+}
+```
+
+If you only have one condition block (e.g., only `AND` or `OR` filters), the
+other condition type will be completely ignored.
+
+A bit more complex filter can look like this:
+
+```php
+$composite = new FilterComposite();
+$composite->addFilter(
+    'servicemanager',
+    new MethodMatchFilter('getServiceManager'),
+    FilterComposite::CONDITION_AND
+);
+$composite->addFilter(
+    'eventmanager',
+    new MethodMatchFilter('getEventManager'),
+    FilterComposite::CONDITION_AND
+);
+
+$hydrator->addFilter('excludes', $composite, FilterComposite::CONDITION_AND);
+
+// Internal
+if (( // default composite inside the ClassMethodsHydrator:
+        ($getFilter
+            || $hasFilter
+            || $isFilter
+        ) && (
+            $numberOfParameterFilter
+        )
+   ) && ( // new composite, added to the one above
+        $serviceManagerFilter
+        && $eventManagerFilter
+   )
+) {
+    // do extraction
+}
+```
+
+If you perform this on the `ClassMethodsHydrator`, all getters will get
+extracted, except for `getServiceManager()` and `getEventManager()`.
+
+## Using the provider interface
+
+`Laminas\Hydrator\Filter\FilterProviderInterface` allows you to configure the
+behavior of the hydrator inside your objects.
+
+```php
+namespace Laminas\Hydrator\Filter;
+
+interface FilterProviderInterface
+{
+    /**
+     * Provides a filter for hydration
+     *
+     * @return FilterInterface
+     */
+    public function getFilter();
+}
+```
+
+(The `getFilter()` method is automatically excluded from `extract()`.) If the
+extracted object implements the `Laminas\Hydrator\Filter\FilterProviderInterface`,
+the returned `FilterInterface` instance can also be a `FilterComposite`.
+
+For example:
+
+```php
+Class Foo implements FilterProviderInterface
+{
+     public function getFoo()
+     {
+         return 'foo';
+     }
+
+     public function hasFoo()
+     {
+         return true;
+     }
+
+     public function getServiceManager()
+     {
+         return 'servicemanager';
+     }
+
+     public function getEventManager()
+     {
+         return 'eventmanager';
+     }
+
+     public function getFilter()
+     {
+         $composite = new FilterComposite();
+         $composite->addFilter('get', new GetFilter());
+
+         $exclusionComposite = new FilterComposite();
+         $exclusionComposite->addFilter(
+             'servicemanager',
+             new MethodMatchFilter('getServiceManager'),
+             FilterComposite::CONDITION_AND
+             );
+         $exclusionComposite->addFilter(
+             'eventmanager',
+             new MethodMatchFilter('getEventManager'),
+             FilterComposite::CONDITION_AND
+         );
+
+         $composite->addFilter('excludes', $exclusionComposite, FilterComposite::CONDITION_AND);
+
+         return $composite;
+     }
+}
+
+$hydrator = new ClassMethodsHydrator(false);
+$extractedArray = $hydrator->extract(new Foo());
+```
+
+`$extractedArray` will only have 'foo' =&gt; 'foo'; all other values are
+excluded from extraction.
+
+> ### Note
+>
+> All pre-registered filters from the `ClassMethodsHydrator` hydrator are ignored when
+> this interface is used. More on those methods below.
+
+## Filter-enabled hydrators and the composite filter
+
+Hydrators can indicate they are filter-enabled by implementing
+`Laminas\Hydrator\Filter\FilterEnabledInterface`:
+
+```php
+namespace Laminas\Hydrator\Filter;
+
+interface FilterEnabledInterface extends FilterProviderInterface
+{
+    /**
+     * Add a new filter to take care of what needs to be hydrated.
+     * To exclude e.g. the method getServiceLocator:
+     *
+     * <code>
+     * $composite->addFilter(
+     *     "servicelocator",
+     *     function ($property) {
+     *         [$class, $method] = explode('::', $property, 2);
+     *         return $method !== 'getServiceLocator';
+     *     },
+     *     FilterComposite::CONDITION_AND
+     * );
+     * </code>
+     *
+     * @param string $name Index in the composite
+     * @param callable|FilterInterface $filter
+     */
+    public function addFilter(string $name, $filter, int $condition = FilterComposite::CONDITION_OR) : void;
+
+    /**
+     * Check whether a specific filter exists at key $name or not
+     *
+     * @param string $name Index in the composite
+     */
+    public function hasFilter(string $name) : bool;
+
+    /**
+     * Remove a filter from the composition.
+     *
+     * To not extract "has" methods, you simply need to unregister it
+     *
+     * <code>
+     * $filterComposite->removeFilter('has');
+     * </code>
+     */
+    public function removeFilter(string $name) : void;
+}
+```
+
+> Note that the interface extends `FilterProviderInterface`, which means it also
+> includes the `getFilter()` method.
+
+The `FilterEnabledInterface` makes the assumption that the class will be backed
+by a `Laminas\Hydrator\Filter\FilterComposite`; the various `addFilter()`,
+`hasFilter()`, and `removeFilter()` methods are expected to proxy to a
+`FilterComposite` instance.
+
+`AbstractHydrator`, on which all the hydrators shipped in this package are
+built, implements `FilterEnabledInterface`. Of the hydrators shipped, only one,
+`ClassMethodsHydrator`, defines any filters from the outset. Its constructor
+includes the following:
+
+```php
+$this->filterComposite->addFilter('is', new IsFilter());
+$this->filterComposite->addFilter('has', new HasFilter());
+$this->filterComposite->addFilter('get', new GetFilter());
+$this->filterComposite->addFilter(
+    'parameter',
+    new NumberOfParameterFilter(),
+    FilterComposite::CONDITION_AND
+);
+```
+
+### Remove filters
+
+If you want to tell a filter-enabled hydrator such as `ClassMethodsHydrator` not
+to extract methods that start with `is`, remove the related filter:
+
+```php
+$hydrator = new ClassMethodsHydrator(false);
+$hydrator->removeFilter('is');
+```
+
+After performing the above, the key/value pairs for `is` methods will no longer
+end up in your extracted array.
+
+### Add filters
+
+You can add filters using the `addFilter()` method. Filters can either implement
+`FilterInterface`, or simply be PHP callables:
+
+```php
+$hydrator->addFilter('len', function($property) {
+    return strlen($property) === 3;
+});
+```
+
+By default, every filter you add will be added with a conditional `OR`. If you
+want to add it with `AND` (such as the `ClassMethodsHydrator` does with its
+composed `NumberOfParameterFilter`, demonstrated above) provide the conditon as
+the third argument to `addFilter`:
+
+```php
+$hydrator->addFilter('len', function($property) {
+    return strlen($property) === 3;
+}, FilterComposite::CONDITION_AND);
+```
+
+One common use case for filters is to omit getters for values that you do not
+want to represent, such as a service manager instance:
+
+```php
+$hydrator->addFilter(
+    'servicemanager',
+    new MethodMatchFilter('getServiceManager'),
+    FilterComposite::CONDITION_AND
+);
+```
+
+The example above will exclude the `getServiceManager()` method and the
+`servicemanager` key from extraction, even if the `get` filter wants to add it.

--- a/docs/book/v4/migration.md
+++ b/docs/book/v4/migration.md
@@ -1,0 +1,24 @@
+# Migration from version 3
+
+This document details changes made between version 3 and version 4 that could affect end-users.
+
+## Interface changes
+
+The `Laminas\Hydrator\Filter\FilterInterface::filter()` method changed signature to accept an optional second argument:
+
+```php
+namespace Laminas\Hydrator\Filter;
+
+interface FilterInterface
+{
+    public function filter(string $property, ?object $instance = null) : bool;
+}
+```
+
+The primary use case for this is when using anonymous objects, to facilitate reflection; the `ClassMethodsHydrator`, for instance, was updated to pass the `$instance` value only when an anonymous object is detected.
+All filter implementations have been updated to the new signature.
+
+## Filter changes
+
+All filters implementing `Laminas\Hydrator\Filter\FilterInterface` shipped with the package are now marked final.
+If you were previously extending these classes, you will need to copy and paste the implementations; if you feel there is a general-purpose use case for extending the class, please open a feature request to remove the `final` keyword on the specific implementation you are interested in.

--- a/docs/book/v4/migration.md
+++ b/docs/book/v4/migration.md
@@ -1,8 +1,8 @@
-# Migration from version 3
+# Migration from Version 3
 
 This document details changes made between version 3 and version 4 that could affect end-users.
 
-## Interface changes
+## Interface Changes
 
 The `Laminas\Hydrator\Filter\FilterInterface::filter()` method changed signature to accept an optional second argument:
 
@@ -18,7 +18,7 @@ interface FilterInterface
 The primary use case for this is when using anonymous objects, to facilitate reflection; the `ClassMethodsHydrator`, for instance, was updated to pass the `$instance` value only when an anonymous object is detected.
 All filter implementations have been updated to the new signature.
 
-## Filter changes
+## Filter Changes
 
 All filters implementing `Laminas\Hydrator\Filter\FilterInterface` shipped with the package are now marked final.
 If you were previously extending these classes, you will need to copy and paste the implementations; if you feel there is a general-purpose use case for extending the class, please open a feature request to remove the `final` keyword on the specific implementation you are interested in.

--- a/docs/book/v4/naming-strategy/composite-naming-strategy.md
+++ b/docs/book/v4/naming-strategy/composite-naming-strategy.md
@@ -1,0 +1,83 @@
+# CompositeNamingStrategy
+
+`Laminas\Hydrator\NamingStrategy\CompositeNamingStrategy` allows you to specify which naming
+strategy should be used for each key encountered during hydration or extraction.
+
+# Basic Usage
+
+When invoked, the following composite strategy will extract the property `bar`
+to the array key `foo` (using the `MapNamingStrategy`), and the property
+`barBat` to the array key `bar_bat` (using the `UnderscoreNamingStrategy`):
+
+```php
+class Foo
+{
+    public $bar;
+    public $barBat;
+}
+
+$mapStrategy = new Laminas\Hydrator\NamingStrategy\MapNamingStrategy([
+    'foo' => 'bar'
+]);
+
+$underscoreNamingStrategy = new Laminas\Hydrator\NamingStrategy\UnderscoreNamingStrategy();
+
+$namingStrategy = new Laminas\Hydrator\NamingStrategy\CompositeNamingStrategy([
+    'bar' => $mapStrategy,
+    'barBat' => $underscoreNamingStrategy,
+]);
+
+$hydrator = new Laminas\Hydrator\ObjectPropertyHydrator();
+$hydrator->setNamingStrategy($namingStrategy);
+
+$foo = new Foo();
+$foo->bar = 123;
+$foo->barBat = 42;
+
+print_r($foo); // Foo Object ( [bar] => 123 [barBat] => 42 )
+print_r($hydrator->extract($foo)); // Array ( [foo] => 123 [bar_bat] => 42 )
+```
+
+Unfortunately, the `CompositeNamingStrategy` can only be used for extraction as it will not know how
+to handle the keys necessary for hydration (`foo` and `bar_bat`, respectively). To rectify this we
+have to cover the keys for both hydration and extraction in our composite strategy:
+
+```php
+class Foo
+{
+    public $bar;
+    public $barBat;
+}
+
+$mapStrategy = new Laminas\Hydrator\NamingStrategy\MapNamingStrategy([
+    'foo' => 'bar'
+]);
+
+$underscoreNamingStrategy = new Laminas\Hydrator\NamingStrategy\UnderscoreNamingStrategy();
+
+$namingStrategy = new Laminas\Hydrator\NamingStrategy\CompositeNamingStrategy([
+    // Define both directions for the foo => bar mapping
+    'bar' => $mapStrategy,
+    'foo' => $mapStrategy,
+    // Define both directions for the barBat => bar_bat mapping
+    'barBat' => $underscoreNamingStrategy,
+    'bar_bat' => $underscoreNamingStrategy,
+]);
+
+$hydrator = new Laminas\Hydrator\ObjectPropertyHydrator();
+$hydrator->setNamingStrategy($namingStrategy);
+
+$foo = new Foo();
+$foo->bar = 123;
+$foo->barBat = 42;
+
+$array = $hydrator->extract($foo);
+
+print_r($foo); // Foo Object ( [bar] => 123 [barBat] => 42 )
+print_r($array); // Array ( [foo] => 123 [bar_bat] => 42 )
+
+$foo2 = new Foo();
+$hydrator->hydrate($array, $foo2);
+
+print_r($foo2); // Foo Object ( [bar] => 123 [barBat] => 42 )
+```

--- a/docs/book/v4/naming-strategy/identity-naming-strategy.md
+++ b/docs/book/v4/naming-strategy/identity-naming-strategy.md
@@ -1,0 +1,32 @@
+# IdentityNamingStrategy
+
+`Laminas\Hydrator\NamingStrategy\IdentityNamingStrategy` uses the keys provided to
+it for hydration and extraction.
+
+## Basic Usage
+
+```php
+$namingStrategy = new Laminas\Hydrator\NamingStrategy\IdentityNamingStrategy();
+
+echo $namingStrategy->hydrate('foo'); // outputs: foo
+echo $namingStrategy->extract('bar'); // outputs: bar
+```
+
+This strategy can be used in hydrators as well:
+
+```php
+class Foo
+{
+    public $foo;
+}
+
+$namingStrategy = new Laminas\Hydrator\NamingStrategy\IdentityNamingStrategy();
+$hydrator = new Laminas\Hydrator\ObjectPropertyHydrator();
+$hydrator->setNamingStrategy($namingStrategy);
+
+$foo = new Foo();
+$hydrator->hydrate(array('foo' => 123), $foo);
+
+print_r($foo); // Foo Object ( [foo] => 123 )
+print_r($hydrator->extract($foo)); // Array ( [foo] => 123 )
+```

--- a/docs/book/v4/naming-strategy/intro.md
+++ b/docs/book/v4/naming-strategy/intro.md
@@ -1,0 +1,85 @@
+# Naming Strategies
+
+Sometimes, the representation of a property should not share the same name as
+the property itself. As an example, when serializing an object for a JSON
+payload, you may want to convert camelCase properties to underscore_separated
+properties, and vice versa when deserializing JSON to an object.
+
+To make that possible, laminas-hydrator provides _naming strategies_. These are
+similar to [strategies](../strategy.md), but instead of operating on the
+_value_, they operate on the _name_.
+
+## NamingStrategyInterface
+
+Naming strategies implement `Laminas\Hydrator\NamingStrategy\NamingStrategyInterface`:
+
+```php
+namespace Laminas\Hydrator\NamingStrategy;
+
+/**
+ * Allow property extraction / hydration for hydrator
+ */
+interface NamingStrategyInterface
+{
+    /**
+     * Converts the given name so that it can be extracted by the hydrator.
+     *
+     * @param null|mixed[] $data The original data for context.
+     */
+    public function hydrate(string $name, ?array $data = null) : string;
+
+    /**
+     * Converts the given name so that it can be hydrated by the hydrator.
+     *
+     * @param null|object $object The original object for context.
+     */
+    public function extract(string $name, ?object $object = null) : string;
+}
+```
+
+## Providing naming strategies
+
+Hydrators can indicate they will consume naming strategies, as well as allow
+registration of them, by implementing `Laminas\Hydrator\NamingStrategy\NamingStrategyEnabledInterface`:
+
+```php
+namespace Laminas\Hydrator\NamingStrategy;
+
+interface NamingStrategyEnabledInterface
+{
+    /**
+     * Sets the naming strategy.
+     */
+    public function setNamingStrategy(NamingStrategyInterface $strategy) : void;
+
+    /**
+     * Gets the naming strategy.
+     */
+    public function getNamingStrategy() : NamingStrategyInterface;
+
+    /**
+     * Checks if a naming strategy exists.
+     */
+    public function hasNamingStrategy() : bool;
+
+    /**
+     * Removes the naming strategy.
+     */
+    public function removeNamingStrategy() : void;
+}
+```
+
+We provide a default implementation of this interface within the
+`Laminas\Hydrator\AbstractHydrator` definition. Its `getNamingStrategy()` will
+lazy-load an `IdentityNamingStrategy` if none has been previously registered.
+Since all shipped hydrators extend `AbstractHydrator`, they can consume naming
+strategies.
+
+## Shipped naming strategies
+
+We provide the following naming strategies:
+
+- [CompositeNamingStrategy](composite-naming-strategy.md)
+- [IdentityNamingStrategy](identity-naming-strategy.md)
+- [MapNamingStrategy](map-naming-strategy.md)
+- [UnderscoreNamingStrategy](underscore-naming-strategy.md)

--- a/docs/book/v4/naming-strategy/map-naming-strategy.md
+++ b/docs/book/v4/naming-strategy/map-naming-strategy.md
@@ -1,0 +1,101 @@
+# MapNamingStrategy
+
+`Laminas\Hydrator\NamingStrategy\MapNamingStrategy` allows you to provide a map of
+keys to use both during extraction and hydration; the map will translate the key
+based on the direction:
+
+- When a map is provided for hydration, but not extraction, the strategy will
+  perform an `array_flip` on the hydration map when performing lookups.
+  You can create an instance with this behavior using
+  `MapNamingStrategy::createFromHydrationMap(array $hydrationMap) : MapNamingStrategy`.
+
+- When a map is provided for extraction, but not hydration, the strategy will
+  perform an `array_flip` on the extraction map when performing lookups.
+  You can create an instance with this behavior using
+  `MapNamingStrategy::createFromExtractionMap(array $extractionMap) : MapNamingStrategy`.
+
+- When maps are provided for both extraction and hydration, the appropriate map
+  will be used during extraction and hydration operations. You can create an
+  instance with this behavior using
+  `MapNamingStrategy::createFromAsymmetricMap(array $extractionMap, array $hydrationStrategy) : MapNamingStrategy`.
+
+Most of the time, you will want your maps symmetrical; as such, set either a
+hydration map or an extraction map, but not both.
+
+## Creating maps
+
+### Hydration map only
+
+```php
+$namingStrategy = Laminas\Hydrator\NamingStrategy\MapNamingStrategy::createFromHydrationMap(
+    [
+        'foo' => 'bar',
+        'baz' => 'bash'
+    ]
+);
+echo $namingStrategy->extract('bar'); // outputs: foo
+echo $namingStrategy->extract('bash'); // outputs: baz
+
+echo $namingStrategy->hydrate('foo'); // outputs: bar
+echo $namingStrategy->hydrate('baz'); // outputs: bash
+```
+
+### Extraction map only
+
+```php
+$namingStrategy = Laminas\Hydrator\NamingStrategy\MapNamingStrategy::createFromExtractionMap(
+    [
+        'foo' => 'bar',
+        'baz' => 'bash'
+    ]
+);
+echo $namingStrategy->extract('foo'); // outputs: bar
+echo $namingStrategy->extract('baz'); // outputs: bash
+
+echo $namingStrategy->hydrate('bar'); // outputs: foo
+echo $namingStrategy->hydrate('bash'); // outputs: baz
+```
+
+### Both hydration and extraction maps
+
+```php
+$namingStrategy = Laminas\Hydrator\NamingStrategy\MapNamingStrategy::createFromAsymmetricMap(
+    [
+        'foo' => 'bar',
+        'baz' => 'bash'
+    ],
+    [
+        'is_bar'   => 'foo',
+        'bashable' => 'baz',
+    ]
+);
+echo $namingStrategy->extract('foo'); // outputs: bar
+echo $namingStrategy->extract('baz'); // outputs: bash
+
+echo $namingStrategy->hydrate('is_bar'); // outputs: foo
+echo $namingStrategy->hydrate('bashable'); // outputs: baz
+```
+
+## Mapping keys for hydrators
+
+This strategy can be used in hydrators to dictate how keys should be mapped:
+
+```php
+class Foo
+{
+    public $bar;
+}
+
+$namingStrategy = Laminas\Hydrator\NamingStrategy\MapNamingStrategy::createFromHydrationMap([
+    'foo' => 'bar',
+    'baz' => 'bash',
+]);
+$hydrator = new Laminas\Hydrator\ObjectPropertyHydrator();
+$hydrator->setNamingStrategy($namingStrategy);
+
+$foo = new Foo();
+$hydrator->hydrate(['foo' => 123], $foo);
+
+print_r($foo); // Foo Object ( [bar] => 123 )
+print_r($hydrator->extract($foo)); // Array ( "foo" => 123 )
+```

--- a/docs/book/v4/naming-strategy/underscore-naming-strategy.md
+++ b/docs/book/v4/naming-strategy/underscore-naming-strategy.md
@@ -1,0 +1,36 @@
+# UnderscoreNamingStrategy
+
+`Laminas\Hydrator\NamingStrategy\UnderscoreNamingStrategy` converts snake case strings (e.g.
+`foo_bar_baz`) to camel-case strings (e.g. `fooBarBaz`) and vice versa.
+
+## Basic Usage
+
+```php
+$namingStrategy = new Laminas\Hydrator\NamingStrategy\UnderscoreNamingStrategy();
+
+echo $namingStrategy->extract('foo_bar'); // outputs: foo_bar
+echo $namingStrategy->extract('Foo_Bar'); // outputs: foo_bar
+echo $namingStrategy->extract('FooBar'); // outputs: foo_bar
+
+echo $namingStrategy->hydrate('fooBar'); // outputs: fooBar
+echo $namingStrategy->hydrate('FooBar'); // outputs: fooBar
+echo $namingStrategy->hydrate('Foo_Bar'); // outputs: fooBar
+```
+
+This strategy can be used in hydrators to dictate how keys should be mapped.
+
+```php
+class Foo
+{
+    public $fooBar;
+}
+
+$hydrator = new Laminas\Hydrator\ObjectPropertyHydrator();
+$hydrator->setNamingStrategy(new Laminas\Hydrator\NamingStrategy\UnderscoreNamingStrategy());
+
+$foo = new Foo();
+$hydrator->hydrate(['foo_bar' => 123], $foo);
+
+print_r($foo); // Foo Object ( [fooBar] => 123 )
+print_r($hydrator->extract($foo)); // Array ( [foo_bar] => 123 )
+```

--- a/docs/book/v4/plugin-managers.md
+++ b/docs/book/v4/plugin-managers.md
@@ -1,0 +1,211 @@
+# Plugin Managers
+
+It can be useful to compose a plugin manager from which you can retrieve
+hydrators; in fact, `Laminas\Hydrator\DelegatingHydrator` does exactly that!
+With such a manager, you can retrieve instances using short names, or instances
+that have dependencies on other services, without needing to know the details of
+how that works.
+
+Examples of Hydrator plugin managers in real-world scenarios include:
+
+- [hydrating database result sets](https://docs.laminas.dev/laminas-db/result-set/#laminas92db92resultset92hydratingresultset)
+- [preparing API payloads](https://docs.mezzio.dev/mezzio-hal/resource-generator/#resourcegenerator)
+
+## HydratorPluginManagerInterface
+
+We provide two plugin manager implementations. Essentially, they only need to
+implement the [PSR-11 ContainerInterface](https://www.php-fig.org/psr/psr-11/),
+but plugin managers in current versions of [laminas-servicemanager](https://docs.laminas.dev/laminas-servicemanager/)
+only implement it indirectly via the container-interop project.
+
+As such, we ship `Laminas\Hydrator\HydratorPluginManagerInterface`, which simply
+extends the PSR-11 `Psr\Container\ContainerInterface`. Each of our
+implementations implement it.
+
+## HydratorPluginManager
+
+If you have used laminas-hydrator prior to version 3, you are likely already
+familiar with this class, as it has been the implementation we have shipped from
+initial versions. The `HydratorPluginManager` extends the laminas-servicemanager
+`AbstractPluginManager`, and has the following behaviors:
+
+- It will only return `Laminas\Hydrator\HydratorInterface` instances.
+- It defines short-name aliases for all shipped hydrators (the class name minus
+  the namespace), in a variety of casing combinations.
+- All but the `DelegatingHydrator` are defined as invokable services (meaning
+  they can be instantiated without any constructor arguments).
+- The `DelegatingHydrator` is configured as a factory-based service, mapping to
+  the `Laminas\Hydrator\DelegatingHydratorFactory`.
+- No services are shared; a new instance is created each time you call `get()`.
+
+### HydratorPluginManagerFactory
+
+`Laminas\Hydrator\HydratorPluginManager` is mapped to the factory
+`Laminas\Hydrator\HydratorPluginManagerFactory` when wired to the dependency
+injection container.
+
+The factory will look for the `config` service, and use the `hydrators`
+configuration key to seed it with additional services. This configuration key
+should map to an array that follows [standard laminas-servicemanager configuration](https://docs.laminas.dev/laminas-servicemanager/configuring-the-service-manager/).
+
+## StandaloneHydratorPluginManager
+
+`Laminas\Hydrator\StandaloneHydratorPluginManager` provides an implementation that
+has no dependencies on other libraries. **It can only load the hydrators shipped
+with laminas-hydrator**.
+
+### StandardHydratorPluginManagerFactory
+
+`Laminas\Hydrator\StandardHydratorPluginManager` is mapped to the factory
+`Laminas\Hydrator\StandardHydratorPluginManagerFactory` when wired to the dependency
+injection container.
+
+## HydratorManager alias
+
+`Laminas\Hydrator\ConfigManager` defines an alias service, `HydratorManager`. That
+service will point to `Laminas\Hydrator\HydratorPluginManager` if
+laminas-servicemanager is installed, and `Laminas\Hydrator\StandaloneHydratorPluginManager`
+otherwise.
+
+## Custom plugin managers
+
+If you do not want to use laminas-servicemanager, but want a plugin manager that is
+customizable, or at least capable of loading the hydrators you have defined for
+your application, you should write a custom implementation of
+`Laminas\Hydrator\HydratorPluginManagerInterface`, and wire it to the
+`HydratorManager` service, and/or one of the existing service names.
+
+As an example, if you want a configurable solution that uses factories, and want
+those factories capable of pulling application-level dependencies, you might do
+something like the following:
+
+Create a custom plugin manager class, e.g.
+`src/YourApplication/CustomHydratorPluginManager.php`:
+
+```php
+namespace YourApplication;
+
+use Psr\Container\NotFoundExceptionInterface;
+use Psr\Container\ContainerInterface;
+use RuntimeException;
+use Laminas\Hydrator\HydratorInterface;
+use Laminas\Hydrator\HydratorPluginManagerInterface;
+use Laminas\Hydrator\StandaloneHydratorPluginManager;
+
+class CustomHydratorPluginManager implements HydratorPluginManagerInterface
+{
+    /** @var ContainerInterface */
+    private $appContainer;
+
+    /** @var StandaloneHydratorPluginManager */
+    private $defaults;
+
+    /** @var array<string, string|callable> */
+    private $factories = [];
+
+    public function __construct(ContainerInterface $appContainer)
+    {
+        $this->appContainer = $appContainer;
+        $this->defaults = new StandaloneHydratorPluginManager();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function get($id) : HydratorInterface
+    {
+        if (! isset($this->factories[$id]) && ! $this->defaults->has($id)) {
+            $message = sprintf('Hydrator service %s not found', $id);
+            throw new class($message) extends RuntimeException implements NotFoundExceptionInterface {};
+        }
+
+        // Default was requested; fallback to standalone container
+        if (! isset($this->factories[$id])) {
+            return $this->defaults->get($id);
+        }
+
+        $factory = $this->factories[$id];
+        if (is_string($factory)) {
+            $this->factories[$id] = $factory = new $factory();
+        }
+
+        return $factory($this->appContainer, $id);
+    }
+
+    public function has($id) : bool
+    {
+        return isset($this->factories[$id]) || $this->defaults->has($id);
+    }
+
+    public function setFactoryClass(string $name, string $factory) : void
+    {
+        $this->factories[$name] = $factory;
+    }
+
+    public function setFactory(string $name, callable $factory) : void
+    {
+        $this->factories[$name] = $factory;
+    }
+}
+```
+
+Create a factory for the custom plugin manager, e.g.
+`src/YourApplication/CustomHydratorPluginManagerFactory.php`:
+
+```php
+namespace YourApplication;
+
+use Psr\Container\ContainerInterface;
+
+class CustomHydratorPluginManagerFactory
+{
+    public function __invoke(ContainerInterface $container) : CustomHydratorPluginManager
+    {
+        $config = $container->has('config') ? $container->get('config') : [];
+        $config = $config['hydrators']['factories'] ?? [];
+
+        $manager = new CustomHydratorPluginManager($this);
+
+        if ([] !== $config) {
+            $this->configureManager($manager, $config);
+        }
+
+        return $manager;
+    }
+
+    /**
+     * @param array<string, string|callable> $config
+     */
+    private function configureManager(CustomHydratorPluginManager $manager, array $config) : void
+    {
+        foreach ($config as $name => $factory) {
+            is_string($factory)
+                ? $manager->setFactoryClass($name, $factory)
+                : $manager->setFactory($name, $factory);
+        }
+    }
+}
+```
+
+Register the custom plugin manager in the application configuration, e.g.
+`config/autoload/hydrators.global.php`:
+
+```php
+return [
+    'dependencies' => [
+        'aliases' => [
+            'HydratorManager' => \YourApplication\CustomHydratorPluginManager::class,
+        ],
+        'factories' => [
+            \YourApplication\CustomHydratorPluginManager::class => \YourApplication\CustomHydratorPluginManagerFactory::class
+        ],
+    ],
+    'hydrators' => [
+        'factories' => [
+            \Blog\PostHydrator::class => \Blog\PostHydratorFactory::class,
+            \News\ItemHydrator::class => \News\ItemHydratorFactory::class,
+            // etc.
+        ],
+    ],
+];
+```

--- a/docs/book/v4/quick-start.md
+++ b/docs/book/v4/quick-start.md
@@ -1,0 +1,167 @@
+# Quick Start
+
+The laminas-hydrator component provides functionality for hydrating objects (which is the act of populating an object from a set of data) and extracting data from them.
+
+The component contains [concrete implementations](#available_implementations) for a number of common use cases, such as by using arrays, object methods, and reflection, and provides [interfaces](#base_interfaces) for creating custom implementations.
+
+## Basic Usage
+
+### Hydrating an Object
+
+To hydrate an object with data, instantiate the hydrator and then pass to it the data for hydrating the object.
+
+```php
+$hydrator = new Laminas\Hydrator\ArraySerializableHydrator();
+
+$data = [
+    'first_name'    => 'James',
+    'last_name'     => 'Kahn',
+    'email_address' => 'james.kahn@example.org',
+    'phone_number'  => '+61 419 1234 5678',
+];
+
+$object = $hydrator->hydrate($data, new ArrayObject());
+```
+
+### Extracting Values From an Object
+
+To extract data from an object, instantiate the applicable hydrator and then call `extract`, passing to it the object to extract data from.
+
+```php
+$hydrator = new Laminas\Hydrator\ArraySerializableHydrator();
+
+// ... Assuming that $object has already been initialised
+$data = $hydrator->extract($object);
+```
+
+## Available Implementations
+
+### ArraySerializableHydrator
+
+The ArraySerializableHydrator hydrates data from an array and extracts an object’s data returning it as an array.
+Objects passed to the hydrate method must implement either `exchangeArray()` or `populate()` to support hydration, and must implement `getArrayCopy()` to support extraction.
+
+### ClassMethodsHydrator
+
+The ClassMethodsHydrator calls "setter" methods matching keys in the data set to hydrate objects and calls "getter" methods matching keys in the data set during extraction, based on the following rules:
+
+- `is*()`, `has*()`, and `get*()` methods will be used when extracting data.
+  The method prefix will be removed from the key's name.
+- `set*()` methods will be used when hydrating properties.
+
+```php
+class User
+{
+    private $firstName;
+    private $lastName;
+    private $emailAddress;
+    private $phoneNumber;
+
+    public function setFirstName(string $firstName)
+    {
+        $this->firstName = $firstName;
+    }
+
+    public function setLastName(string $lastName)
+    {
+        $this->lastName = $lastName;
+    }
+
+    public function setEmailAddress(string $emailAddress)
+    {
+        $this->emailAddress = $emailAddress;
+    }
+
+    public function setPhoneNumber(string $phoneNumber)
+    {
+        $this->phoneNumber = $phoneNumber;
+    }
+}
+
+$data = [
+    'first_name'    => 'James',
+    'last_name'     => 'Kahn',
+    'email_address' => 'james.kahn@example.org',
+    'phone_number'  => '+61 419 1234 5678',
+];
+
+$hydrator = new Laminas\Hydrator\ClassMethodsHydrator();
+$user     = $hydrator->hydrate($data, new User());
+$data     = $hydrator->extract(new User());
+```
+
+### ObjectPropertyHydrator
+
+The ObjectPropertyHydrator hydrates objects and extracts data using publicly accessible properties which match a key in the data set.
+
+```php
+class User
+{
+    private $firstName;
+    private $lastName;
+    private $emailAddress;
+    private $phoneNumber;
+}
+
+$data = [
+    'first_name'    => 'James',
+    'last_name'     => 'Kahn',
+    'email_address' => 'james.kahn@example.org',
+    'phone_number'  => '+61 419 1234 5678',
+];
+
+$hydrator = new Laminas\Hydrator\ObjectPropertyHydrator();
+$user     = $hydrator->hydrate($data, new User());
+$data     = $hydrator->extract(new User());
+```
+
+### ReflectionHydrator
+
+The ReflectionHydrator is similar to the `ObjectPropertyHydrator`, however it uses [PHP's reflection API](http://php.net/manual/en/intro.reflection.php) to hydrate or extract properties of any visibility.
+Any data key matching an existing property will be hydrated.
+Any existing properties will be used for extracting data.
+
+```php
+class User
+{
+    private $firstName;
+    private $lastName;
+    private $emailAddress;
+    private $phoneNumber;
+}
+
+$data = [
+    'first_name'    => 'James',
+    'last_name'     => 'Kahn',
+    'email_address' => 'james.kahn@example.org',
+    'phone_number'  => '+61 419 1234 5678',
+];
+
+$hydrator = new Laminas\Hydrator\ReflectionHydrator();
+$user     = $hydrator->hydrate($data, new User());
+$data     = $hydrator->extract(new User());
+```
+
+### DelegatingHydrator
+
+The DelegatingHydrator composes a hydrator locator, and will delegate `hydrate()` and `extract()` calls to the appropriate one based upon the class name of the object being operated on.
+
+```php
+// Instantiate each hydrator you wish to delegate to
+$albumHydrator  = new Laminas\Hydrator\ClassMethodsHydrator();
+$artistHydrator = new Laminas\Hydrator\ClassMethodsHydrator();
+
+// Map the entity class name to the hydrator using the HydratorPluginManager.
+// In this case we have two entity classes, "Album" and "Artist".
+$hydrators = new Laminas\Hydrator\HydratorPluginManager;
+$hydrators->setService('Album', $albumHydrator);
+$hydrators->setService('Artist', $artistHydrator);
+
+// Create the DelegatingHydrator and tell it to use our configured hydrator locator
+$delegating = new Laminas\Hydrator\DelegatingHydrator($hydrators);
+
+// Now we can use $delegating to hydrate or extract any supported object
+// Assumes that $data and Artist have already been initialised
+$array  = $delegating->extract(new Artist());
+$artist = $delegating->hydrate($data, new Artist());
+```

--- a/docs/book/v4/strategies/collection.md
+++ b/docs/book/v4/strategies/collection.md
@@ -1,0 +1,245 @@
+# Collection
+
+The `CollectionStrategy` can be used to **hydrate a collection of objects
+with data from an array with multiple items and vice versa**.
+
+The strategy uses a hydrator to hydrate and extract data from each item of a
+collection. 
+
+## Basic usage
+
+The following code example shows standalone usage without adding the strategy
+to a hydrator.
+
+### Create and configure strategy
+
+Create the strategy and set a hydrator and a classname for the handled object
+items.
+
+```php
+$strategy = new Laminas\Hydrator\Strategy\CollectionStrategy(
+    new Laminas\Hydrator\ObjectPropertyHydrator(),
+    stdClass::class
+);
+```
+
+### Hydrate data
+
+```php
+$hydrated = $strategy->hydrate([
+    [
+        'title'    => 'Modern Love',
+        'duration' => '4:46',
+    ],
+    [
+        'title'    => 'China Girl',
+        'duration' => '5:32',
+    ],
+    // …
+]);
+
+echo $hydrated[1]->title; // 'China Girl'
+echo $hydrated[1]->duration; // '5:32'
+```
+
+### Extract data
+
+```php
+// Define array with objects
+$track1           = new stdClass();
+$track1->title    = 'Modern Love';
+$track1->duration = '4:46';
+
+$track2           = new stdClass();
+$track2->title    = 'China Girl';
+$track2->duration = '5:32';
+
+$data = [
+    $track1,
+    $track2,
+];
+
+// Extract
+$extracted = $strategy->extract($data);
+
+var_dump($extracted);
+/*
+array(2) {
+  [0] =>
+  array(2) {
+    'title' =>
+    string(11) "Modern Love"
+    'duration' =>
+    string(4) "4:46"
+  }
+  [1] =>
+  array(2) {
+    'title' =>
+    string(10) "China Girl"
+    'duration' =>
+    string(4) "5:32"
+  }
+}
+*/
+```
+
+## Example
+
+The following example shows the hydration for a class with a property that
+consumes array of classes.
+
+An example class which represents a music album with tracks.
+
+```php
+class Album
+{
+    private ?string $title;
+
+    private ?string $artist;
+
+    private array $tracks;
+
+    public function __construct(
+        ?string $title = null,
+        ?string $artist = null,
+        array $tracks = []
+    ) {
+        $this->title  = $title;
+        $this->artist = $artist;
+        $this->tracks = $tracks;
+    }
+
+    public function getTitle() : ?string
+    {
+        return $this->title;
+    }
+
+    public function getArtist() : ?string
+    {
+        return $this->artist;
+    }
+
+    public function getTracks() : array
+    {
+        return $this->tracks;
+    }
+}
+```
+
+An example class representing a track of an album.
+
+```php
+class Track
+{
+    private ?string $title;
+
+    private ?string $duration;
+
+    public function __construct(
+        ?string $title = null,
+        ?string $duration = null
+    ) {
+        $this->title    = $title;
+        $this->duration = $duration;
+    }
+
+    public function getTitle() : ?string
+    {
+        return $this->title;
+    }
+
+    public function getDuration() : ?string
+    {
+        return $this->duration;
+    }
+}
+```
+
+### Create hydrator and add strategy
+
+Create a hydrator and add `CollectionStrategy` as a strategy, with a hydrator
+and a classname for the handled object items.
+
+```php
+$hydrator = new Laminas\Hydrator\ReflectionHydrator();
+$hydrator->addStrategy(
+    'tracks',
+    new Laminas\Hydrator\Strategy\CollectionStrategy(
+        new Laminas\Hydrator\ReflectionHydrator(),
+        Track::class
+    )
+);
+```
+
+### Hydrate data
+
+Create an instance of the example `Album` class and hydrate data.
+
+```php
+$album = new Album();
+$hydrator->hydrate(
+    [
+        'artist' => 'David Bowie',
+        'title'  => 'Let\'s Dance',
+        'tracks' => [
+            [
+                'title'    => 'Modern Love',
+                'duration' => '4:46',
+            ],
+            [
+                'title'    => 'China Girl',
+                'duration' => '5:32',
+            ],
+            [
+                'title'    => 'Let\'s Dance',
+                'duration' => '7:38',
+            ],
+            // …
+        ],
+    ],
+    $album
+);
+
+echo $album->getTitle(); // "Let's Dance"
+echo $album->getArtist(); // 'David Bowie'
+echo $album->getTracks()[1]->getTitle(); // 'China Girl'
+echo $album->getTracks()[1]->getDuration(); // '5:32'
+```
+
+### Extract data
+
+```php
+var_dump($hydrator->extract($album));
+/*
+array(3) {
+  'title' =>
+  string(11) "Let's Dance"
+  'artist' =>
+  string(11) "David Bowie"
+  'tracks' =>
+  array(3) {
+    [0] =>
+    array(2) {
+      'title' =>
+      string(11) "Modern Love"
+      'duration' =>
+      string(4) "4:46"
+    }
+    [1] =>
+    array(2) {
+      'title' =>
+      string(10) "China Girl"
+      'duration' =>
+      string(4) "5:32"
+    }
+    [2] =>
+    array(2) {
+      'title' =>
+      string(11) "Let's Dance"
+      'duration' =>
+      string(4) "7:38"
+    }
+  }
+} 
+*/
+```

--- a/docs/book/v4/strategies/datetime-immutable-formatter-strategy.md
+++ b/docs/book/v4/strategies/datetime-immutable-formatter-strategy.md
@@ -1,0 +1,100 @@
+# DateTimeImmutableFormatter
+
+> Available since version 3.1.0
+
+`DateTimeImmutableFormatterStrategy` provides **bidirectional conversion between
+strings and `DateTimeImmutable` instances**.
+
+The strategy uses `DateTimeFormatterStrategy` for conversion where the
+[input and output formats](../strategy.md#laminas-hydrator-strategy-datetimeformatterstrategy)
+can be set.
+
+## Basic Usage
+
+The following code example shows standalone usage without adding the strategy
+to a hydrator.
+
+### Create and configure strategy
+
+Create the strategy and set the [input and output formats](../strategy.md#laminas-hydrator-strategy-datetimeformatterstrategy)
+via the `DateTimeFormatterStrategy`.
+
+```php
+$strategy = new Laminas\Hydrator\Strategy\DateTimeImmutableFormatterStrategy(
+    new Laminas\Hydrator\Strategy\DateTimeFormatterStrategy('Y-m-d')
+);
+```
+
+### Hydrate data
+
+```php
+$hydrated = $strategy->hydrate('2020-07-01');
+
+var_dump($hydrated instanceof DateTimeImmutable); // true
+```
+
+### Extract data
+
+```php
+$extracted = $strategy->extract(
+    DateTimeImmutable::createFromFormat('Y-m-d', '2020-07-01')
+);
+
+echo $extracted // '2020-07-01'
+```
+
+## Example
+
+The following example demonstrates hydration for a class with a property.
+
+An example class which represents a music album with a release date:
+
+```php
+class Album
+{
+    private ?DateTimeImmutable $releaseDate;
+
+    public function __construct(?DateTimeImmutable $releaseDate = null)
+    {
+        $this->releaseDate = $releaseDate;
+    }
+
+    public function getReleaseDate() : ?DateTimeImmutable
+    {
+        return $this->releaseDate;
+    }
+}
+```
+
+### Create hydrator and add strategy
+
+Create a hydrator and add `DateTimeImmutableFormatterStrategy` as strategy:
+
+```php
+$hydrator = new Laminas\Hydrator\ReflectionHydrator();
+$hydrator->addStrategy(
+    'releaseDate',
+    new Laminas\Hydrator\Strategy\DateTimeImmutableFormatterStrategy(
+        new Laminas\Hydrator\Strategy\DateTimeFormatterStrategy('Y-m-d')
+    )
+);
+```
+
+### Hydrate data
+
+Create an instance of the example class and hydrate data:
+
+```php
+$album = new Album();
+$hydrator->hydrate(['releaseDate' => '2020-07-01'], $album);
+
+var_dump($album->getReleaseDate() instanceof DateTimeImmutable); // true
+```
+
+### Extract data
+
+```php
+$extracted = $hydrator->extract($album);
+
+echo $extracted; // '2020-07-01'
+```

--- a/docs/book/v4/strategies/hydrator.md
+++ b/docs/book/v4/strategies/hydrator.md
@@ -1,0 +1,178 @@
+# Hydrator
+
+> Available since version 3.1.0
+
+The `HydratorStrategy` can be used to **hydrate an object and its child objects
+with data from a nested array and vice versa**.
+
+## Basic usage
+
+The following code example shows standalone usage without adding the strategy
+to a hydrator.
+
+### Create and configure strategy
+
+Create the strategy and set a hydrator and a classname for the handled object.
+
+```php
+$strategy = new Laminas\Hydrator\Strategy\HydratorStrategy(
+    new Laminas\Hydrator\ObjectPropertyHydrator(),
+    stdClass::class
+);
+```
+
+### Hydrate data
+
+```php
+$hydrated = $strategy->hydrate([
+    'firstName' => 'David',
+    'lastName'  => 'Bowie',
+]);
+
+echo $hydrated->firstName; // 'David'
+echo $hydrated->lastName; // 'Bowie'
+```
+
+### Extract data
+
+```php
+$class            = new stdClass();
+$class->firstName = 'David';
+$class->lastName  = 'Bowie';
+
+$extracted = $strategy->extract($class);
+
+var_dump($extracted); // ['firstName' => 'David', 'lastName' => 'Bowie']
+```
+
+## Example
+
+The following example shows the hydration for a class with a property that
+consumes another class.
+
+An example class which represents a music album.
+
+```php
+class Album
+{
+    private ?int $id = null;
+
+    private ?string $title = null;
+
+    private ?Artist $artist = null;
+
+    public function __construct(
+        ?int $id = null,
+        ?string $title = null,
+        ?Artist $artist = null
+    ) {
+        $this->id     = $id;
+        $this->title  = $title;
+        $this->artist = $artist;
+    }
+
+    public function getId() : ?int
+    {
+        return $this->id;
+    }
+
+    public function getTitle() : ?string
+    {
+        return $this->title;
+    }
+
+    public function getArtist() : ?Artist
+    {
+        return $this->artist;
+    }
+}
+```
+
+An example class representing the artist of an album.
+
+```php
+class Artist
+{
+    private ?string $firstName;
+
+    private ?string $lastName;
+
+    public function __construct(
+        ?string $firstName = null,
+        ?string $lastName = null
+    ) {
+        $this->firstName = $firstName;
+        $this->lastName  = $lastName;
+    }
+
+    public function getFirstName() : ?string
+    {
+        return $this->firstName;
+    }
+
+    public function getLastName() : ?string
+    {
+        return $this->lastName;
+    }
+}
+```
+
+### Create hydrator and add strategy
+
+Create a hydrator and add `HydratorStrategy` as a strategy, with a hydrator and a
+classname for the handled object.
+
+```php
+$hydrator = new Laminas\Hydrator\ReflectionHydrator();
+$hydrator->addStrategy(
+    'artist',
+    new Laminas\Hydrator\Strategy\HydratorStrategy(
+        new Laminas\Hydrator\ReflectionHydrator(),
+        Artist::class
+    )
+);
+```
+
+### Hydrate data
+
+Create an instance of the example `Album` class and hydrate data.
+
+```php
+$album = new Album();
+$hydrator->hydrate(
+    [
+        'id'     => 100,
+        'title'  => 'The Next Day (Deluxe Version)',
+        'artist' => [
+            'firstName' => 'David',
+            'lastName'  => 'Bowie',
+        ],
+    ],
+    $album
+);
+
+echo $album->getTitle(); // 'The Next Day (Deluxe Version)'
+echo $album->getArtist()->getFirstName(); // 'David'
+echo $album->getArtist()->getLastName(); // 'Bowie'
+```
+
+### Extract data
+
+```php
+var_dump($hydrator->extract($album));
+/*
+array(3) {
+  'id' =>
+  int(100)
+  'title' =>
+  string(29) "The Next Day (Deluxe Version)"
+  'artist' =>
+  array(2) {
+    'firstName' =>
+    string(5) "David"
+    'lastName' =>
+    string(5) "Bowie"
+  }
+}
+*/
+```

--- a/docs/book/v4/strategies/serializable.md
+++ b/docs/book/v4/strategies/serializable.md
@@ -1,0 +1,149 @@
+# Serializable
+
+The `SerializableStrategy` can be used for **serializing and deserializing PHP
+types to and from different representations**.
+
+The strategy uses [laminas-serializer](https://docs.laminas.dev/laminas-serializer/)
+for serializing and deserializing of data.
+
+## Basic usage
+
+The following code example shows standalone usage without adding the strategy
+to a hydrator.
+
+### Create and configure strategy
+
+Create the strategy and set a serializer adapter.
+
+```php
+$strategy = new Laminas\Hydrator\Strategy\SerializableStrategy(
+    new Laminas\Serializer\Adapter\Json()
+);
+```
+
+For available serializer adapters see the [documentation of laminas-serializer](https://docs.laminas.dev/laminas-serializer/adapter/).
+
+### Hydrate data
+
+```php
+$json = '[{"title":"Modern Love","duration":"4:46"},{"title":"China Girl","duration":"5:32"}]';
+$hydrated = $strategy->hydrate($json);
+
+echo $hydrated[1]['title']; // 'China Girl'
+echo $hydrated[1]['duration']; // '5:32'
+```
+
+### Extract data
+
+```php
+$data = [
+    [
+        'title'    => 'Modern Love',
+        'duration' => '4:46',
+    ],
+    [
+        'title'    => 'China Girl',
+        'duration' => '5:32',
+    ],
+    // …
+];
+
+$extracted = $strategy->extract($data);
+
+echo $extracted; // '[{"title":"Modern Love","duration":"4:46"},{"title":"China Girl","duration":"5:32"}]'
+```
+
+## Example
+
+The following example shows the hydration for a class with a property where the
+data is provided by a JSON string.
+
+An example class which represents a music album with tracks.
+
+```php
+class Album
+{
+    private ?string $title;
+
+    private ?string $artist;
+
+    private array $tracks;
+
+    public function __construct(
+        ?string $title = null,
+        ?string $artist = null,
+        array $tracks = []
+    ) {
+        $this->title  = $title;
+        $this->artist = $artist;
+        $this->tracks = $tracks;
+    }
+
+    public function getTitle() : ?string
+    {
+        return $this->title;
+    }
+
+    public function getArtist() : ?string
+    {
+        return $this->artist;
+    }
+
+    public function getTracks() : array
+    {
+        return $this->tracks;
+    }
+}
+```
+
+### Create hydrator and add strategy
+
+Create a hydrator and add `SerializableStrategy` as a strategy, with a
+serializer adapter which converts the JSON string to `array` and vice versa.
+
+```php
+$hydrator = new Laminas\Hydrator\ReflectionHydrator();
+$hydrator->addStrategy(
+    'tracks',
+    new Laminas\Hydrator\Strategy\SerializableStrategy(
+        new Laminas\Serializer\Adapter\Json()
+    )
+);
+```
+
+### Hydrate data
+
+Create an instance of the example `Album` class and hydrate data.
+
+```php
+$album = new Album();
+$hydrator->hydrate(
+    [
+        'artist' => 'David Bowie',
+        'title'  => 'Let\'s Dance',
+        'tracks' => '[{"title":"Modern Love","duration":"4:46"},{"title":"China Girl","duration":"5:32"}]',
+    ],
+    $album
+);
+
+echo $album->getTitle(); // "Let's Dance"
+echo $album->getArtist(); // 'David Bowie'
+echo $album->getTracks()[1]['title']; // 'China Girl'
+echo $album->getTracks()[1]['duration']; // '5:32'
+```
+
+### Extract data
+
+```php
+var_dump($hydrator->extract($album));
+/*
+array(3) {
+  'title' =>
+  string(11) "Let's Dance"
+  'artist' =>
+  string(11) "David Bowie"
+  'tracks' =>
+  string(84) "[{"title":"Modern Love","duration":"4:46"},{"title":"China Girl","duration":"5:32"}]"
+}
+*/
+```

--- a/docs/book/v4/strategy.md
+++ b/docs/book/v4/strategy.md
@@ -1,0 +1,232 @@
+# Introduction
+
+You can compose `Laminas\Hydrator\Strategy\StrategyInterface` instances in any of
+the hydrators to manipulate the way they behave on `extract()` and `hydrate()`
+for specific key/value pairs. The interface offers the following definitions:
+
+```php
+namespace Laminas\Hydrator\Strategy;
+
+interface StrategyInterface
+{
+    /**
+     * Converts the given value so that it can be extracted by the hydrator.
+     *
+     * @param  mixed       $value The original value.
+     * @param  null|object $object (optional) The original object for context.
+     * @return mixed       Returns the value that should be extracted.
+     */
+    public function extract($value, ?object $object = null);
+
+    /**
+     * Converts the given value so that it can be hydrated by the hydrator.
+     *
+     * @param  mixed      $value The original value.
+     * @param  null|array $data (optional) The original data for context.
+     * @return mixed      Returns the value that should be hydrated.
+     */
+    public function hydrate($value, ?array $data = null);
+}
+```
+
+This interface is similar to what the `Laminas\Hydrator\ExtractionInterface` and
+`Laminas\Hydrator\HydrationInterface` provide; the reason is that strategies
+provide a proxy implementation for `hydrate()` and `extract()` on individual
+values. For this reason, their return types are listed as mixed, versus as
+`array` and `object`, respectively.
+
+## Adding strategies to the hydrators
+
+This package provides the interface `Laminas\Hydrator\Strategy\StrategyEnabledInterface`.
+Hydrators can implement this interface, and then call on its `getStrategy()`
+method in order to extract or hydrate individual values. The interface has the
+following definition:
+
+```php
+namespace Laminas\Hydrator\Strategy;
+
+interface StrategyEnabledInterface
+{
+    /**
+     * Adds the given strategy under the given name.
+     */
+    public function addStrategy(string $name, StrategyInterface $strategy) : void;
+
+    /**
+     * Gets the strategy with the given name.
+     */
+    public function getStrategy(string $name) : StrategyInterface;
+
+    /**
+     * Checks if the strategy with the given name exists.
+     */
+    public function hasStrategy(string $name) : bool;
+
+    /**
+     * Removes the strategy with the given name.
+     */
+    public function removeStrategy(string $name) : void;
+}
+```
+
+We provide a default implementation of the interface as part of
+`Laminas\Hydrator\AbstractHydrator`; it uses an array property to store and
+retrieve strategies by name when extracting and hydrating values. Since all
+shipped hydrators are based on `AbstractHydrator`, they share these
+capabilities.
+
+Additionally, the functionality that consumes strategies within
+`AbstractHydrator` also contains checks if a naming strategy is composed, and,
+if present, will use it to translate the property name prior to looking up a
+  strategy for it.
+
+## Available implementations
+
+### Laminas\\Hydrator\\Strategy\\BooleanStrategy
+
+This strategy converts values into Booleans and vice versa. It expects two
+arguments at the constructor, which are used to define value maps for `true` and
+`false`.
+
+### Laminas\\Hydrator\\Strategy\\ClosureStrategy
+
+This is a strategy that allows you to pass in options for:
+
+- `hydrate`, a callback to be called when hydrating a value, and
+- `extract`, a callback to be called when extracting a value.
+
+### Laminas\\Hydrator\\Strategy\\DateTimeFormatterStrategy
+
+`DateTimeFormatterStrategy` provides bidirectional conversion between strings
+and DateTime instances. The input and output formats can be provided as
+constructor arguments.
+
+The strategy allows `DateTime` formats that use `!` to prepend the format, or
+`|` or `+` to append it; these ensure that, during hydration, the new `DateTime`
+instance created will set the time element accordingly. As a specific example,
+`Y-m-d|` will drop the time component, ensuring comparisons are based on a
+midnight time value.
+
+Starting in version 3.0, the constructor defines a third, optional argument,
+`$dateTimeFallback`.  If enabled and hydration fails, the given string is parsed
+by the `DateTime` constructor, as demonstrated below:
+
+```php
+// Previous behavior:
+$strategy = new Laminas\Hydrator\Strategy\DateTimeFormatterStrategy('Y-m-d H:i:s.uP');
+$hydrated1 = $strategy->hydrate('2016-03-04 10:29:40.123456+01'); // Format is the same; returns DateTime instance
+$hydrated2 = $strategy->hydrate('2016-03-04 10:29:40+01');        // Format is different; value is not hydrated
+
+// Using new $dateTimeFallback flag; both values are hydrated:
+$strategy = new Laminas\Hydrator\Strategy\DateTimeFormatterStrategy('Y-m-d H:i:s.uP', null, true);
+$hydrated1 = $strategy->hydrate('2016-03-04 10:29:40.123456+01');
+$hydrated2 = $strategy->hydrate('2016-03-04 10:29:40+01');
+```
+
+### Laminas\\Hydrator\\Strategy\\DefaultStrategy
+
+The `DefaultStrategy` simply proxies everything through, without performing any
+conversion of values.
+
+### Laminas\\Hydrator\\Strategy\\ExplodeStrategy
+
+This strategy is a wrapper around PHP's `implode()` and `explode()` functions.
+The delimiter and a limit can be provided to the constructor; the limit will
+only be used for `extract` operations.
+
+### Laminas\\Hydrator\\Strategy\\StrategyChain
+
+This strategy takes an array of `StrategyInterface` instances and iterates
+over them when performing `extract()` and `hydrate()` operations. Each operates
+on the return value of the previous, allowing complex operations based on
+smaller, single-purpose strategies.
+
+## Writing custom strategies
+
+The following example, while not terribly useful, will provide you with the
+basics for writing your own strategies, as well as provide ideas as to where and
+when to use them. This strategy simply transforms the value for the defined key
+using `str_rot13()` during both the `extract()` and `hydrate()` operations:
+
+```php
+class Rot13Strategy implements StrategyInterface
+{
+    public function extract($value)
+    {
+        return str_rot13($value);
+    }
+
+    public function hydrate($value)
+    {
+        return str_rot13($value);
+    }
+}
+```
+
+This is the example class with which we want to use the hydrator example:
+
+```php
+class Foo
+{
+    protected $foo = null;
+    protected $bar = null;
+
+    public function getFoo()
+    {
+        return $this->foo;
+    }
+
+    public function setFoo($foo)
+    {
+        $this->foo = $foo;
+    }
+
+    public function getBar()
+    {
+        return $this->bar;
+    }
+
+    public function setBar($bar)
+    {
+        $this->bar = $bar;
+    }
+}
+```
+
+Now, we'll add the `rot13` strategy to the method `getFoo()` and `setFoo($foo)`:
+
+```php
+$foo = new Foo();
+$foo->setFoo('bar');
+$foo->setBar('foo');
+
+$hydrator = new ClassMethodsHydrator();
+$hydrator->addStrategy('foo', new Rot13Strategy());
+```
+
+When you use the hydrator to extract an array for the object `$foo`, you'll
+receive the following:
+
+```php
+$extractedArray = $hydrator->extract($foo);
+
+// array(2) {
+//     ["foo"]=>
+//     string(3) "one"
+//     ["bar"]=>
+//     string(3) "foo"
+// }
+```
+
+And when hydrating a new `Foo` instance:
+
+```php
+$hydrator->hydrate($extractedArray, $foo)
+
+// object(Foo)#2 (2) {
+//   ["foo":protected]=>
+//   string(3) "bar"
+//   ["bar":protected]=>
+//   string(3) "foo"
+// }
+```

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -2,12 +2,31 @@ docs_dir: docs/book
 site_dir: docs/html
 extra:
   project: Components
-  current_version: v3
+  current_version: v4
   versions:
+    - v4
     - v3
     - v2
 nav:
     - Home: index.md
+    - v4:
+      - "Quick Start": v4/quick-start.md
+      - "Filters": v4/filter.md
+      - "Strategies":
+        - Introduction: v4/strategy.md
+        - Collection: v4/strategies/collection.md
+        - DateTimeImmutableFormatter: v4/strategies/datetime-immutable-formatter-strategy.md
+        - Hydrator: v4/strategies/hydrator.md
+        - Serializable: v4/strategies/serializable.md
+      - "Aggregates": v4/aggregate.md
+      - "Naming Strategies":
+        - "Introduction": v4/naming-strategy/intro.md
+        - "Identity": v4/naming-strategy/identity-naming-strategy.md
+        - "Mapping": v4/naming-strategy/map-naming-strategy.md
+        - "Underscore Mapping": v4/naming-strategy/underscore-naming-strategy.md
+        - "Composite": v4/naming-strategy/composite-naming-strategy.md
+      - "Plugin Managers": v4/plugin-managers.md
+      - Migration: v4/migration.md
     - v3:
       - "Quick Start": v3/quick-start.md
       - "Filters": v3/filter.md


### PR DESCRIPTION
This patch provides:

- v4 documentation, including:
- a v3 -> v4 migration guide, and
- updates to the "filter" chapter to reflect changes in v4.

Fixes #38
