### PR TITLE
workaround for PHP 8.1 float key issues on test

### DIFF
--- a/test/NamingStrategy/MapNamingStrategyTest.php
+++ b/test/NamingStrategy/MapNamingStrategyTest.php
@@ -76,7 +76,7 @@ class MapNamingStrategyTest extends TestCase
      * @param mixed $invalidKey
      */
     public function testExtractionMapConstructorRaisesExceptionWhenFlippingHydrationMapForInvalidKeys(
-        $invalidKey,
+        $invalidKey
     ): void {
         $this->expectException(Exception\InvalidArgumentException::class);
         $this->expectExceptionMessage('can not be flipped');


### PR DESCRIPTION
<!--
Fill in the relevant information below to help triage your issue.

Pick the target branch based on the following criteria:
  * Documentation improvement: master branch
  * Bugfix: master branch
  * QA improvement (additional tests, CS fixes, etc.) that does not change code
    behavior: master branch
  * New feature, or refactor of existing code: develop branch

You MUST provide a signoff in your commits for us to be able to accept your
patch; you can do this by providing either the --signoff or -s flag when using
"git commit". Please see the project contributing guide and
https://developercertificate.org for details.
-->

|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | no
| BC Break      | no
| New Feature   | no
| RFC           | no
| QA            | yes

### Description
Currently test fails.
https://github.com/laminas/laminas-hydrator/runs/5077797525?check_suite_focus=true

```
1) LaminasTest\Hydrator\NamingStrategy\MapNamingStrategyTest::testExtractionMapConstructorRaisesExceptionWhenFlippingHydrationMapForInvalidKeys with data set "float" (1.1, 'Implicit conversion')
Failed asserting that Laminas\Hydrator\Exception\InvalidArgumentException Object &0000000000000b9f0000000000000000 (
    'message' => 'Mapping array can not be flipped because of invalid key'
    'string' => ''
    'code' => 0
    'file' => '/github/workspace/src/NamingStrategy/MapNamingStrategy.php'
    'line' => 102
    'previous' => null
) exception of type "PHPUnit\Framework\Error\Error" or exception of type "Error".
```
This PR is workaround to pass tests.

Current test fail is caused by `E_DEPRECATED`.
```
$ php8.1 -d error_reporting=-1 -r '[1.1 => true];'
PHP Deprecated:  Implicit conversion from float 1.1 to int loses precision in Command line code on line 1
```

* @weierophinney 's PHP 8.1 workaround https://github.com/laminas/laminas-hydrator/commit/b1d6ac21bf1360128fb7802b9c05c4c8f77c34c1 is committed before PHP 8.1 stable release. So it seems not work well.

* On other hand, I don't feel good for this PR's workaround.
  * I don't feel requirements to check float key on 8.1. 
* Mostly PHP 8.1 users would be noticed with static analysis OR running unit-tests with `E_DEPRECATED`.

```
MapNamingStrategy::createFromExtractionMap([1.1 => 'foo']);
```


<!--
Tell us about why this change is necessary:
- Are you fixing a bug or providing a failing unit test to demonstrate a bug?
  - How do you reproduce it?
  - What did you expect to happen?
  - What actually happened?
  - TARGET THE master BRANCH

- Are you adding documentation?
  - TARGET THE master BRANCH

- Are you providing a QA improvement (additional tests, CS fixes, etc.) that
  does not change behavior?
  - Explain why the changes are necessary
  - TARGET THE master BRANCH

- Are you fixing a BC Break?
  - How do you reproduce it?
  - What was the previous behavior?
  - What is the current behavior?
  - TARGET THE master BRANCH

- Are you adding something the library currently does not support?
  - Why should it be added?
  - What will it enable?
  - How will the code be used?
  - TARGET THE develop BRANCH

- Are you refactoring code?
  - Why do you feel the refactor is necessary?
  - What types of refactoring are you doing?
  - TARGET THE develop BRANCH
-->
