### PR TITLE
Fix property visibility in `ObjectPropertyHydrator` example (requires `public` properties)

### DIFF
--- a/docs/book/v4/quick-start.md
+++ b/docs/book/v4/quick-start.md
@@ -97,10 +97,10 @@ The ObjectPropertyHydrator hydrates objects and extracts data using publicly acc
 ```php
 class User
 {
-    private $firstName;
-    private $lastName;
-    private $emailAddress;
-    private $phoneNumber;
+    public $firstName;
+    public $lastName;
+    public $emailAddress;
+    public $phoneNumber;
 }
 
 $data = [


### PR DESCRIPTION
ObjectPropertyHydrator example should probably consist of publicly accessible properties, as opposed to ReflectionHydrator.