### PR TITLE
Simplify redirects of legacy documentation pages

### DIFF
--- a/docs/book/aggregate.md
+++ b/docs/book/aggregate.md
@@ -1,6 +1,0 @@
-<noscript><meta http-equiv="refresh" content="0; url=/laminas-hydrator/v2/aggregate/"></noscript>
-<script>
-  document.addEventListener("DOMContentLoaded", function (event) {
-    window.location.pathname = '/laminas-hydrator/v2/aggregate/';
-  });
-</script>

--- a/docs/book/filter.md
+++ b/docs/book/filter.md
@@ -1,6 +1,0 @@
-<noscript><meta http-equiv="refresh" content="0; url=/laminas-hydrator/v2/filter/"></noscript>
-<script>
-  document.addEventListener("DOMContentLoaded", function (event) {
-    window.location.pathname = '/laminas-hydrator/v2/filter/';
-  });
-</script>

--- a/docs/book/naming-strategy/composite-naming-strategy.md
+++ b/docs/book/naming-strategy/composite-naming-strategy.md
@@ -1,7 +1,0 @@
-<!-- markdownlint-disable -->
-<noscript><meta http-equiv="refresh" content="0; url=/laminas-hydrator/v2/naming-strategy/composite-naming-strategy/"></noscript>
-<script>
-  document.addEventListener("DOMContentLoaded", function (event) {
-    window.location.pathname = '/laminas-hydrator/v2/naming-strategy/composite-naming-strategy/';
-  });
-</script>

--- a/docs/book/naming-strategy/identity-naming-strategy.md
+++ b/docs/book/naming-strategy/identity-naming-strategy.md
@@ -1,7 +1,0 @@
-<!-- markdownlint-disable -->
-<noscript><meta http-equiv="refresh" content="0; url=/laminas-hydrator/v2/naming-strategy/identity-naming-strategy/"></noscript>
-<script>
-  document.addEventListener("DOMContentLoaded", function (event) {
-    window.location.pathname = '/laminas-hydrator/v2/naming-strategy/identity-naming-strategy/';
-  });
-</script>

--- a/docs/book/naming-strategy/map-naming-strategy.md
+++ b/docs/book/naming-strategy/map-naming-strategy.md
@@ -1,7 +1,0 @@
-<!-- markdownlint-disable -->
-<noscript><meta http-equiv="refresh" content="0; url=/laminas-hydrator/v2/naming-strategy/map-naming-strategy/"></noscript>
-<script>
-  document.addEventListener("DOMContentLoaded", function (event) {
-    window.location.pathname = '/laminas-hydrator/v2/naming-strategy/map-naming-strategy/';
-  });
-</script>

--- a/docs/book/naming-strategy/underscore-naming-strategy.md
+++ b/docs/book/naming-strategy/underscore-naming-strategy.md
@@ -1,7 +1,0 @@
-<!-- markdownlint-disable -->
-<noscript><meta http-equiv="refresh" content="0; url=/laminas-hydrator/v2/naming-strategy/underscore-naming-strategy/"></noscript>
-<script>
-  document.addEventListener("DOMContentLoaded", function (event) {
-    window.location.pathname = '/laminas-hydrator/v2/naming-strategy/underscore-naming-strategy/';
-  });
-</script>

--- a/docs/book/quick-start.md
+++ b/docs/book/quick-start.md
@@ -1,6 +1,0 @@
-<noscript><meta http-equiv="refresh" content="0; url=/laminas-hydrator/v2/quick-start/"></noscript>
-<script>
-  document.addEventListener("DOMContentLoaded", function (event) {
-    window.location.pathname = '/laminas-hydrator/v2/quick-start/';
-  });
-</script>

--- a/docs/book/strategy.md
+++ b/docs/book/strategy.md
@@ -1,6 +1,0 @@
-<noscript><meta http-equiv="refresh" content="0; url=/laminas-hydrator/v2/strategy/"></noscript>
-<script>
-  document.addEventListener("DOMContentLoaded", function (event) {
-    window.location.pathname = '/laminas-hydrator/v2/strategy/';
-  });
-</script>

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -56,15 +56,18 @@ nav:
             - "Mapping": v2/naming-strategy/map-naming-strategy.md
             - "Underscore Mapping": v2/naming-strategy/underscore-naming-strategy.md
             - "Composite": v2/naming-strategy/composite-naming-strategy.md
-    - "_hidden-legacy-page-links":
-        - "_quick_start": quick-start.md
-        - "_filters": filter.md
-        - "_strategies": strategy.md
-        - "_aggregates": aggregate.md
-        - "_naming_strategies-identity": naming-strategy/identity-naming-strategy.md
-        - "_naming_strategies-mapping": naming-strategy/map-naming-strategy.md
-        - "_naming_strategies-underscore_mapping": naming-strategy/underscore-naming-strategy.md
-        - "_naming_strategies-composite": naming-strategy/composite-naming-strategy.md
 site_name: laminas-hydrator
 site_description: "Serialize objects to arrays, and vice versa"
 repo_url: 'https://github.com/laminas/laminas-hydrator'
+plugins:
+  - search
+  - redirects:
+      redirect_maps:
+        aggregate.md: v2/aggregate.md
+        filter.md: v2/filter.md
+        naming-strategy/composite-naming-strategy.md: v2/naming-strategy/composite-naming-strategy.md
+        naming-strategy/identity-naming-strategy.md: v2/naming-strategy/identity-naming-strategy.md
+        naming-strategy/map-naming-strategy.md: v2/naming-strategy/map-naming-strategy.md
+        naming-strategy/underscore-naming-strategy.md: v2/naming-strategy/underscore-naming-strategy.md
+        quick-start.md: v2/quick-start.md
+        strategy.md: v2/strategy.md


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | yes
| Bugfix        | no
| BC Break      | no
| New Feature   | no
| RFC           | no
| QA            | no

### Description

The docs folder contains several manual redirects, i.d. HTML documents with a hard-coded redirect for legacy URLs. I found that laminas-form in its [mkdocs.yml](https://github.com/laminas/laminas-form/blob/3.1.x/mkdocs.yml) has found a much simpler approach using the redirects plugin.

This PR moves the redirects for legacy URLs in `mkdocs.yml` and removes the manually created HTML documents from Git.