### PR TITLE
Correct CompositeNamingStrategy example in docs

### DIFF
--- a/docs/book/v4/naming-strategy/composite-naming-strategy.md
+++ b/docs/book/v4/naming-strategy/composite-naming-strategy.md
@@ -16,7 +16,7 @@ class Foo
     public $barBat;
 }
 
-$mapStrategy = new Laminas\Hydrator\NamingStrategy\MapNamingStrategy([
+$mapStrategy = Laminas\Hydrator\NamingStrategy\MapNamingStrategy::createFromHydrationMap([
     'foo' => 'bar'
 ]);
 


### PR DESCRIPTION
The second example usage of CompositeNamingStrategy involves creating an instance of MapNamingStrategy using the new operator. This would cause a fatal error as the constructor is private.

Signed-off-by: Paul <paul@itsociaal.nl>

|    Q          |   A
|-------------- | ------
| Documentation | yes
| Bugfix        | no
| BC Break      | no
| New Feature   | no
| RFC           | no
| QA            | no

### Description
This pull request fixes a slight error in one of the examples of the documentation. I've tested both the original example as well as my modified example, and the modified example appears to work as intended.