### PR TITLE
Undeprecate Laminas\Hydrator\Strategy\BooleanStrategy

### DIFF
--- a/docs/book/v4/strategy.md
+++ b/docs/book/v4/strategy.md
@@ -84,11 +84,24 @@ if present, will use it to translate the property name prior to looking up a
 
 ### Laminas\\Hydrator\\Strategy\\BooleanStrategy
 
-> Deprecated since version 4.2.0. Use the [ScalarTypeStrategy](#laminashydratorstrategyscalartypestrategy] instead.
-
-This strategy converts values into Booleans and vice versa. It expects two
+This strategy converts values into booleans and vice versa. It expects two
 arguments at the constructor, which are used to define value maps for `true` and
 `false`.
+
+The arguments could be strings:
+
+```php
+$boolStrategy = new Laminas\Hydrator\Strategy\BooleanStrategy('1', '0');
+```
+
+or integers:
+
+```php
+$boolStrategy = new Laminas\Hydrator\Strategy\BooleanStrategy(1, 0);
+```
+
+The main difference from [ScalarTypeStrategy](#laminashydratorstrategyscalartypestrategy)
+is extracting booleans back to arguments given at the constructor.
 
 ### Laminas\\Hydrator\\Strategy\\ClosureStrategy
 

--- a/psalm.xml.dist
+++ b/psalm.xml.dist
@@ -16,12 +16,6 @@
     </projectFiles>
 
     <issueHandlers>
-        <DeprecatedClass>
-            <errorLevel type="suppress">
-                <file name="test/Strategy/BooleanStrategyTest.php"/>
-            </errorLevel>
-        </DeprecatedClass>
-
         <InternalMethod>
             <errorLevel type="suppress">
                 <referencedMethod name="PHPUnit\Framework\MockObject\Builder\InvocationMocker::method"/>

--- a/src/Strategy/BooleanStrategy.php
+++ b/src/Strategy/BooleanStrategy.php
@@ -16,8 +16,6 @@ use function sprintf;
 
 /**
  * This Strategy extracts and hydrates int and string values to Boolean values
- *
- * @deprecated Since version 4.2.0; use the {@see ScalarTypeStrategy} instead.
  */
 final class BooleanStrategy implements StrategyInterface
 {


### PR DESCRIPTION
<!--
Fill in the relevant information below to help triage your issue.

Pick the target branch based on the following criteria:
  * Documentation improvement: master branch
  * Bugfix: master branch
  * QA improvement (additional tests, CS fixes, etc.) that does not change code
    behavior: master branch
  * New feature, or refactor of existing code: develop branch

You MUST provide a signoff in your commits for us to be able to accept your
patch; you can do this by providing either the --signoff or -s flag when using
"git commit". Please see the project contributing guide and
https://developercertificate.org for details.
-->

|    Q          |   A
|-------------- | ------
| Documentation | yes
| Bugfix        | yes
| BC Break      | no
| New Feature   | no
| RFC           | no
| QA            | no

### Description

`ScalarTypeStrategy` does not extract booleans back to value map `true`|`false` arguments as described in #66 .

<!--
Tell us about why this change is necessary:
- Are you fixing a bug or providing a failing unit test to demonstrate a bug?
  - How do you reproduce it?
  - What did you expect to happen?
  - What actually happened?
  - TARGET THE master BRANCH

- Are you adding documentation?
  - TARGET THE master BRANCH

- Are you providing a QA improvement (additional tests, CS fixes, etc.) that
  does not change behavior?
  - Explain why the changes are necessary
  - TARGET THE master BRANCH

- Are you fixing a BC Break?
  - How do you reproduce it?
  - What was the previous behavior?
  - What is the current behavior?
  - TARGET THE master BRANCH

- Are you adding something the library currently does not support?
  - Why should it be added?
  - What will it enable?
  - How will the code be used?
  - TARGET THE develop BRANCH

- Are you refactoring code?
  - Why do you feel the refactor is necessary?
  - What types of refactoring are you doing?
  - TARGET THE develop BRANCH
-->
