### PR TITLE
Fix class method hydrator redundant filter

### DIFF
--- a/src/ClassMethodsHydrator.php
+++ b/src/ClassMethodsHydrator.php
@@ -52,7 +52,7 @@ class ClassMethodsHydrator extends AbstractHydrator implements HydratorOptionsIn
     private $extractionMethodsCache = [];
 
     /** @var Filter\FilterInterface */
-    private $callableMethodFilter;
+    private $optionalParameterFilter;
 
     /**
      * Define if extract values will use camel case or name with underscore
@@ -62,7 +62,7 @@ class ClassMethodsHydrator extends AbstractHydrator implements HydratorOptionsIn
         $this->setUnderscoreSeparatedKeys($underscoreSeparatedKeys);
         $this->setMethodExistsCheck($methodExistsCheck);
 
-        $this->callableMethodFilter = new Filter\OptionalParametersFilter();
+        $this->optionalParameterFilter = new Filter\OptionalParametersFilter();
 
         $compositeFilter = $this->getCompositeFilter();
         $compositeFilter->addFilter('is', new Filter\IsFilter());
@@ -153,7 +153,7 @@ class ClassMethodsHydrator extends AbstractHydrator implements HydratorOptionsIn
 
                 if (
                     ! $filter->filter($methodFqn, $isAnonymous ? $object : null)
-                    || ! $this->callableMethodFilter->filter($methodFqn, $isAnonymous ? $object : null)
+                    || ! $this->optionalParameterFilter->filter($methodFqn, $isAnonymous ? $object : null)
                 ) {
                     continue;
                 }

--- a/src/ClassMethodsHydrator.php
+++ b/src/ClassMethodsHydrator.php
@@ -68,11 +68,6 @@ class ClassMethodsHydrator extends AbstractHydrator implements HydratorOptionsIn
         $compositeFilter->addFilter('is', new Filter\IsFilter());
         $compositeFilter->addFilter('has', new Filter\HasFilter());
         $compositeFilter->addFilter('get', new Filter\GetFilter());
-        $compositeFilter->addFilter(
-            'parameter',
-            new Filter\OptionalParametersFilter(),
-            Filter\FilterComposite::CONDITION_AND
-        );
     }
 
     /**

--- a/src/ClassMethodsHydrator.php
+++ b/src/ClassMethodsHydrator.php
@@ -52,7 +52,7 @@ class ClassMethodsHydrator extends AbstractHydrator implements HydratorOptionsIn
     private $extractionMethodsCache = [];
 
     /** @var Filter\FilterInterface */
-    private $optionalParameterFilter;
+    private $optionalParametersFilter;
 
     /**
      * Define if extract values will use camel case or name with underscore
@@ -62,7 +62,7 @@ class ClassMethodsHydrator extends AbstractHydrator implements HydratorOptionsIn
         $this->setUnderscoreSeparatedKeys($underscoreSeparatedKeys);
         $this->setMethodExistsCheck($methodExistsCheck);
 
-        $this->optionalParameterFilter = new Filter\OptionalParametersFilter();
+        $this->optionalParametersFilter = new Filter\OptionalParametersFilter();
 
         $compositeFilter = $this->getCompositeFilter();
         $compositeFilter->addFilter('is', new Filter\IsFilter());
@@ -153,7 +153,7 @@ class ClassMethodsHydrator extends AbstractHydrator implements HydratorOptionsIn
 
                 if (
                     ! $filter->filter($methodFqn, $isAnonymous ? $object : null)
-                    || ! $this->optionalParameterFilter->filter($methodFqn, $isAnonymous ? $object : null)
+                    || ! $this->optionalParametersFilter->filter($methodFqn, $isAnonymous ? $object : null)
                 ) {
                     continue;
                 }


### PR DESCRIPTION
Remove the OptionalParameterFilter from the internal CompositeFilter to avoid duplicate check at lines 166-167:

https://github.com/laminas/laminas-hydrator/blob/cd865fcc01fb5eef62018294456161dc4eb22538/src/ClassMethodsHydrator.php#L167

rename internal 'callableMethodFilter' property to 'optionalParameterFilter' for clarity

see #51 

PS
In my travis account I encountered an unrelated psalm error for PHP-7.4 DEPS=latest

