### PR TITLE
fix never-met condition

### DIFF
--- a/src/ClassMethodsHydrator.php
+++ b/src/ClassMethodsHydrator.php
@@ -175,7 +175,7 @@ class ClassMethodsHydrator extends AbstractHydrator implements HydratorOptionsIn
 
         $values = [];
 
-        if (null === $this->extractionMethodsCache[$objectClass]) {
+        if (empty($this->extractionMethodsCache[$objectClass])) {
             return $values;
         }
 


### PR DESCRIPTION
Since https://github.com/laminas/laminas-hydrator/blob/4.2.x/src/ClassMethodsHydrator.php#L155,
`$this->extractionMethodsCache[$objectClass]` is at least an empty array.

there is a unrelated travis build error for php-7.4 (same as previous merged PR https://github.com/laminas/laminas-hydrator/pull/45) (edit)...mmmh...at least it happened in my travis account...