### PR TITLE
3.2.x - remove class-methods-hydrator redundant filter

### DIFF
--- a/src/ClassMethodsHydrator.php
+++ b/src/ClassMethodsHydrator.php
@@ -75,11 +75,6 @@ class ClassMethodsHydrator extends AbstractHydrator implements HydratorOptionsIn
         $compositeFilter->addFilter('is', new Filter\IsFilter());
         $compositeFilter->addFilter('has', new Filter\HasFilter());
         $compositeFilter->addFilter('get', new Filter\GetFilter());
-        $compositeFilter->addFilter(
-            'parameter',
-            new Filter\OptionalParametersFilter(),
-            Filter\FilterComposite::CONDITION_AND
-        );
     }
 
     /**

--- a/src/ClassMethodsHydrator.php
+++ b/src/ClassMethodsHydrator.php
@@ -59,7 +59,7 @@ class ClassMethodsHydrator extends AbstractHydrator implements HydratorOptionsIn
     /**
      * @var Filter\FilterInterface
      */
-    private $optionalParameterFilter;
+    private $optionalParametersFilter;
 
     /**
      * Define if extract values will use camel case or name with underscore
@@ -69,7 +69,7 @@ class ClassMethodsHydrator extends AbstractHydrator implements HydratorOptionsIn
         $this->setUnderscoreSeparatedKeys($underscoreSeparatedKeys);
         $this->setMethodExistsCheck($methodExistsCheck);
 
-        $this->optionalParameterFilter = new Filter\OptionalParametersFilter();
+        $this->optionalParametersFilter = new Filter\OptionalParametersFilter();
 
         $compositeFilter = $this->getCompositeFilter();
         $compositeFilter->addFilter('is', new Filter\IsFilter());
@@ -151,7 +151,7 @@ class ClassMethodsHydrator extends AbstractHydrator implements HydratorOptionsIn
             foreach ($methods as $method) {
                 $methodFqn = $objectClass . '::' . $method;
 
-                if (! ($filter->filter($methodFqn) && $this->optionalParameterFilter->filter($methodFqn))) {
+                if (! ($filter->filter($methodFqn) && $this->optionalParametersFilter->filter($methodFqn))) {
                     continue;
                 }
 

--- a/src/ClassMethodsHydrator.php
+++ b/src/ClassMethodsHydrator.php
@@ -59,7 +59,7 @@ class ClassMethodsHydrator extends AbstractHydrator implements HydratorOptionsIn
     /**
      * @var Filter\FilterInterface
      */
-    private $callableMethodFilter;
+    private $optionalParameterFilter;
 
     /**
      * Define if extract values will use camel case or name with underscore
@@ -69,7 +69,7 @@ class ClassMethodsHydrator extends AbstractHydrator implements HydratorOptionsIn
         $this->setUnderscoreSeparatedKeys($underscoreSeparatedKeys);
         $this->setMethodExistsCheck($methodExistsCheck);
 
-        $this->callableMethodFilter = new Filter\OptionalParametersFilter();
+        $this->optionalParameterFilter = new Filter\OptionalParametersFilter();
 
         $compositeFilter = $this->getCompositeFilter();
         $compositeFilter->addFilter('is', new Filter\IsFilter());
@@ -151,7 +151,7 @@ class ClassMethodsHydrator extends AbstractHydrator implements HydratorOptionsIn
             foreach ($methods as $method) {
                 $methodFqn = $objectClass . '::' . $method;
 
-                if (! ($filter->filter($methodFqn) && $this->callableMethodFilter->filter($methodFqn))) {
+                if (! ($filter->filter($methodFqn) && $this->optionalParameterFilter->filter($methodFqn))) {
                     continue;
                 }
 


### PR DESCRIPTION
same fix as in https://github.com/laminas/laminas-hydrator/pull/52, backported for 3.2.x