### PR TITLE
Add `BackedEnumStrategy`

### DIFF
--- a/docs/book/v4/strategies/backed-enum.md
+++ b/docs/book/v4/strategies/backed-enum.md
@@ -1,8 +1,10 @@
 # BackedEnum
 
-> Available since 4.8.0
+INFO: **New Feature**
+Available since version 4.8.0
 
-> Requires PHP 8.1+
+MISSING: **Installation Requirements**
+[Enumerations](https://www.php.net/manual/language.enumerations.overview.php) require PHP version 8.1 or higher.
 
 The `BackedEnumStrategy` provides **bidirectional conversion between strings 
 or integers and [Backed Enums](https://www.php.net/manual/en/language.enumerations.backed.php)**.

--- a/docs/book/v4/strategies/backed-enum.md
+++ b/docs/book/v4/strategies/backed-enum.md
@@ -21,12 +21,12 @@ enum Genre: string
 }
 ```
 
-## Basic usage
+## Basic Usage
 
 The following code example shows standalone usage without adding the strategy
 to a hydrator.
 
-### Create and configure strategy
+### Create and Configure Strategy
 
 Create the strategy passing the class name of the enum it will hydrate and extract:
 
@@ -34,14 +34,14 @@ Create the strategy passing the class name of the enum it will hydrate and extra
 $strategy = new Laminas\Hydrator\Strategy\BackedEnumStrategy(Genre::class);
 ```
 
-### Hydrate data
+### Hydrate Data
 
 ```php
 $hydrated = $strategy->hydrate('blues', null);
 var_dump($hydrated); // enum Genre::Blues : string("blues");
 ```
 
-### Extract data
+### Extract Data
 
 ```php
 $extracted = $strategy->extract(Genre::Pop);
@@ -71,7 +71,7 @@ class Album
 }
 ```
 
-### Create hydrator and add strategy
+### Create Hydrator and Add Atrategy
 
 Create a hydrator and add the `BackedEnumStrategy` as a strategy:
 
@@ -83,7 +83,7 @@ $hydrator->addStrategy(
 );
 ```
 
-### Hydrate data
+### Hydrate Data
 
 Create an instance of the example class and hydrate data:
 
@@ -94,7 +94,7 @@ $hydrator->hydrate(['genre' => 'jazz'], $album);
 echo $album->getGenre()->value; // "jazz"
 ```
 
-### Extract data
+### Extract Data
 
 ```php
 $extracted = $hydrator->extract($album);

--- a/docs/book/v4/strategies/backed-enum.md
+++ b/docs/book/v4/strategies/backed-enum.md
@@ -1,0 +1,101 @@
+# BackedEnum
+
+> Available since 4.8.0
+
+> Requires PHP 8.1+
+
+The `BackedEnumStrategy` provides **bidirectional conversion between strings 
+or integers and [Backed Enums](https://www.php.net/manual/en/language.enumerations.backed.php)**.
+
+The code examples below will use the following backed enum, representing a 
+genre of music:
+
+```php
+enum Genre: string
+{
+    case Pop   = 'pop';
+    case Blues = 'blues';
+    case Jazz  = 'jazz';
+}
+```
+
+## Basic usage
+
+The following code example shows standalone usage without adding the strategy
+to a hydrator.
+
+### Create and configure strategy
+
+Create the strategy passing the class name of the enum it will hydrate and extract:
+
+```php
+$strategy = new Laminas\Hydrator\Strategy\BackedEnumStrategy(Genre::class);
+```
+
+### Hydrate data
+
+```php
+$hydrated = $strategy->hydrate('blues', null);
+var_dump($hydrated); // enum Genre::Blues : string("blues");
+```
+
+### Extract data
+
+```php
+$extracted = $strategy->extract(Genre::Pop);
+var_dump($extracted); // string(3) "pop"
+```
+
+## Example
+
+The following example demonstrates hydration for a class with a property.
+
+An example class which represents an album with a music genre:
+
+```php
+class Album
+{
+    private ?Genre $genre;
+
+    public function __construct(?Genre $genre = null)
+    {
+        $this->genre = $genre;
+    }
+
+    public function getGenre() : Genre
+    {
+        return $this->genre;
+    }
+}
+```
+
+### Create hydrator and add strategy
+
+Create a hydrator and add the `BackedEnumStrategy` as a strategy:
+
+```php
+$hydrator = new Laminas\Hydrator\ReflectionHydrator();
+$hydrator->addStrategy(
+    'genre',
+    new Laminas\Hydrator\Strategy\BackedEnumStrategy(Genre::class)
+);
+```
+
+### Hydrate data
+
+Create an instance of the example class and hydrate data:
+
+```php
+$album = new Album();
+$hydrator->hydrate(['genre' => 'jazz'], $album);
+
+echo $album->getGenre()->value; // "jazz"
+```
+
+### Extract data
+
+```php
+$extracted = $hydrator->extract($album);
+
+echo $extracted['genre']; // "jazz"
+```

--- a/docs/book/v4/strategy.md
+++ b/docs/book/v4/strategy.md
@@ -82,6 +82,26 @@ if present, will use it to translate the property name prior to looking up a
 
 ## Available implementations
 
+### Laminas\\Hydrator\\Strategy\\BackedEnumStrategy
+
+**PHP 8.1+** This strategy coverts scalar values into [Backed Enums](https://www.php.net/manual/en/language.enumerations.backed.php)
+and visa versa:
+
+```php
+enum Direction: string
+{
+    case Left  = 'left';
+    case Right = 'right';
+}
+
+$enumStrategy = new Laminas\Hydrator\Strategy\BackedEnumStrategy(Direction::class);
+
+$case = $enumStrategy->hydrate('right', null);
+// enum Direction::Right : string("right");
+$direction = $enumStrategy->extract(Direction::Left);
+// string(4) "left"
+```
+
 ### Laminas\\Hydrator\\Strategy\\BooleanStrategy
 
 This strategy converts values into booleans and vice versa. It expects two

--- a/docs/book/v4/strategy.md
+++ b/docs/book/v4/strategy.md
@@ -82,26 +82,6 @@ if present, will use it to translate the property name prior to looking up a
 
 ## Available implementations
 
-### Laminas\\Hydrator\\Strategy\\BackedEnumStrategy
-
-**PHP 8.1+** This strategy coverts scalar values into [Backed Enums](https://www.php.net/manual/en/language.enumerations.backed.php)
-and visa versa:
-
-```php
-enum Direction: string
-{
-    case Left  = 'left';
-    case Right = 'right';
-}
-
-$enumStrategy = new Laminas\Hydrator\Strategy\BackedEnumStrategy(Direction::class);
-
-$case = $enumStrategy->hydrate('right', null);
-// enum Direction::Right : string("right");
-$direction = $enumStrategy->extract(Direction::Left);
-// string(4) "left"
-```
-
 ### Laminas\\Hydrator\\Strategy\\BooleanStrategy
 
 This strategy converts values into booleans and vice versa. It expects two

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -14,6 +14,7 @@ nav:
       - "Filters": v4/filter.md
       - "Strategies":
         - Introduction: v4/strategy.md
+        - BackedEnum: v4/strategies/backed-enum.md
         - Collection: v4/strategies/collection.md
         - DateTimeImmutableFormatter: v4/strategies/datetime-immutable-formatter-strategy.md
         - Hydrator: v4/strategies/hydrator.md

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -74,9 +74,7 @@
     <MixedInferredReturnType occurrences="1">
       <code>HydratorInterface</code>
     </MixedInferredReturnType>
-    <MixedReturnStatement occurrences="1">
-      <code>$this-&gt;hydrators-&gt;get($object::class)</code>
-    </MixedReturnStatement>
+    <MixedReturnStatement occurrences="1"/>
   </file>
   <file src="src/DelegatingHydratorFactory.php">
     <MixedInferredReturnType occurrences="1">
@@ -84,7 +82,6 @@
     </MixedInferredReturnType>
     <MixedReturnStatement occurrences="3">
       <code>$container-&gt;get('HydratorManager')</code>
-      <code>$container-&gt;get('Zend\Hydrator\HydratorPluginManager')</code>
       <code>$container-&gt;get(HydratorPluginManager::class)</code>
     </MixedReturnStatement>
   </file>
@@ -118,9 +115,7 @@
     <MixedAssignment occurrences="1">
       <code>$currentValue</code>
     </MixedAssignment>
-    <MixedMethodCall occurrences="1">
-      <code>new $prototype()</code>
-    </MixedMethodCall>
+    <MixedMethodCall occurrences="1"/>
   </file>
   <file src="src/Module.php">
     <MixedAssignment occurrences="2">
@@ -224,14 +219,6 @@
     <InvalidStringClass occurrences="1">
       <code>new $class()</code>
     </InvalidStringClass>
-  </file>
-  <file src="src/Strategy/BackedEnumStrategy.php">
-    <MixedInferredReturnType occurrences="1">
-      <code>T</code>
-    </MixedInferredReturnType>
-    <MixedReturnStatement occurrences="1">
-      <code>$this-&gt;enumClass::from($value)</code>
-    </MixedReturnStatement>
   </file>
   <file src="src/Strategy/BooleanStrategy.php">
     <DocblockTypeContradiction occurrences="4">
@@ -371,6 +358,7 @@
       <code>$andFilters</code>
       <code>$orFilters</code>
       <code>$value</code>
+      <code>$value</code>
     </MixedAssignment>
   </file>
   <file src="test/HydratorAwareTraitTest.php">
@@ -421,6 +409,7 @@
   </file>
   <file src="test/HydratorObjectPropertyTest.php">
     <MissingClosureParamType occurrences="1">
+      <code>$property</code>
       <code>$property</code>
     </MissingClosureParamType>
   </file>
@@ -541,40 +530,8 @@
       <code>$instance</code>
     </MixedAssignment>
   </file>
-  <file src="test/Strategy/BackedEnumStrategyTest.php">
-    <MixedArgument occurrences="6">
-      <code>TestBackedEnum::class</code>
-      <code>TestBackedEnum::class</code>
-      <code>TestBackedEnum::class</code>
-      <code>TestBackedEnum::class</code>
-      <code>TestBackedEnum::class</code>
-      <code>TestBackedEnum::class</code>
-    </MixedArgument>
-    <MixedAssignment occurrences="1">
-      <code>$expected</code>
-    </MixedAssignment>
-    <MixedOperand occurrences="1">
-      <code>TestBackedEnum::class</code>
-    </MixedOperand>
-    <UndefinedClass occurrences="12">
-      <code>TestBackedEnum</code>
-      <code>TestBackedEnum</code>
-      <code>TestBackedEnum</code>
-      <code>TestBackedEnum</code>
-      <code>TestBackedEnum</code>
-      <code>TestBackedEnum</code>
-      <code>TestBackedEnum</code>
-      <code>TestBackedEnum</code>
-      <code>TestBackedEnum</code>
-      <code>TestBackedEnum</code>
-      <code>TestBackedEnum</code>
-      <code>TestUnitEnum</code>
-    </UndefinedClass>
-  </file>
   <file src="test/Strategy/BooleanStrategyTest.php">
-    <InvalidArgument occurrences="1">
-      <code>false</code>
-    </InvalidArgument>
+    <InvalidArgument occurrences="1"/>
     <InvalidScalarArgument occurrences="2">
       <code>5</code>
       <code>true</code>
@@ -598,13 +555,17 @@
     <MixedAssignment occurrences="5">
       <code>$date</code>
       <code>$date</code>
+      <code>$date</code>
       <code>$extracted</code>
       <code>$extracted</code>
       <code>$hydrated</code>
     </MixedAssignment>
     <MixedMethodCall occurrences="3">
       <code>format</code>
+      <code>format</code>
       <code>getName</code>
+      <code>getName</code>
+      <code>getTimezone</code>
       <code>getTimezone</code>
     </MixedMethodCall>
   </file>

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -74,7 +74,9 @@
     <MixedInferredReturnType occurrences="1">
       <code>HydratorInterface</code>
     </MixedInferredReturnType>
-    <MixedReturnStatement occurrences="1"/>
+    <MixedReturnStatement occurrences="1">
+      <code>$this-&gt;hydrators-&gt;get($object::class)</code>
+    </MixedReturnStatement>
   </file>
   <file src="src/DelegatingHydratorFactory.php">
     <MixedInferredReturnType occurrences="1">
@@ -82,6 +84,7 @@
     </MixedInferredReturnType>
     <MixedReturnStatement occurrences="3">
       <code>$container-&gt;get('HydratorManager')</code>
+      <code>$container-&gt;get('Zend\Hydrator\HydratorPluginManager')</code>
       <code>$container-&gt;get(HydratorPluginManager::class)</code>
     </MixedReturnStatement>
   </file>
@@ -115,7 +118,9 @@
     <MixedAssignment occurrences="1">
       <code>$currentValue</code>
     </MixedAssignment>
-    <MixedMethodCall occurrences="1"/>
+    <MixedMethodCall occurrences="1">
+      <code>new $prototype()</code>
+    </MixedMethodCall>
   </file>
   <file src="src/Module.php">
     <MixedAssignment occurrences="2">
@@ -219,6 +224,26 @@
     <InvalidStringClass occurrences="1">
       <code>new $class()</code>
     </InvalidStringClass>
+  </file>
+  <file src="src/Strategy/BackedEnumStrategy.php">
+    <MixedInferredReturnType occurrences="1">
+      <code>T</code>
+    </MixedInferredReturnType>
+    <MixedReturnStatement occurrences="1">
+      <code>$this-&gt;enumClass::from($value)</code>
+    </MixedReturnStatement>
+    <PropertyNotSetInConstructor occurrences="1">
+      <code>$enumClass</code>
+    </PropertyNotSetInConstructor>
+    <UndefinedClass occurrences="1">
+      <code>$this-&gt;enumClass</code>
+    </UndefinedClass>
+    <UndefinedDocblockClass occurrences="4">
+      <code>$value-&gt;value</code>
+      <code>T</code>
+      <code>class-string&lt;T&gt;</code>
+      <code>string</code>
+    </UndefinedDocblockClass>
   </file>
   <file src="src/Strategy/BooleanStrategy.php">
     <DocblockTypeContradiction occurrences="4">
@@ -358,7 +383,6 @@
       <code>$andFilters</code>
       <code>$orFilters</code>
       <code>$value</code>
-      <code>$value</code>
     </MixedAssignment>
   </file>
   <file src="test/HydratorAwareTraitTest.php">
@@ -409,7 +433,6 @@
   </file>
   <file src="test/HydratorObjectPropertyTest.php">
     <MissingClosureParamType occurrences="1">
-      <code>$property</code>
       <code>$property</code>
     </MissingClosureParamType>
   </file>
@@ -530,8 +553,40 @@
       <code>$instance</code>
     </MixedAssignment>
   </file>
+  <file src="test/Strategy/BackedEnumStrategyTest.php">
+    <MixedArgument occurrences="6">
+      <code>TestBackedEnum::class</code>
+      <code>TestBackedEnum::class</code>
+      <code>TestBackedEnum::class</code>
+      <code>TestBackedEnum::class</code>
+      <code>TestBackedEnum::class</code>
+      <code>TestBackedEnum::class</code>
+    </MixedArgument>
+    <MixedAssignment occurrences="1">
+      <code>$expected</code>
+    </MixedAssignment>
+    <MixedOperand occurrences="1">
+      <code>TestBackedEnum::class</code>
+    </MixedOperand>
+    <UndefinedClass occurrences="12">
+      <code>TestBackedEnum</code>
+      <code>TestBackedEnum</code>
+      <code>TestBackedEnum</code>
+      <code>TestBackedEnum</code>
+      <code>TestBackedEnum</code>
+      <code>TestBackedEnum</code>
+      <code>TestBackedEnum</code>
+      <code>TestBackedEnum</code>
+      <code>TestBackedEnum</code>
+      <code>TestBackedEnum</code>
+      <code>TestBackedEnum</code>
+      <code>TestUnitEnum</code>
+    </UndefinedClass>
+  </file>
   <file src="test/Strategy/BooleanStrategyTest.php">
-    <InvalidArgument occurrences="1"/>
+    <InvalidArgument occurrences="1">
+      <code>false</code>
+    </InvalidArgument>
     <InvalidScalarArgument occurrences="2">
       <code>5</code>
       <code>true</code>
@@ -555,17 +610,13 @@
     <MixedAssignment occurrences="5">
       <code>$date</code>
       <code>$date</code>
-      <code>$date</code>
       <code>$extracted</code>
       <code>$extracted</code>
       <code>$hydrated</code>
     </MixedAssignment>
     <MixedMethodCall occurrences="3">
       <code>format</code>
-      <code>format</code>
       <code>getName</code>
-      <code>getName</code>
-      <code>getTimezone</code>
       <code>getTimezone</code>
     </MixedMethodCall>
   </file>

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -74,7 +74,9 @@
     <MixedInferredReturnType occurrences="1">
       <code>HydratorInterface</code>
     </MixedInferredReturnType>
-    <MixedReturnStatement occurrences="1"/>
+    <MixedReturnStatement occurrences="1">
+      <code>$this-&gt;hydrators-&gt;get($object::class)</code>
+    </MixedReturnStatement>
   </file>
   <file src="src/DelegatingHydratorFactory.php">
     <MixedInferredReturnType occurrences="1">
@@ -82,6 +84,7 @@
     </MixedInferredReturnType>
     <MixedReturnStatement occurrences="3">
       <code>$container-&gt;get('HydratorManager')</code>
+      <code>$container-&gt;get('Zend\Hydrator\HydratorPluginManager')</code>
       <code>$container-&gt;get(HydratorPluginManager::class)</code>
     </MixedReturnStatement>
   </file>
@@ -115,7 +118,9 @@
     <MixedAssignment occurrences="1">
       <code>$currentValue</code>
     </MixedAssignment>
-    <MixedMethodCall occurrences="1"/>
+    <MixedMethodCall occurrences="1">
+      <code>new $prototype()</code>
+    </MixedMethodCall>
   </file>
   <file src="src/Module.php">
     <MixedAssignment occurrences="2">
@@ -219,6 +224,14 @@
     <InvalidStringClass occurrences="1">
       <code>new $class()</code>
     </InvalidStringClass>
+  </file>
+  <file src="src/Strategy/BackedEnumStrategy.php">
+    <MixedInferredReturnType occurrences="1">
+      <code>T</code>
+    </MixedInferredReturnType>
+    <MixedReturnStatement occurrences="1">
+      <code>$this-&gt;enumClass::from($value)</code>
+    </MixedReturnStatement>
   </file>
   <file src="src/Strategy/BooleanStrategy.php">
     <DocblockTypeContradiction occurrences="4">
@@ -358,7 +371,6 @@
       <code>$andFilters</code>
       <code>$orFilters</code>
       <code>$value</code>
-      <code>$value</code>
     </MixedAssignment>
   </file>
   <file src="test/HydratorAwareTraitTest.php">
@@ -409,7 +421,6 @@
   </file>
   <file src="test/HydratorObjectPropertyTest.php">
     <MissingClosureParamType occurrences="1">
-      <code>$property</code>
       <code>$property</code>
     </MissingClosureParamType>
   </file>
@@ -530,8 +541,40 @@
       <code>$instance</code>
     </MixedAssignment>
   </file>
+  <file src="test/Strategy/BackedEnumStrategyTest.php">
+    <MixedArgument occurrences="6">
+      <code>TestBackedEnum::class</code>
+      <code>TestBackedEnum::class</code>
+      <code>TestBackedEnum::class</code>
+      <code>TestBackedEnum::class</code>
+      <code>TestBackedEnum::class</code>
+      <code>TestBackedEnum::class</code>
+    </MixedArgument>
+    <MixedAssignment occurrences="1">
+      <code>$expected</code>
+    </MixedAssignment>
+    <MixedOperand occurrences="1">
+      <code>TestBackedEnum::class</code>
+    </MixedOperand>
+    <UndefinedClass occurrences="12">
+      <code>TestBackedEnum</code>
+      <code>TestBackedEnum</code>
+      <code>TestBackedEnum</code>
+      <code>TestBackedEnum</code>
+      <code>TestBackedEnum</code>
+      <code>TestBackedEnum</code>
+      <code>TestBackedEnum</code>
+      <code>TestBackedEnum</code>
+      <code>TestBackedEnum</code>
+      <code>TestBackedEnum</code>
+      <code>TestBackedEnum</code>
+      <code>TestUnitEnum</code>
+    </UndefinedClass>
+  </file>
   <file src="test/Strategy/BooleanStrategyTest.php">
-    <InvalidArgument occurrences="1"/>
+    <InvalidArgument occurrences="1">
+      <code>false</code>
+    </InvalidArgument>
     <InvalidScalarArgument occurrences="2">
       <code>5</code>
       <code>true</code>
@@ -555,17 +598,13 @@
     <MixedAssignment occurrences="5">
       <code>$date</code>
       <code>$date</code>
-      <code>$date</code>
       <code>$extracted</code>
       <code>$extracted</code>
       <code>$hydrated</code>
     </MixedAssignment>
     <MixedMethodCall occurrences="3">
       <code>format</code>
-      <code>format</code>
       <code>getName</code>
-      <code>getName</code>
-      <code>getTimezone</code>
       <code>getTimezone</code>
     </MixedMethodCall>
   </file>

--- a/psalm.xml
+++ b/psalm.xml
@@ -14,9 +14,7 @@
             <directory name="test/TestAsset"/>
             <directory name="vendor"/>
             <!-- can be removed once PHP8.0 support dropped -->
-            <file name="src/Strategy/BackedEnumStrategy.php"/>
             <directory name="test/Strategy/TestAsset"/>
-            <file name="test/Strategy/BackedEnumStrategyTest.php"/>
         </ignoreFiles>
     </projectFiles>
 

--- a/psalm.xml
+++ b/psalm.xml
@@ -14,6 +14,7 @@
             <directory name="test/TestAsset"/>
             <directory name="vendor"/>
             <!-- can be removed once PHP8.0 support dropped -->
+            <file name="src/Strategy/BackedEnumStrategy.php"/>
             <directory name="test/Strategy/TestAsset"/>
             <file name="test/Strategy/BackedEnumStrategyTest.php"/>
         </ignoreFiles>

--- a/psalm.xml
+++ b/psalm.xml
@@ -14,7 +14,9 @@
             <directory name="test/TestAsset"/>
             <directory name="vendor"/>
             <!-- can be removed once PHP8.0 support dropped -->
+            <file name="src/Strategy/BackedEnumStrategy.php"/>
             <directory name="test/Strategy/TestAsset"/>
+            <file name="test/Strategy/BackedEnumStrategyTest.php"/>
         </ignoreFiles>
     </projectFiles>
 

--- a/psalm.xml
+++ b/psalm.xml
@@ -13,6 +13,9 @@
         <ignoreFiles>
             <directory name="test/TestAsset"/>
             <directory name="vendor"/>
+            <!-- can be removed once PHP8.0 support dropped -->
+            <directory name="test/Strategy/TestAsset"/>
+            <file name="test/Strategy/BackedEnumStrategyTest.php"/>
         </ignoreFiles>
     </projectFiles>
 

--- a/src/Strategy/BackedEnumStrategy.php
+++ b/src/Strategy/BackedEnumStrategy.php
@@ -1,0 +1,81 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Laminas\Hydrator\Strategy;
+
+use BackedEnum;
+use Laminas\Hydrator\Exception\DomainException;
+use Laminas\Hydrator\Strategy\Exception\InvalidArgumentException;
+use ValueError;
+
+use function get_debug_type;
+use function is_a;
+use function is_scalar;
+use function sprintf;
+
+use const PHP_VERSION_ID;
+
+final class BackedEnumStrategy implements StrategyInterface
+{
+    private string $enumClass;
+
+    /**
+     * @param class-string $enumClass
+     */
+    public function __construct(string $enumClass)
+    {
+        if (PHP_VERSION_ID < 80100) {
+            throw new DomainException("Backed enums require PHP 8.1+");
+        }
+
+        if (! is_a($enumClass, BackedEnum::class, true)) {
+            throw new InvalidArgumentException("$enumClass is not a BackedEnum");
+        }
+
+        $this->enumClass = $enumClass;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function extract($value, ?object $object = null)
+    {
+        if (! $value instanceof $this->enumClass) {
+            throw new InvalidArgumentException(sprintf(
+                "Value must be a %s; %s provided",
+                $this->enumClass,
+                get_debug_type($value)
+            ));
+        }
+
+        return $value->value;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function hydrate($value, ?array $data)
+    {
+        if ($value instanceof $this->enumClass) {
+            return $value;
+        }
+
+        if (! is_scalar($value)) {
+            throw new InvalidArgumentException(sprintf(
+                "Value must be scalar; %s provided",
+                get_debug_type($value)
+            ));
+        }
+
+        try {
+            return ($this->enumClass)::from($value);
+        } catch (ValueError $error) {
+            throw new InvalidArgumentException(sprintf(
+                "Value '%s' is not a valid scalar value for %s",
+                $value,
+                $this->enumClass
+            ), 0, $error);
+        }
+    }
+}

--- a/src/Strategy/BackedEnumStrategy.php
+++ b/src/Strategy/BackedEnumStrategy.php
@@ -9,15 +9,19 @@ use Laminas\Hydrator\Exception\DomainException;
 use Laminas\Hydrator\Strategy\Exception\InvalidArgumentException;
 use ValueError;
 
+use function assert;
 use function get_debug_type;
 use function is_a;
+use function is_object;
 use function is_scalar;
+use function property_exists;
 use function sprintf;
 
 use const PHP_VERSION_ID;
 
 final class BackedEnumStrategy implements StrategyInterface
 {
+    /** @var class-string  */
     private string $enumClass;
 
     /**
@@ -49,6 +53,7 @@ final class BackedEnumStrategy implements StrategyInterface
             ));
         }
 
+        assert(is_object($value) && property_exists($value, 'value'));
         return $value->value;
     }
 
@@ -69,11 +74,12 @@ final class BackedEnumStrategy implements StrategyInterface
         }
 
         try {
-            return ($this->enumClass)::from($value);
+            /** @psalm-suppress MixedMethodCall */
+            return $this->enumClass::from($value);
         } catch (ValueError $error) {
             throw new InvalidArgumentException(sprintf(
                 "Value '%s' is not a valid scalar value for %s",
-                $value,
+                (string) $value,
                 $this->enumClass
             ), 0, $error);
         }

--- a/src/Strategy/BackedEnumStrategy.php
+++ b/src/Strategy/BackedEnumStrategy.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Laminas\Hydrator\Strategy;
 
 use BackedEnum;
-use Laminas\Hydrator\Exception\DomainException;
 use Laminas\Hydrator\Strategy\Exception\InvalidArgumentException;
 use ValueError;
 
@@ -17,8 +16,6 @@ use function is_scalar;
 use function property_exists;
 use function sprintf;
 
-use const PHP_VERSION_ID;
-
 final class BackedEnumStrategy implements StrategyInterface
 {
     /** @var class-string  */
@@ -29,10 +26,6 @@ final class BackedEnumStrategy implements StrategyInterface
      */
     public function __construct(string $enumClass)
     {
-        if (PHP_VERSION_ID < 80100) {
-            throw new DomainException("Backed enums require PHP 8.1+");
-        }
-
         if (! is_a($enumClass, BackedEnum::class, true)) {
             throw new InvalidArgumentException("$enumClass is not a BackedEnum");
         }

--- a/src/Strategy/BackedEnumStrategy.php
+++ b/src/Strategy/BackedEnumStrategy.php
@@ -8,28 +8,24 @@ use BackedEnum;
 use Laminas\Hydrator\Strategy\Exception\InvalidArgumentException;
 use ValueError;
 
-use function assert;
 use function get_debug_type;
-use function is_a;
-use function is_object;
-use function is_scalar;
-use function property_exists;
+use function is_int;
+use function is_string;
 use function sprintf;
 
+/**
+ * @template T of BackedEnum
+ */
 final class BackedEnumStrategy implements StrategyInterface
 {
-    /** @var class-string  */
+    /** @var class-string<T> */
     private string $enumClass;
 
     /**
-     * @param class-string $enumClass
+     * @param class-string<T> $enumClass
      */
     public function __construct(string $enumClass)
     {
-        if (! is_a($enumClass, BackedEnum::class, true)) {
-            throw new InvalidArgumentException("$enumClass is not a BackedEnum");
-        }
-
         $this->enumClass = $enumClass;
     }
 
@@ -46,12 +42,12 @@ final class BackedEnumStrategy implements StrategyInterface
             ));
         }
 
-        assert(is_object($value) && property_exists($value, 'value'));
         return $value->value;
     }
 
     /**
-     * @inheritDoc
+     * @param mixed $value
+     * @return T
      */
     public function hydrate($value, ?array $data)
     {
@@ -59,15 +55,14 @@ final class BackedEnumStrategy implements StrategyInterface
             return $value;
         }
 
-        if (! is_scalar($value)) {
+        if (! (is_int($value) || is_string($value))) {
             throw new InvalidArgumentException(sprintf(
-                "Value must be scalar; %s provided",
+                "Value must be string or int; %s provided",
                 get_debug_type($value)
             ));
         }
 
         try {
-            /** @psalm-suppress MixedMethodCall */
             return $this->enumClass::from($value);
         } catch (ValueError $error) {
             throw new InvalidArgumentException(sprintf(

--- a/test/Strategy/BackedEnumStrategyTest.php
+++ b/test/Strategy/BackedEnumStrategyTest.php
@@ -1,0 +1,105 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LaminasTest\Hydrator\Strategy;
+
+use Laminas\Hydrator\Exception\DomainException;
+use Laminas\Hydrator\Strategy\BackedEnumStrategy;
+use Laminas\Hydrator\Strategy\Exception\InvalidArgumentException;
+use LaminasTest\Hydrator\Strategy\TestAsset\TestBackedEnum;
+use LaminasTest\Hydrator\Strategy\TestAsset\TestUnitEnum;
+use PHPUnit\Framework\TestCase;
+
+use const PHP_VERSION_ID;
+
+/**
+ * @uses \Laminas\Hydrator\Exception\DomainException
+ * @uses \Laminas\Hydrator\Strategy\Exception\InvalidArgumentException
+ *
+ * @covers \Laminas\Hydrator\Strategy\BackedEnumStrategy
+ */
+final class BackedEnumStrategyTest extends TestCase
+{
+    public function testConstructInvalidPhpVersionThrowsException(): void
+    {
+        if (PHP_VERSION_ID >= 80100) {
+            self::markTestSkipped("PHP >=8.1 detected");
+        }
+
+        self::expectException(DomainException::class);
+        new BackedEnumStrategy(TestBackedEnum::class);
+    }
+
+    public function testConstructUnitEnumThrowsException(): void
+    {
+        $this->checkVersion();
+
+        self::expectException(InvalidArgumentException::class);
+        new BackedEnumStrategy(TestUnitEnum::class);
+    }
+
+    public function testExtractInvalidValueThrowsException(): void
+    {
+        $this->checkVersion();
+
+        $strategy = new BackedEnumStrategy(TestBackedEnum::class);
+        self::expectException(InvalidArgumentException::class);
+        $strategy->extract(TestUnitEnum::One);
+    }
+
+    public function testExtractExtractsValue(): void
+    {
+        $this->checkVersion();
+
+        $strategy = new BackedEnumStrategy(TestBackedEnum::class);
+        $actual   = $strategy->extract(TestBackedEnum::One);
+        self::assertSame('one', $actual);
+    }
+
+    public function testHydrateEnumReturnsEnum(): void
+    {
+        $this->checkVersion();
+
+        $expected = TestBackedEnum::Two;
+        $strategy = new BackedEnumStrategy(TestBackedEnum::class);
+        $actual   = $strategy->hydrate($expected, null);
+        self::assertSame(TestBackedEnum::Two, $actual);
+    }
+
+    public function testHydrateNonScalarThrowsException(): void
+    {
+        $this->checkVersion();
+
+        $strategy = new BackedEnumStrategy(TestBackedEnum::class);
+        self::expectException(InvalidArgumentException::class);
+        self::expectExceptionMessage("Value must be scalar; array provided");
+        $strategy->hydrate([], null);
+    }
+
+    public function testHydrateNonCaseThrowsException(): void
+    {
+        $this->checkVersion();
+
+        $strategy = new BackedEnumStrategy(TestBackedEnum::class);
+        self::expectException(InvalidArgumentException::class);
+        self::expectExceptionMessage("Value 'three' is not a valid scalar value for " . TestBackedEnum::class);
+        $strategy->hydrate('three', null);
+    }
+
+    public function testHydrateValueReturnsEnum(): void
+    {
+        $this->checkVersion();
+
+        $strategy = new BackedEnumStrategy(TestBackedEnum::class);
+        $actual   = $strategy->hydrate('two', null);
+        self::assertSame(TestBackedEnum::Two, $actual);
+    }
+
+    private function checkVersion(): void
+    {
+        if (PHP_VERSION_ID < 80100) {
+            self::markTestSkipped("PHP 8.1+ required");
+        }
+    }
+}

--- a/test/Strategy/BackedEnumStrategyTest.php
+++ b/test/Strategy/BackedEnumStrategyTest.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace LaminasTest\Hydrator\Strategy;
 
-use Laminas\Hydrator\Exception\DomainException;
 use Laminas\Hydrator\Strategy\BackedEnumStrategy;
 use Laminas\Hydrator\Strategy\Exception\InvalidArgumentException;
 use LaminasTest\Hydrator\Strategy\TestAsset\TestBackedEnum;
@@ -21,28 +20,23 @@ use const PHP_VERSION_ID;
  */
 final class BackedEnumStrategyTest extends TestCase
 {
-    public function testConstructInvalidPhpVersionThrowsException(): void
+    protected function setUp(): void
     {
-        if (PHP_VERSION_ID >= 80100) {
-            self::markTestSkipped("PHP >=8.1 detected");
-        }
+        parent::setUp();
 
-        self::expectException(DomainException::class);
-        new BackedEnumStrategy(TestBackedEnum::class);
+        if (PHP_VERSION_ID < 80100) {
+            self::markTestSkipped("PHP 8.1+ required");
+        }
     }
 
     public function testConstructUnitEnumThrowsException(): void
     {
-        $this->checkVersion();
-
         self::expectException(InvalidArgumentException::class);
         new BackedEnumStrategy(TestUnitEnum::class);
     }
 
     public function testExtractInvalidValueThrowsException(): void
     {
-        $this->checkVersion();
-
         $strategy = new BackedEnumStrategy(TestBackedEnum::class);
         self::expectException(InvalidArgumentException::class);
         $strategy->extract(TestUnitEnum::One);
@@ -50,8 +44,6 @@ final class BackedEnumStrategyTest extends TestCase
 
     public function testExtractExtractsValue(): void
     {
-        $this->checkVersion();
-
         $strategy = new BackedEnumStrategy(TestBackedEnum::class);
         $actual   = $strategy->extract(TestBackedEnum::One);
         self::assertSame('one', $actual);
@@ -59,8 +51,6 @@ final class BackedEnumStrategyTest extends TestCase
 
     public function testHydrateEnumReturnsEnum(): void
     {
-        $this->checkVersion();
-
         $expected = TestBackedEnum::Two;
         $strategy = new BackedEnumStrategy(TestBackedEnum::class);
         $actual   = $strategy->hydrate($expected, null);
@@ -69,8 +59,6 @@ final class BackedEnumStrategyTest extends TestCase
 
     public function testHydrateNonScalarThrowsException(): void
     {
-        $this->checkVersion();
-
         $strategy = new BackedEnumStrategy(TestBackedEnum::class);
         self::expectException(InvalidArgumentException::class);
         self::expectExceptionMessage("Value must be scalar; array provided");
@@ -79,8 +67,6 @@ final class BackedEnumStrategyTest extends TestCase
 
     public function testHydrateNonCaseThrowsException(): void
     {
-        $this->checkVersion();
-
         $strategy = new BackedEnumStrategy(TestBackedEnum::class);
         self::expectException(InvalidArgumentException::class);
         self::expectExceptionMessage("Value 'three' is not a valid scalar value for " . TestBackedEnum::class);
@@ -89,17 +75,8 @@ final class BackedEnumStrategyTest extends TestCase
 
     public function testHydrateValueReturnsEnum(): void
     {
-        $this->checkVersion();
-
         $strategy = new BackedEnumStrategy(TestBackedEnum::class);
         $actual   = $strategy->hydrate('two', null);
         self::assertSame(TestBackedEnum::Two, $actual);
-    }
-
-    private function checkVersion(): void
-    {
-        if (PHP_VERSION_ID < 80100) {
-            self::markTestSkipped("PHP 8.1+ required");
-        }
     }
 }

--- a/test/Strategy/BackedEnumStrategyTest.php
+++ b/test/Strategy/BackedEnumStrategyTest.php
@@ -29,12 +29,6 @@ final class BackedEnumStrategyTest extends TestCase
         }
     }
 
-    public function testConstructUnitEnumThrowsException(): void
-    {
-        self::expectException(InvalidArgumentException::class);
-        new BackedEnumStrategy(TestUnitEnum::class);
-    }
-
     public function testExtractInvalidValueThrowsException(): void
     {
         $strategy = new BackedEnumStrategy(TestBackedEnum::class);
@@ -61,7 +55,7 @@ final class BackedEnumStrategyTest extends TestCase
     {
         $strategy = new BackedEnumStrategy(TestBackedEnum::class);
         self::expectException(InvalidArgumentException::class);
-        self::expectExceptionMessage("Value must be scalar; array provided");
+        self::expectExceptionMessage("Value must be string or int; array provided");
         $strategy->hydrate([], null);
     }
 

--- a/test/Strategy/TestAsset/TestBackedEnum.php
+++ b/test/Strategy/TestAsset/TestBackedEnum.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LaminasTest\Hydrator\Strategy\TestAsset;
+
+enum TestBackedEnum: string
+{
+    case One = 'one';
+    case Two = 'two';
+}

--- a/test/Strategy/TestAsset/TestUnitEnum.php
+++ b/test/Strategy/TestAsset/TestUnitEnum.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LaminasTest\Hydrator\Strategy\TestAsset;
+
+enum TestUnitEnum
+{
+    case One;
+    case Two;
+}


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | yes
| Bugfix        | no
| BC Break      | no
| New Feature   | yes
| RFC           | no
| QA            | no

### Description

This adds a BackedEnumStrategy for hydrating / extracting (PHP81+) backed enums. See the changes to docs/book/strategy.md for usage example.
