### PR TITLE
Fixed errors running phpcs under PHP 8.1

### DIFF
--- a/test/TestAsset/ArrayObjectIterator.php
+++ b/test/TestAsset/ArrayObjectIterator.php
@@ -24,32 +24,28 @@ class ArrayObjectIterator implements Iterator
         }
     }
 
-    /** @return void */
-    public function rewind()
+    public function rewind(): void
     {
         reset($this->var);
     }
 
-    /** @return mixed */
-    public function current()
+    public function current(): mixed
     {
         return current($this->var);
     }
 
     /** @return int|string */
-    public function key()
+    public function key(): mixed
     {
         return key($this->var);
     }
 
-    /** @return mixed */
-    public function next()
+    public function next(): void
     {
-        return next($this->var);
+        next($this->var);
     }
 
-    /** @return bool */
-    public function valid()
+    public function valid(): bool
     {
         $key = key($this->var);
         return $key !== null && $key !== false;


### PR DESCRIPTION

|    Q          |   A
|-------------- | ------
| Bugfix        | yes

### Description

`phpcs` barfs when running under PHP8.1:
```
PHP Fatal error:  During inheritance of Iterator: Uncaught PHP_CodeSniffer\Exceptions\RuntimeException: Return type of LaminasTest\Hydrator\TestAsset\ArrayObjectIterator::current() should either be compatible with Iterator::current(): mixed, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice
```

Funny, I would've thought that would make CI fail, but I guess not 🤷 