### PR TITLE
Change access method to "protected" for ClassMethodsHydrator::identifyAttributeName()

### DIFF
--- a/src/ClassMethodsHydrator.php
+++ b/src/ClassMethodsHydrator.php
@@ -205,7 +205,7 @@ class ClassMethodsHydrator extends AbstractHydrator implements HydratorOptionsIn
         return $this->getCompositeFilter();
     }
 
-    private function identifyAttributeName(object $object, string $method): string
+    protected function identifyAttributeName(object $object, string $method): string
     {
         if (strpos($method, 'get') === 0) {
             $attribute = substr($method, 3);


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | no
| BC Break      | no
| New Feature   | no
| RFC           | no
| QA            | no

### Description

Example:
```
<?php

use Laminas\Hydrator\ClassMethodsHydrator;

class Foo 
{
  private bool $bar;

  public function __construct(bool $bar) 
  {
    $this->bar = $bar;
  }

  public function isBar(): bool
  {
    return $this->bar;
  }
}

$foo = new Foo(true);
$hydrator = new ClassMethodsHydrator(false);
$data = $hydrator->extract($foo);

// Result of $data: 
// [ 'isBar' => true ]

```
But I need to have `['bar' => true]` in `$data` .
To do this, I need to override the `ClassMethodsHydrator::identifyAttributeName()` method. 
But access to this method is `private`. 
I suggest setting access to `protected`.
