### PR TITLE
Add constructor decorator

### DIFF
--- a/src/ConstructorParametersHydratorDecorator.php
+++ b/src/ConstructorParametersHydratorDecorator.php
@@ -75,24 +75,23 @@ final class ConstructorParametersHydratorDecorator implements HydratorInterface
 
     /**
      * @param mixed $value
-     * @param ReflectionParameter $constructorParameter
      * @return mixed
      */
     private function castScalarValue($value, ReflectionParameter $constructorParameter)
     {
-        if ($value === null || !$constructorParameter->getType() instanceof ReflectionNamedType) {
+        if ($value === null || ! $constructorParameter->getType() instanceof ReflectionNamedType) {
             return $value;
         }
 
         switch ($constructorParameter->getType()->getName()) {
             case 'string':
-                return (string)$value;
+                return (string) $value;
             case 'int':
-                return (int)$value;
+                return (int) $value;
             case 'float':
-                return (float)$value;
+                return (float) $value;
             case 'bool':
-                return (bool)$value;
+                return (bool) $value;
             default:
                 return $value;
         }

--- a/src/ConstructorParametersHydratorDecorator.php
+++ b/src/ConstructorParametersHydratorDecorator.php
@@ -50,7 +50,7 @@ final class ConstructorParametersHydratorDecorator implements HydratorInterface
                 $value = null;
             }
 
-            $value = $this->castScalarValue($value, $constructorParameter);
+            $value        = $this->castScalarValue($value, $constructorParameter);
             $parameters[] = $this->decoratedHydrator->hydrateValue($parameterName, $value, $data);
         }
 

--- a/src/ConstructorParametersHydratorDecorator.php
+++ b/src/ConstructorParametersHydratorDecorator.php
@@ -1,0 +1,72 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Laminas\Hydrator;
+
+use ReflectionClass;
+use ReflectionException;
+use ReflectionParameter;
+
+final class ConstructorParametersHydratorDecorator implements HydratorInterface
+{
+    /** @var array<class-string, ReflectionParameter[]> */
+    private static $parametersCache = [];
+
+    /** @var AbstractHydrator */
+    private $decoratedHydrator;
+
+    public function __construct(AbstractHydrator $decoratedHydrator)
+    {
+        $this->decoratedHydrator = $decoratedHydrator;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function extract(object $object): array
+    {
+        return $this->decoratedHydrator->extract($object);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function hydrate(array $data, object $object)
+    {
+        if (! $object instanceof ProxyObject) {
+            return $this->decoratedHydrator->hydrate($data, $object);
+        }
+
+        $constructorParameters = $this->getConstructorParameters($object);
+        $parameters            = [];
+        foreach ($constructorParameters as $constructorParameter) {
+            $parameterName = $this->decoratedHydrator->extractName($constructorParameter->getName());
+            try {
+                /** @var mixed $value */
+                $value = $data[$parameterName] ?? $constructorParameter->getDefaultValue();
+            } catch (ReflectionException $e) {
+                $value = null;
+            }
+            $parameters[] = $this->decoratedHydrator->hydrateValue($parameterName, $value, $data);
+        }
+
+        return $this->decoratedHydrator->hydrate($data, $object->createProxiedObject($parameters));
+    }
+
+    /** @return ReflectionParameter[] */
+    private function getConstructorParameters(ProxyObject $object): array
+    {
+        if (! isset(self::$parametersCache[$object->getObjectClassName()])) {
+            $reflection  = new ReflectionClass($object->getObjectClassName());
+            $constructor = $reflection->getConstructor();
+
+            self::$parametersCache[$object->getObjectClassName()] = [];
+            if ($constructor !== null) {
+                self::$parametersCache[$object->getObjectClassName()] = $constructor->getParameters();
+            }
+        }
+
+        return self::$parametersCache[$object->getObjectClassName()];
+    }
+}

--- a/src/ConstructorParametersHydratorDecorator.php
+++ b/src/ConstructorParametersHydratorDecorator.php
@@ -6,6 +6,7 @@ namespace Laminas\Hydrator;
 
 use ReflectionClass;
 use ReflectionException;
+use ReflectionNamedType;
 use ReflectionParameter;
 
 final class ConstructorParametersHydratorDecorator implements HydratorInterface
@@ -48,6 +49,8 @@ final class ConstructorParametersHydratorDecorator implements HydratorInterface
             } catch (ReflectionException $e) {
                 $value = null;
             }
+
+            $value = $this->castScalarValue($value, $constructorParameter);
             $parameters[] = $this->decoratedHydrator->hydrateValue($parameterName, $value, $data);
         }
 
@@ -68,5 +71,30 @@ final class ConstructorParametersHydratorDecorator implements HydratorInterface
         }
 
         return self::$parametersCache[$object->getObjectClassName()];
+    }
+
+    /**
+     * @param mixed $value
+     * @param ReflectionParameter $constructorParameter
+     * @return mixed
+     */
+    private function castScalarValue($value, ReflectionParameter $constructorParameter)
+    {
+        if ($value === null || !$constructorParameter->getType() instanceof ReflectionNamedType) {
+            return $value;
+        }
+
+        switch ($constructorParameter->getType()->getName()) {
+            case 'string':
+                return (string)$value;
+            case 'int':
+                return (int)$value;
+            case 'float':
+                return (float)$value;
+            case 'bool':
+                return (bool)$value;
+            default:
+                return $value;
+        }
     }
 }

--- a/src/DelegatingHydrator.php
+++ b/src/DelegatingHydrator.php
@@ -23,7 +23,10 @@ class DelegatingHydrator implements HydratorInterface
      */
     public function hydrate(array $data, object $object)
     {
-        return $this->getHydrator($object)->hydrate($data, $object);
+        if (! $object instanceof ProxyObject) {
+            return $this->getHydrator($object)->hydrate($data, $object);
+        }
+        return $this->hydrators->get($object->getObjectClassName())->hydrate($data, $object);
     }
 
     /**

--- a/src/ProxyObject.php
+++ b/src/ProxyObject.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Laminas\Hydrator;
+
+final class ProxyObject
+{
+    /** @var class-string */
+    private $objectClassName;
+
+    /** @param class-string $objectClassName */
+    public function __construct(string $objectClassName)
+    {
+        $this->objectClassName = $objectClassName;
+    }
+
+    /** @return class-string */
+    public function getObjectClassName(): string
+    {
+        return $this->objectClassName;
+    }
+
+    /** @param array<int, mixed> $parameters */
+    public function createProxiedObject(array $parameters): object
+    {
+        return new $this->objectClassName(...$parameters);
+    }
+}

--- a/src/Strategy/HydratorStrategy.php
+++ b/src/Strategy/HydratorStrategy.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Laminas\Hydrator\Strategy;
 
 use Laminas\Hydrator\HydratorInterface;
+use Laminas\Hydrator\ProxyObject;
 use ReflectionClass;
 use ReflectionException;
 
@@ -23,12 +24,16 @@ class HydratorStrategy implements StrategyInterface
     /** @var string */
     private $objectClassName;
 
+    /** @var bool */
+    private $useProxyObject;
+
     /**
      * @throws Exception\InvalidArgumentException
      */
     public function __construct(
         HydratorInterface $objectHydrator,
-        string $objectClassName
+        string $objectClassName,
+        bool $useProxyObject = false
     ) {
         if (! class_exists($objectClassName)) {
             throw new Exception\InvalidArgumentException(
@@ -41,6 +46,7 @@ class HydratorStrategy implements StrategyInterface
 
         $this->objectHydrator  = $objectHydrator;
         $this->objectClassName = $objectClassName;
+        $this->useProxyObject  = $useProxyObject;
     }
 
     /**
@@ -88,6 +94,10 @@ class HydratorStrategy implements StrategyInterface
                     is_object($value) ? get_class($value) : gettype($value)
                 )
             );
+        }
+
+        if ($this->useProxyObject) {
+            return new ProxyObject($this->objectClassName);
         }
 
         $reflection = new ReflectionClass($this->objectClassName);

--- a/test/ConstructorParametersHydratorDecoratorTest.php
+++ b/test/ConstructorParametersHydratorDecoratorTest.php
@@ -20,12 +20,28 @@ final class ConstructorParametersHydratorDecoratorTest extends TestCase
             'foo'         => 'bar',
             'bar'         => 99,
             'isMandatory' => true,
+            'price'       => 19.98,
         ];
         $subject = new ConstructorParametersHydratorDecorator(new ClassMethodsHydrator(false));
         $object  = $subject->hydrate($data, new ProxyObject(ObjectWithConstructor::class));
 
         Assert::assertInstanceOf(ObjectWithConstructor::class, $object);
-        Assert::assertEquals(new ObjectWithConstructor('bar', 99, true), $object);
+        Assert::assertEquals(new ObjectWithConstructor('bar', true, 19.98, 99), $object);
+    }
+
+    public function testWithWrongScalarType(): void
+    {
+        $data    = [
+            'foo'         => 123,
+            'bar'         => '99',
+            'isMandatory' => 1,
+            'price'       => '19.98',
+        ];
+        $subject = new ConstructorParametersHydratorDecorator(new ClassMethodsHydrator(false));
+        $object  = $subject->hydrate($data, new ProxyObject(ObjectWithConstructor::class));
+
+        Assert::assertInstanceOf(ObjectWithConstructor::class, $object);
+        Assert::assertEquals(new ObjectWithConstructor('123', true, 19.98, 99), $object);
     }
 
     public function testWithAdditionalSetter(): void
@@ -34,6 +50,7 @@ final class ConstructorParametersHydratorDecoratorTest extends TestCase
             'foo'         => 'bar',
             'bar'         => 99,
             'isMandatory' => true,
+            'price'       => 19.98,
             'baz'         => 'Hello world',
         ];
         $subject = new ConstructorParametersHydratorDecorator(new ClassMethodsHydrator(false));
@@ -41,7 +58,7 @@ final class ConstructorParametersHydratorDecoratorTest extends TestCase
 
         Assert::assertInstanceOf(ObjectWithConstructor::class, $object);
         Assert::assertEquals(
-            (new ObjectWithConstructor('bar', 99, true))->setBaz('Hello world'),
+            (new ObjectWithConstructor('bar', true, 19.98, 99))->setBaz('Hello world'),
             $object
         );
     }
@@ -51,12 +68,13 @@ final class ConstructorParametersHydratorDecoratorTest extends TestCase
         $data    = [
             'foo'         => 'bar',
             'isMandatory' => true,
+            'price'       => 19.98,
         ];
         $subject = new ConstructorParametersHydratorDecorator(new ClassMethodsHydrator(false));
         $object  = $subject->hydrate($data, new ProxyObject(ObjectWithConstructor::class));
 
         Assert::assertInstanceOf(ObjectWithConstructor::class, $object);
-        Assert::assertEquals(new ObjectWithConstructor('bar', 42, true), $object);
+        Assert::assertEquals(new ObjectWithConstructor('bar', true, 19.98, 42), $object);
     }
 
     public function testWithMissingMandatoryParameter(): void
@@ -71,12 +89,13 @@ final class ConstructorParametersHydratorDecoratorTest extends TestCase
     public function testExtract(): void
     {
         $subject = new ConstructorParametersHydratorDecorator(new ClassMethodsHydrator(false));
-        $data    = $subject->extract(new ObjectWithConstructor('bar', 99, true));
+        $data    = $subject->extract(new ObjectWithConstructor('bar', true, 19.98, 99));
         Assert::assertSame(
             [
                 'foo'         => 'bar',
-                'bar'         => 99,
                 'isMandatory' => true,
+                'price'       => 19.98,
+                'bar'         => 99,
                 'baz'         => null,
             ],
             $data

--- a/test/ConstructorParametersHydratorDecoratorTest.php
+++ b/test/ConstructorParametersHydratorDecoratorTest.php
@@ -1,0 +1,85 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LaminasTest\Hydrator;
+
+use Laminas\Hydrator\ClassMethodsHydrator;
+use Laminas\Hydrator\ConstructorParametersHydratorDecorator;
+use Laminas\Hydrator\ProxyObject;
+use LaminasTest\Hydrator\TestAsset\ObjectWithConstructor;
+use PHPUnit\Framework\Assert;
+use PHPUnit\Framework\TestCase;
+use TypeError;
+
+final class ConstructorParametersHydratorDecoratorTest extends TestCase
+{
+    public function testWithAllParametersPresent(): void
+    {
+        $data    = [
+            'foo'         => 'bar',
+            'bar'         => 99,
+            'isMandatory' => true,
+        ];
+        $subject = new ConstructorParametersHydratorDecorator(new ClassMethodsHydrator(false));
+        $object  = $subject->hydrate($data, new ProxyObject(ObjectWithConstructor::class));
+
+        Assert::assertInstanceOf(ObjectWithConstructor::class, $object);
+        Assert::assertEquals(new ObjectWithConstructor('bar', 99, true), $object);
+    }
+
+    public function testWithAdditionalSetter(): void
+    {
+        $data    = [
+            'foo'         => 'bar',
+            'bar'         => 99,
+            'isMandatory' => true,
+            'baz'         => 'Hello world',
+        ];
+        $subject = new ConstructorParametersHydratorDecorator(new ClassMethodsHydrator(false));
+        $object  = $subject->hydrate($data, new ProxyObject(ObjectWithConstructor::class));
+
+        Assert::assertInstanceOf(ObjectWithConstructor::class, $object);
+        Assert::assertEquals(
+            (new ObjectWithConstructor('bar', 99, true))->setBaz('Hello world'),
+            $object
+        );
+    }
+
+    public function testWithMissingOptionalParameter(): void
+    {
+        $data    = [
+            'foo'         => 'bar',
+            'isMandatory' => true,
+        ];
+        $subject = new ConstructorParametersHydratorDecorator(new ClassMethodsHydrator(false));
+        $object  = $subject->hydrate($data, new ProxyObject(ObjectWithConstructor::class));
+
+        Assert::assertInstanceOf(ObjectWithConstructor::class, $object);
+        Assert::assertEquals(new ObjectWithConstructor('bar', 42, true), $object);
+    }
+
+    public function testWithMissingMandatoryParameter(): void
+    {
+        $data    = [];
+        $subject = new ConstructorParametersHydratorDecorator(new ClassMethodsHydrator(false));
+
+        $this->expectException(TypeError::class);
+        $subject->hydrate($data, new ProxyObject(ObjectWithConstructor::class));
+    }
+
+    public function testExtract(): void
+    {
+        $subject = new ConstructorParametersHydratorDecorator(new ClassMethodsHydrator(false));
+        $data    = $subject->extract(new ObjectWithConstructor('bar', 99, true));
+        Assert::assertSame(
+            [
+                'foo'         => 'bar',
+                'bar'         => 99,
+                'isMandatory' => true,
+                'baz'         => null,
+            ],
+            $data
+        );
+    }
+}

--- a/test/TestAsset/ObjectWithConstructor.php
+++ b/test/TestAsset/ObjectWithConstructor.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LaminasTest\Hydrator\TestAsset;
+
+final class ObjectWithConstructor
+{
+    /** @var string */
+    private $foo;
+
+    /** @var int|null */
+    private $bar;
+
+    /** @var bool */
+    private $isMandatory;
+
+    /** @var string|null */
+    private $baz;
+
+    /** @codingStandardsIgnoreStart */
+    public function __construct(string $foo, ?int $bar = 42, bool $isMandatory)
+    {
+        $this->foo = $foo;
+        $this->bar = $bar;
+        $this->isMandatory = $isMandatory;
+    }
+    /** @codingStandardsIgnoreEnd */
+
+    public function getFoo(): string
+    {
+        return $this->foo;
+    }
+
+    public function getBar(): ?int
+    {
+        return $this->bar;
+    }
+
+    public function isMandatory(): bool
+    {
+        return $this->isMandatory;
+    }
+
+    public function getBaz(): ?string
+    {
+        return $this->baz;
+    }
+
+    public function setBaz(?string $baz): self
+    {
+        $this->baz = $baz;
+        return $this;
+    }
+}

--- a/test/TestAsset/ObjectWithConstructor.php
+++ b/test/TestAsset/ObjectWithConstructor.php
@@ -23,10 +23,10 @@ final class ObjectWithConstructor
 
     public function __construct(string $foo, bool $isMandatory, float $price, ?int $bar = 42)
     {
-        $this->foo = $foo;
+        $this->foo         = $foo;
         $this->isMandatory = $isMandatory;
-        $this->bar = $bar;
-        $this->price = $price;
+        $this->bar         = $bar;
+        $this->price       = $price;
     }
 
     public function getFoo(): string

--- a/test/TestAsset/ObjectWithConstructor.php
+++ b/test/TestAsset/ObjectWithConstructor.php
@@ -9,37 +9,44 @@ final class ObjectWithConstructor
     /** @var string */
     private $foo;
 
-    /** @var int|null */
-    private $bar;
-
     /** @var bool */
     private $isMandatory;
+
+    /** @var float */
+    private $price;
+
+    /** @var int|null */
+    private $bar;
 
     /** @var string|null */
     private $baz;
 
-    /** @codingStandardsIgnoreStart */
-    public function __construct(string $foo, ?int $bar = 42, bool $isMandatory)
+    public function __construct(string $foo, bool $isMandatory, float $price, ?int $bar = 42)
     {
         $this->foo = $foo;
-        $this->bar = $bar;
         $this->isMandatory = $isMandatory;
+        $this->bar = $bar;
+        $this->price = $price;
     }
-    /** @codingStandardsIgnoreEnd */
 
     public function getFoo(): string
     {
         return $this->foo;
     }
 
-    public function getBar(): ?int
-    {
-        return $this->bar;
-    }
-
     public function isMandatory(): bool
     {
         return $this->isMandatory;
+    }
+
+    public function getPrice(): float
+    {
+        return $this->price;
+    }
+
+    public function getBar(): ?int
+    {
+        return $this->bar;
     }
 
     public function getBaz(): ?string


### PR DESCRIPTION
Signed-off-by: Marcel Kempf <marcel.kempf93@gmail.com>

|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | no
| BC Break      | no
| New Feature   | yes
| RFC           | no
| QA            | no

### Description

Hi, I wanted to get rid of setters just for the sake of hydrators without using reflection to write directly to properties, so I wrote this little decorator that uses the constructor to hydrate an object. Works really well in our projects, maybe this could also be interesting to other people.

Small simplified example:
```php
<?php

class MyObject {
  private int $foo;
  public function __construct(int $foo) {
    $this->foo = $foo;
  }

  public function getFoo(): int
  {
    return $this->foo;
  }
}

$hydrator = new ClassMethodsHydrator(false);
$hydrator->addStrategy('foo', ScalarTypeStrategy::createToInt());
$hydrator = new ConstructorParametersHydratorDecorator($hydrator);

$myObject = $hydrator->hydrate(['foo' => '42'], new ProxyObject(MyObject::class));
echo $myObject->getFoo(); // 42
```

**Open question on my end:**
For now I added new boolean flags to `CollectionStrategy` and `HydratorStrategy` in order to use the new `ProxyObject` instead of a reflection. Another way could be two new classes, e.g. `ProxyObjectCollectionStrategy` and `ProxyObjectHydratorStrategy`. What do you think about this?
Will adjust/add tests for those when that's decided.
