### PR TITLE
Merge release 4.0.3 into 4.1.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,28 @@
 
 All notable changes to this project will be documented in this file, in reverse chronological order by release.
 
+## 4.0.3 - TBD
+
+### Added
+
+- Nothing.
+
+### Changed
+
+- Nothing.
+
+### Deprecated
+
+- Nothing.
+
+### Removed
+
+- Nothing.
+
+### Fixed
+
+- Nothing.
+
 ## 4.0.2 - 2020-12-16
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,28 @@
 
 All notable changes to this project will be documented in this file, in reverse chronological order by release.
 
+## 4.0.4 - TBD
+
+### Added
+
+- Nothing.
+
+### Changed
+
+- Nothing.
+
+### Deprecated
+
+- Nothing.
+
+### Removed
+
+- Nothing.
+
+### Fixed
+
+- Nothing.
+
 ## 4.0.3 - 2021-06-28
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,28 @@
 
 All notable changes to this project will be documented in this file, in reverse chronological order by release.
 
+## 3.2.1 - TBD
+
+### Added
+
+- Nothing.
+
+### Changed
+
+- Nothing.
+
+### Deprecated
+
+- Nothing.
+
+### Removed
+
+- Nothing.
+
+### Fixed
+
+- Nothing.
+
 ## 3.2.0 - 2020-10-06
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,27 +2,26 @@
 
 All notable changes to this project will be documented in this file, in reverse chronological order by release.
 
-## 4.0.3 - TBD
+## 4.0.3 - 2021-06-28
 
-### Added
 
-- Nothing.
+-----
 
-### Changed
-
-- Nothing.
-
-### Deprecated
-
-- Nothing.
-
-### Removed
-
-- Nothing.
+### Release Notes for [4.0.3](https://github.com/laminas/laminas-hydrator/milestone/13)
 
 ### Fixed
 
-- Nothing.
+- Forward ports a patch from 3.2.1 that resolves a false positive cache hit in the `ClassMethodsHydrator`.
+
+### 4.0.3
+
+- Total issues resolved: **0**
+- Total pull requests resolved: **1**
+- Total contributors: **1**
+
+#### Bug
+
+ - [59: Merge release 3.2.1 into 4.0.x](https://github.com/laminas/laminas-hydrator/pull/59) thanks to @github-actions[bot]
 
 ## 4.0.2 - 2020-12-16
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,28 @@
 
 All notable changes to this project will be documented in this file, in reverse chronological order by release.
 
+## 3.2.2 - TBD
+
+### Added
+
+- Nothing.
+
+### Changed
+
+- Nothing.
+
+### Deprecated
+
+- Nothing.
+
+### Removed
+
+- Nothing.
+
+### Fixed
+
+- Nothing.
+
 ## 3.2.1 - 2021-06-28
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,27 +2,27 @@
 
 All notable changes to this project will be documented in this file, in reverse chronological order by release.
 
-## 3.2.1 - TBD
+## 3.2.1 - 2021-06-28
 
-### Added
 
-- Nothing.
+-----
 
-### Changed
-
-- Nothing.
-
-### Deprecated
-
-- Nothing.
-
-### Removed
-
-- Nothing.
+### Release Notes for [3.2.1](https://github.com/laminas/laminas-hydrator/milestone/7)
 
 ### Fixed
 
-- Nothing.
+- The `ClassMethodsHydrator` would occasionally have a scenario whereby no methods were cached, but a conditional would miss this fact, which would lead to a logic error later. The conditional has been updated.
+
+### 3.2.1
+
+- Total issues resolved: **0**
+- Total pull requests resolved: **2**
+- Total contributors: **1**
+
+#### Bug
+
+ - [53: 3.2.x - remove class-methods-hydrator redundant filter](https://github.com/laminas/laminas-hydrator/pull/53) thanks to @pine3ree
+ - [48: fix never met condition](https://github.com/laminas/laminas-hydrator/pull/48) thanks to @pine3ree
 
 ## 3.2.0 - 2020-10-06
 

--- a/docs/book/v4/strategy.md
+++ b/docs/book/v4/strategy.md
@@ -134,6 +134,16 @@ This strategy is a wrapper around PHP's `implode()` and `explode()` functions.
 The delimiter and a limit can be provided to the constructor; the limit will
 only be used for `extract` operations.
 
+### Laminas\\Hydrator\\Strategy\\NullableStrategy
+
+- Since 4.1.0
+
+This strategy acts as a decorator around another strategy, allowing extraction and hydration of nullable values.
+The constructor accepts two arguments: the strategy to decorate, and a boolean flag indicating whether or not to treat empty values as `null`.
+By default, the flag is `false`, indicating only `null` values should be treated as `null`.
+
+Usage of this strategy also ensures a value is extracted or hydrated when it is `null`, instead of being dropped from the representation.
+
 ### Laminas\\Hydrator\\Strategy\\StrategyChain
 
 This strategy takes an array of `StrategyInterface` instances and iterates

--- a/src/ClassMethodsHydrator.php
+++ b/src/ClassMethodsHydrator.php
@@ -75,11 +75,6 @@ class ClassMethodsHydrator extends AbstractHydrator implements HydratorOptionsIn
         $compositeFilter->addFilter('is', new Filter\IsFilter());
         $compositeFilter->addFilter('has', new Filter\HasFilter());
         $compositeFilter->addFilter('get', new Filter\GetFilter());
-        $compositeFilter->addFilter(
-            'parameter',
-            new Filter\OptionalParametersFilter(),
-            Filter\FilterComposite::CONDITION_AND
-        );
     }
 
     /**

--- a/src/ClassMethodsHydrator.php
+++ b/src/ClassMethodsHydrator.php
@@ -59,7 +59,7 @@ class ClassMethodsHydrator extends AbstractHydrator implements HydratorOptionsIn
     /**
      * @var Filter\FilterInterface
      */
-    private $optionalParameterFilter;
+    private $optionalParametersFilter;
 
     /**
      * Define if extract values will use camel case or name with underscore
@@ -69,7 +69,7 @@ class ClassMethodsHydrator extends AbstractHydrator implements HydratorOptionsIn
         $this->setUnderscoreSeparatedKeys($underscoreSeparatedKeys);
         $this->setMethodExistsCheck($methodExistsCheck);
 
-        $this->optionalParameterFilter = new Filter\OptionalParametersFilter();
+        $this->optionalParametersFilter = new Filter\OptionalParametersFilter();
 
         $compositeFilter = $this->getCompositeFilter();
         $compositeFilter->addFilter('is', new Filter\IsFilter());
@@ -151,7 +151,7 @@ class ClassMethodsHydrator extends AbstractHydrator implements HydratorOptionsIn
             foreach ($methods as $method) {
                 $methodFqn = $objectClass . '::' . $method;
 
-                if (! ($filter->filter($methodFqn) && $this->optionalParameterFilter->filter($methodFqn))) {
+                if (! ($filter->filter($methodFqn) && $this->optionalParametersFilter->filter($methodFqn))) {
                     continue;
                 }
 

--- a/src/ClassMethodsHydrator.php
+++ b/src/ClassMethodsHydrator.php
@@ -161,7 +161,9 @@ class ClassMethodsHydrator extends AbstractHydrator implements HydratorOptionsIn
 
         $values = [];
 
-        if (empty($this->extractionMethodsCache[$objectClass])) {
+        if (null === $this->extractionMethodsCache[$objectClass]
+            || [] === $this->extractionMethodsCache[$objectClass]
+        ) {
             return $values;
         }
 

--- a/src/ClassMethodsHydrator.php
+++ b/src/ClassMethodsHydrator.php
@@ -59,7 +59,7 @@ class ClassMethodsHydrator extends AbstractHydrator implements HydratorOptionsIn
     /**
      * @var Filter\FilterInterface
      */
-    private $callableMethodFilter;
+    private $optionalParameterFilter;
 
     /**
      * Define if extract values will use camel case or name with underscore
@@ -69,7 +69,7 @@ class ClassMethodsHydrator extends AbstractHydrator implements HydratorOptionsIn
         $this->setUnderscoreSeparatedKeys($underscoreSeparatedKeys);
         $this->setMethodExistsCheck($methodExistsCheck);
 
-        $this->callableMethodFilter = new Filter\OptionalParametersFilter();
+        $this->optionalParameterFilter = new Filter\OptionalParametersFilter();
 
         $compositeFilter = $this->getCompositeFilter();
         $compositeFilter->addFilter('is', new Filter\IsFilter());
@@ -151,7 +151,7 @@ class ClassMethodsHydrator extends AbstractHydrator implements HydratorOptionsIn
             foreach ($methods as $method) {
                 $methodFqn = $objectClass . '::' . $method;
 
-                if (! ($filter->filter($methodFqn) && $this->callableMethodFilter->filter($methodFqn))) {
+                if (! ($filter->filter($methodFqn) && $this->optionalParameterFilter->filter($methodFqn))) {
                     continue;
                 }
 

--- a/src/ClassMethodsHydrator.php
+++ b/src/ClassMethodsHydrator.php
@@ -158,7 +158,9 @@ class ClassMethodsHydrator extends AbstractHydrator implements HydratorOptionsIn
                     ? $method
                     : $objectClass . '::' . $method;
 
-                if (! ($filter->filter($methodFqn) && $this->optionalParametersFilter->filter($methodFqn))) {
+                if (! $filter->filter($methodFqn) 
+                    || ! $this->optionalParametersFilter->filter($methodFqn, $isAnonymous ? $object : null)
+                ) {
                     continue;
                 }
 

--- a/src/ClassMethodsHydrator.php
+++ b/src/ClassMethodsHydrator.php
@@ -161,7 +161,7 @@ class ClassMethodsHydrator extends AbstractHydrator implements HydratorOptionsIn
 
         $values = [];
 
-        if (null === $this->extractionMethodsCache[$objectClass]) {
+        if (empty($this->extractionMethodsCache[$objectClass])) {
             return $values;
         }
 

--- a/src/ClassMethodsHydrator.php
+++ b/src/ClassMethodsHydrator.php
@@ -158,7 +158,7 @@ class ClassMethodsHydrator extends AbstractHydrator implements HydratorOptionsIn
                     ? $method
                     : $objectClass . '::' . $method;
 
-                if (! $filter->filter($methodFqn) 
+                if (! $filter->filter($methodFqn)
                     || ! $this->optionalParametersFilter->filter($methodFqn, $isAnonymous ? $object : null)
                 ) {
                     continue;


### PR DESCRIPTION
- Bumps changelog version to 3.2.1
- Bumps changelog version to 4.0.3
- remove redundant optional-parameter filter
- rename internal property for clarity
- fix property name typo missing plural form "s"
- fix never met condition
- qa: strict checks for null or empty array value of $extractionMethodsCache
- 3.2.1 readiness
- Bumps changelog version to 3.2.2
- docs: documents `NullableStrategy`
- fix: ensure ClassMethodsHydrator properly calls composed OptionalParametersListener
- qa: fix CS issues reported by phpcs
- 4.0.3 readiness
