### PR TITLE
Remove Support for PHP 8.0, Upgrade PHPUnit to 10.x

### DIFF
--- a/.laminas-ci.json
+++ b/.laminas-ci.json
@@ -1,6 +1,2 @@
 {
-    "ignore_php_platform_requirements": {
-        "8.1": false,
-        "8.2": true
-    }
 }

--- a/composer.json
+++ b/composer.json
@@ -42,7 +42,7 @@
         "laminas/laminas-serializer": "^2.14.0",
         "laminas/laminas-servicemanager": "^3.21",
         "phpbench/phpbench": "^1.2.10",
-        "phpunit/phpunit": "^9.6.8",
+        "phpunit/phpunit": "^10.1.3",
         "psalm/plugin-phpunit": "^0.18.4",
         "vimeo/psalm": "^5.11"
     },

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
             "dealerdirect/phpcodesniffer-composer-installer": true
         },
         "platform": {
-            "php": "8.0.99"
+            "php": "8.1.99"
         }
     },
     "extra": {
@@ -31,7 +31,7 @@
         }
     },
     "require": {
-        "php": "~8.0.0 || ~8.1.0 || ~8.2.0",
+        "php": "~8.1.0 || ~8.2.0",
         "laminas/laminas-stdlib": "^3.3",
         "webmozart/assert": "^1.10"
     },
@@ -40,11 +40,11 @@
         "laminas/laminas-eventmanager": "^3.10",
         "laminas/laminas-modulemanager": "^2.14.0",
         "laminas/laminas-serializer": "^2.14.0",
-        "laminas/laminas-servicemanager": "^3.20",
-        "phpbench/phpbench": "^1.2.8",
-        "phpunit/phpunit": "^9.5.28",
+        "laminas/laminas-servicemanager": "^3.21",
+        "phpbench/phpbench": "^1.2.10",
+        "phpunit/phpunit": "^9.6.8",
         "psalm/plugin-phpunit": "^0.18.4",
-        "vimeo/psalm": "^5.6"
+        "vimeo/psalm": "^5.11"
     },
     "suggest": {
         "laminas/laminas-eventmanager": "^3.2, to support aggregate hydrator usage",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "61e6cf398c1f608dfc037cce1e39082e",
+    "content-hash": "9c887678a116d572457176503d28cfa9",
     "packages": [
         {
             "name": "laminas/laminas-stdlib",
@@ -818,76 +818,6 @@
                 "source": "https://github.com/doctrine/annotations/tree/2.0.1"
             },
             "time": "2023-02-02T22:02:53+00:00"
-        },
-        {
-            "name": "doctrine/instantiator",
-            "version": "2.0.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/doctrine/instantiator.git",
-                "reference": "c6222283fa3f4ac679f8b9ced9a4e23f163e80d0"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/instantiator/zipball/c6222283fa3f4ac679f8b9ced9a4e23f163e80d0",
-                "reference": "c6222283fa3f4ac679f8b9ced9a4e23f163e80d0",
-                "shasum": ""
-            },
-            "require": {
-                "php": "^8.1"
-            },
-            "require-dev": {
-                "doctrine/coding-standard": "^11",
-                "ext-pdo": "*",
-                "ext-phar": "*",
-                "phpbench/phpbench": "^1.2",
-                "phpstan/phpstan": "^1.9.4",
-                "phpstan/phpstan-phpunit": "^1.3",
-                "phpunit/phpunit": "^9.5.27",
-                "vimeo/psalm": "^5.4"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "Doctrine\\Instantiator\\": "src/Doctrine/Instantiator/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Marco Pivetta",
-                    "email": "ocramius@gmail.com",
-                    "homepage": "https://ocramius.github.io/"
-                }
-            ],
-            "description": "A small, lightweight utility to instantiate objects in PHP without invoking their constructors",
-            "homepage": "https://www.doctrine-project.org/projects/instantiator.html",
-            "keywords": [
-                "constructor",
-                "instantiate"
-            ],
-            "support": {
-                "issues": "https://github.com/doctrine/instantiator/issues",
-                "source": "https://github.com/doctrine/instantiator/tree/2.0.0"
-            },
-            "funding": [
-                {
-                    "url": "https://www.doctrine-project.org/sponsorship.html",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://www.patreon.com/phpdoctrine",
-                    "type": "patreon"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/doctrine%2Finstantiator",
-                    "type": "tidelift"
-                }
-            ],
-            "time": "2022-12-30T00:23:10+00:00"
         },
         {
             "name": "doctrine/lexer",
@@ -2294,16 +2224,16 @@
         },
         {
             "name": "phpunit/php-code-coverage",
-            "version": "9.2.26",
+            "version": "10.1.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
-                "reference": "443bc6912c9bd5b409254a40f4b0f4ced7c80ea1"
+                "reference": "884a0da7f9f46f28b2cb69134217fd810b793974"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/443bc6912c9bd5b409254a40f4b0f4ced7c80ea1",
-                "reference": "443bc6912c9bd5b409254a40f4b0f4ced7c80ea1",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/884a0da7f9f46f28b2cb69134217fd810b793974",
+                "reference": "884a0da7f9f46f28b2cb69134217fd810b793974",
                 "shasum": ""
             },
             "require": {
@@ -2311,18 +2241,18 @@
                 "ext-libxml": "*",
                 "ext-xmlwriter": "*",
                 "nikic/php-parser": "^4.15",
-                "php": ">=7.3",
-                "phpunit/php-file-iterator": "^3.0.3",
-                "phpunit/php-text-template": "^2.0.2",
-                "sebastian/code-unit-reverse-lookup": "^2.0.2",
-                "sebastian/complexity": "^2.0",
-                "sebastian/environment": "^5.1.2",
-                "sebastian/lines-of-code": "^1.0.3",
-                "sebastian/version": "^3.0.1",
+                "php": ">=8.1",
+                "phpunit/php-file-iterator": "^4.0",
+                "phpunit/php-text-template": "^3.0",
+                "sebastian/code-unit-reverse-lookup": "^3.0",
+                "sebastian/complexity": "^3.0",
+                "sebastian/environment": "^6.0",
+                "sebastian/lines-of-code": "^2.0",
+                "sebastian/version": "^4.0",
                 "theseer/tokenizer": "^1.2.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "^9.3"
+                "phpunit/phpunit": "^10.1"
             },
             "suggest": {
                 "ext-pcov": "PHP extension that provides line coverage",
@@ -2331,7 +2261,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "9.2-dev"
+                    "dev-main": "10.1-dev"
                 }
             },
             "autoload": {
@@ -2359,7 +2289,8 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/php-code-coverage/issues",
-                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/9.2.26"
+                "security": "https://github.com/sebastianbergmann/php-code-coverage/security/policy",
+                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/10.1.1"
             },
             "funding": [
                 {
@@ -2367,32 +2298,32 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-03-06T12:58:08+00:00"
+            "time": "2023-04-17T12:15:40+00:00"
         },
         {
             "name": "phpunit/php-file-iterator",
-            "version": "3.0.6",
+            "version": "4.0.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-file-iterator.git",
-                "reference": "cf1c2e7c203ac650e352f4cc675a7021e7d1b3cf"
+                "reference": "5647d65443818959172645e7ed999217360654b6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/cf1c2e7c203ac650e352f4cc675a7021e7d1b3cf",
-                "reference": "cf1c2e7c203ac650e352f4cc675a7021e7d1b3cf",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/5647d65443818959172645e7ed999217360654b6",
+                "reference": "5647d65443818959172645e7ed999217360654b6",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.3"
+                "php": ">=8.1"
             },
             "require-dev": {
-                "phpunit/phpunit": "^9.3"
+                "phpunit/phpunit": "^10.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.0-dev"
+                    "dev-main": "4.0-dev"
                 }
             },
             "autoload": {
@@ -2419,7 +2350,8 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/php-file-iterator/issues",
-                "source": "https://github.com/sebastianbergmann/php-file-iterator/tree/3.0.6"
+                "security": "https://github.com/sebastianbergmann/php-file-iterator/security/policy",
+                "source": "https://github.com/sebastianbergmann/php-file-iterator/tree/4.0.2"
             },
             "funding": [
                 {
@@ -2427,28 +2359,28 @@
                     "type": "github"
                 }
             ],
-            "time": "2021-12-02T12:48:52+00:00"
+            "time": "2023-05-07T09:13:23+00:00"
         },
         {
             "name": "phpunit/php-invoker",
-            "version": "3.1.1",
+            "version": "4.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-invoker.git",
-                "reference": "5a10147d0aaf65b58940a0b72f71c9ac0423cc67"
+                "reference": "f5e568ba02fa5ba0ddd0f618391d5a9ea50b06d7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-invoker/zipball/5a10147d0aaf65b58940a0b72f71c9ac0423cc67",
-                "reference": "5a10147d0aaf65b58940a0b72f71c9ac0423cc67",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-invoker/zipball/f5e568ba02fa5ba0ddd0f618391d5a9ea50b06d7",
+                "reference": "f5e568ba02fa5ba0ddd0f618391d5a9ea50b06d7",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.3"
+                "php": ">=8.1"
             },
             "require-dev": {
                 "ext-pcntl": "*",
-                "phpunit/phpunit": "^9.3"
+                "phpunit/phpunit": "^10.0"
             },
             "suggest": {
                 "ext-pcntl": "*"
@@ -2456,7 +2388,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.1-dev"
+                    "dev-main": "4.0-dev"
                 }
             },
             "autoload": {
@@ -2482,7 +2414,7 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/php-invoker/issues",
-                "source": "https://github.com/sebastianbergmann/php-invoker/tree/3.1.1"
+                "source": "https://github.com/sebastianbergmann/php-invoker/tree/4.0.0"
             },
             "funding": [
                 {
@@ -2490,32 +2422,32 @@
                     "type": "github"
                 }
             ],
-            "time": "2020-09-28T05:58:55+00:00"
+            "time": "2023-02-03T06:56:09+00:00"
         },
         {
             "name": "phpunit/php-text-template",
-            "version": "2.0.4",
+            "version": "3.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-text-template.git",
-                "reference": "5da5f67fc95621df9ff4c4e5a84d6a8a2acf7c28"
+                "reference": "9f3d3709577a527025f55bcf0f7ab8052c8bb37d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-text-template/zipball/5da5f67fc95621df9ff4c4e5a84d6a8a2acf7c28",
-                "reference": "5da5f67fc95621df9ff4c4e5a84d6a8a2acf7c28",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-text-template/zipball/9f3d3709577a527025f55bcf0f7ab8052c8bb37d",
+                "reference": "9f3d3709577a527025f55bcf0f7ab8052c8bb37d",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.3"
+                "php": ">=8.1"
             },
             "require-dev": {
-                "phpunit/phpunit": "^9.3"
+                "phpunit/phpunit": "^10.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.0-dev"
+                    "dev-main": "3.0-dev"
                 }
             },
             "autoload": {
@@ -2541,7 +2473,7 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/php-text-template/issues",
-                "source": "https://github.com/sebastianbergmann/php-text-template/tree/2.0.4"
+                "source": "https://github.com/sebastianbergmann/php-text-template/tree/3.0.0"
             },
             "funding": [
                 {
@@ -2549,32 +2481,32 @@
                     "type": "github"
                 }
             ],
-            "time": "2020-10-26T05:33:50+00:00"
+            "time": "2023-02-03T06:56:46+00:00"
         },
         {
             "name": "phpunit/php-timer",
-            "version": "5.0.3",
+            "version": "6.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-timer.git",
-                "reference": "5a63ce20ed1b5bf577850e2c4e87f4aa902afbd2"
+                "reference": "e2a2d67966e740530f4a3343fe2e030ffdc1161d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-timer/zipball/5a63ce20ed1b5bf577850e2c4e87f4aa902afbd2",
-                "reference": "5a63ce20ed1b5bf577850e2c4e87f4aa902afbd2",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-timer/zipball/e2a2d67966e740530f4a3343fe2e030ffdc1161d",
+                "reference": "e2a2d67966e740530f4a3343fe2e030ffdc1161d",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.3"
+                "php": ">=8.1"
             },
             "require-dev": {
-                "phpunit/phpunit": "^9.3"
+                "phpunit/phpunit": "^10.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "5.0-dev"
+                    "dev-main": "6.0-dev"
                 }
             },
             "autoload": {
@@ -2600,7 +2532,7 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/php-timer/issues",
-                "source": "https://github.com/sebastianbergmann/php-timer/tree/5.0.3"
+                "source": "https://github.com/sebastianbergmann/php-timer/tree/6.0.0"
             },
             "funding": [
                 {
@@ -2608,24 +2540,23 @@
                     "type": "github"
                 }
             ],
-            "time": "2020-10-26T13:16:10+00:00"
+            "time": "2023-02-03T06:57:52+00:00"
         },
         {
             "name": "phpunit/phpunit",
-            "version": "9.6.8",
+            "version": "10.1.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "17d621b3aff84d0c8b62539e269e87d8d5baa76e"
+                "reference": "2379ebafc1737e71cdc84f402acb6b7f04198b9d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/17d621b3aff84d0c8b62539e269e87d8d5baa76e",
-                "reference": "17d621b3aff84d0c8b62539e269e87d8d5baa76e",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/2379ebafc1737e71cdc84f402acb6b7f04198b9d",
+                "reference": "2379ebafc1737e71cdc84f402acb6b7f04198b9d",
                 "shasum": ""
             },
             "require": {
-                "doctrine/instantiator": "^1.3.1 || ^2",
                 "ext-dom": "*",
                 "ext-json": "*",
                 "ext-libxml": "*",
@@ -2635,27 +2566,26 @@
                 "myclabs/deep-copy": "^1.10.1",
                 "phar-io/manifest": "^2.0.3",
                 "phar-io/version": "^3.0.2",
-                "php": ">=7.3",
-                "phpunit/php-code-coverage": "^9.2.13",
-                "phpunit/php-file-iterator": "^3.0.5",
-                "phpunit/php-invoker": "^3.1.1",
-                "phpunit/php-text-template": "^2.0.3",
-                "phpunit/php-timer": "^5.0.2",
-                "sebastian/cli-parser": "^1.0.1",
-                "sebastian/code-unit": "^1.0.6",
-                "sebastian/comparator": "^4.0.8",
-                "sebastian/diff": "^4.0.3",
-                "sebastian/environment": "^5.1.3",
-                "sebastian/exporter": "^4.0.5",
-                "sebastian/global-state": "^5.0.1",
-                "sebastian/object-enumerator": "^4.0.3",
-                "sebastian/resource-operations": "^3.0.3",
-                "sebastian/type": "^3.2",
-                "sebastian/version": "^3.0.2"
+                "php": ">=8.1",
+                "phpunit/php-code-coverage": "^10.1.1",
+                "phpunit/php-file-iterator": "^4.0",
+                "phpunit/php-invoker": "^4.0",
+                "phpunit/php-text-template": "^3.0",
+                "phpunit/php-timer": "^6.0",
+                "sebastian/cli-parser": "^2.0",
+                "sebastian/code-unit": "^2.0",
+                "sebastian/comparator": "^5.0",
+                "sebastian/diff": "^5.0",
+                "sebastian/environment": "^6.0",
+                "sebastian/exporter": "^5.0",
+                "sebastian/global-state": "^6.0",
+                "sebastian/object-enumerator": "^5.0",
+                "sebastian/recursion-context": "^5.0",
+                "sebastian/type": "^4.0",
+                "sebastian/version": "^4.0"
             },
             "suggest": {
-                "ext-soap": "To be able to generate mocks based on WSDL files",
-                "ext-xdebug": "PHP extension that provides line coverage as well as branch and path coverage"
+                "ext-soap": "To be able to generate mocks based on WSDL files"
             },
             "bin": [
                 "phpunit"
@@ -2663,7 +2593,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "9.6-dev"
+                    "dev-main": "10.1-dev"
                 }
             },
             "autoload": {
@@ -2695,7 +2625,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/phpunit/issues",
                 "security": "https://github.com/sebastianbergmann/phpunit/security/policy",
-                "source": "https://github.com/sebastianbergmann/phpunit/tree/9.6.8"
+                "source": "https://github.com/sebastianbergmann/phpunit/tree/10.1.3"
             },
             "funding": [
                 {
@@ -2711,7 +2641,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-05-11T05:14:45+00:00"
+            "time": "2023-05-11T05:16:22+00:00"
         },
         {
             "name": "psalm/plugin-phpunit",
@@ -2922,28 +2852,28 @@
         },
         {
             "name": "sebastian/cli-parser",
-            "version": "1.0.1",
+            "version": "2.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/cli-parser.git",
-                "reference": "442e7c7e687e42adc03470c7b668bc4b2402c0b2"
+                "reference": "efdc130dbbbb8ef0b545a994fd811725c5282cae"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/cli-parser/zipball/442e7c7e687e42adc03470c7b668bc4b2402c0b2",
-                "reference": "442e7c7e687e42adc03470c7b668bc4b2402c0b2",
+                "url": "https://api.github.com/repos/sebastianbergmann/cli-parser/zipball/efdc130dbbbb8ef0b545a994fd811725c5282cae",
+                "reference": "efdc130dbbbb8ef0b545a994fd811725c5282cae",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.3"
+                "php": ">=8.1"
             },
             "require-dev": {
-                "phpunit/phpunit": "^9.3"
+                "phpunit/phpunit": "^10.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.0-dev"
+                    "dev-main": "2.0-dev"
                 }
             },
             "autoload": {
@@ -2966,7 +2896,7 @@
             "homepage": "https://github.com/sebastianbergmann/cli-parser",
             "support": {
                 "issues": "https://github.com/sebastianbergmann/cli-parser/issues",
-                "source": "https://github.com/sebastianbergmann/cli-parser/tree/1.0.1"
+                "source": "https://github.com/sebastianbergmann/cli-parser/tree/2.0.0"
             },
             "funding": [
                 {
@@ -2974,32 +2904,32 @@
                     "type": "github"
                 }
             ],
-            "time": "2020-09-28T06:08:49+00:00"
+            "time": "2023-02-03T06:58:15+00:00"
         },
         {
             "name": "sebastian/code-unit",
-            "version": "1.0.8",
+            "version": "2.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/code-unit.git",
-                "reference": "1fc9f64c0927627ef78ba436c9b17d967e68e120"
+                "reference": "a81fee9eef0b7a76af11d121767abc44c104e503"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/code-unit/zipball/1fc9f64c0927627ef78ba436c9b17d967e68e120",
-                "reference": "1fc9f64c0927627ef78ba436c9b17d967e68e120",
+                "url": "https://api.github.com/repos/sebastianbergmann/code-unit/zipball/a81fee9eef0b7a76af11d121767abc44c104e503",
+                "reference": "a81fee9eef0b7a76af11d121767abc44c104e503",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.3"
+                "php": ">=8.1"
             },
             "require-dev": {
-                "phpunit/phpunit": "^9.3"
+                "phpunit/phpunit": "^10.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.0-dev"
+                    "dev-main": "2.0-dev"
                 }
             },
             "autoload": {
@@ -3022,7 +2952,7 @@
             "homepage": "https://github.com/sebastianbergmann/code-unit",
             "support": {
                 "issues": "https://github.com/sebastianbergmann/code-unit/issues",
-                "source": "https://github.com/sebastianbergmann/code-unit/tree/1.0.8"
+                "source": "https://github.com/sebastianbergmann/code-unit/tree/2.0.0"
             },
             "funding": [
                 {
@@ -3030,32 +2960,32 @@
                     "type": "github"
                 }
             ],
-            "time": "2020-10-26T13:08:54+00:00"
+            "time": "2023-02-03T06:58:43+00:00"
         },
         {
             "name": "sebastian/code-unit-reverse-lookup",
-            "version": "2.0.3",
+            "version": "3.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/code-unit-reverse-lookup.git",
-                "reference": "ac91f01ccec49fb77bdc6fd1e548bc70f7faa3e5"
+                "reference": "5e3a687f7d8ae33fb362c5c0743794bbb2420a1d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/code-unit-reverse-lookup/zipball/ac91f01ccec49fb77bdc6fd1e548bc70f7faa3e5",
-                "reference": "ac91f01ccec49fb77bdc6fd1e548bc70f7faa3e5",
+                "url": "https://api.github.com/repos/sebastianbergmann/code-unit-reverse-lookup/zipball/5e3a687f7d8ae33fb362c5c0743794bbb2420a1d",
+                "reference": "5e3a687f7d8ae33fb362c5c0743794bbb2420a1d",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.3"
+                "php": ">=8.1"
             },
             "require-dev": {
-                "phpunit/phpunit": "^9.3"
+                "phpunit/phpunit": "^10.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.0-dev"
+                    "dev-main": "3.0-dev"
                 }
             },
             "autoload": {
@@ -3077,7 +3007,7 @@
             "homepage": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/",
             "support": {
                 "issues": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/issues",
-                "source": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/tree/2.0.3"
+                "source": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/tree/3.0.0"
             },
             "funding": [
                 {
@@ -3085,34 +3015,36 @@
                     "type": "github"
                 }
             ],
-            "time": "2020-09-28T05:30:19+00:00"
+            "time": "2023-02-03T06:59:15+00:00"
         },
         {
             "name": "sebastian/comparator",
-            "version": "4.0.8",
+            "version": "5.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/comparator.git",
-                "reference": "fa0f136dd2334583309d32b62544682ee972b51a"
+                "reference": "72f01e6586e0caf6af81297897bd112eb7e9627c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/fa0f136dd2334583309d32b62544682ee972b51a",
-                "reference": "fa0f136dd2334583309d32b62544682ee972b51a",
+                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/72f01e6586e0caf6af81297897bd112eb7e9627c",
+                "reference": "72f01e6586e0caf6af81297897bd112eb7e9627c",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.3",
-                "sebastian/diff": "^4.0",
-                "sebastian/exporter": "^4.0"
+                "ext-dom": "*",
+                "ext-mbstring": "*",
+                "php": ">=8.1",
+                "sebastian/diff": "^5.0",
+                "sebastian/exporter": "^5.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "^9.3"
+                "phpunit/phpunit": "^10.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "4.0-dev"
+                    "dev-main": "5.0-dev"
                 }
             },
             "autoload": {
@@ -3151,7 +3083,7 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/comparator/issues",
-                "source": "https://github.com/sebastianbergmann/comparator/tree/4.0.8"
+                "source": "https://github.com/sebastianbergmann/comparator/tree/5.0.0"
             },
             "funding": [
                 {
@@ -3159,33 +3091,33 @@
                     "type": "github"
                 }
             ],
-            "time": "2022-09-14T12:41:17+00:00"
+            "time": "2023-02-03T07:07:16+00:00"
         },
         {
             "name": "sebastian/complexity",
-            "version": "2.0.2",
+            "version": "3.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/complexity.git",
-                "reference": "739b35e53379900cc9ac327b2147867b8b6efd88"
+                "reference": "e67d240970c9dc7ea7b2123a6d520e334dd61dc6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/complexity/zipball/739b35e53379900cc9ac327b2147867b8b6efd88",
-                "reference": "739b35e53379900cc9ac327b2147867b8b6efd88",
+                "url": "https://api.github.com/repos/sebastianbergmann/complexity/zipball/e67d240970c9dc7ea7b2123a6d520e334dd61dc6",
+                "reference": "e67d240970c9dc7ea7b2123a6d520e334dd61dc6",
                 "shasum": ""
             },
             "require": {
-                "nikic/php-parser": "^4.7",
-                "php": ">=7.3"
+                "nikic/php-parser": "^4.10",
+                "php": ">=8.1"
             },
             "require-dev": {
-                "phpunit/phpunit": "^9.3"
+                "phpunit/phpunit": "^10.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.0-dev"
+                    "dev-main": "3.0-dev"
                 }
             },
             "autoload": {
@@ -3208,7 +3140,7 @@
             "homepage": "https://github.com/sebastianbergmann/complexity",
             "support": {
                 "issues": "https://github.com/sebastianbergmann/complexity/issues",
-                "source": "https://github.com/sebastianbergmann/complexity/tree/2.0.2"
+                "source": "https://github.com/sebastianbergmann/complexity/tree/3.0.0"
             },
             "funding": [
                 {
@@ -3216,33 +3148,33 @@
                     "type": "github"
                 }
             ],
-            "time": "2020-10-26T15:52:27+00:00"
+            "time": "2023-02-03T06:59:47+00:00"
         },
         {
             "name": "sebastian/diff",
-            "version": "4.0.5",
+            "version": "5.0.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/diff.git",
-                "reference": "74be17022044ebaaecfdf0c5cd504fc9cd5a7131"
+                "reference": "912dc2fbe3e3c1e7873313cc801b100b6c68c87b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/74be17022044ebaaecfdf0c5cd504fc9cd5a7131",
-                "reference": "74be17022044ebaaecfdf0c5cd504fc9cd5a7131",
+                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/912dc2fbe3e3c1e7873313cc801b100b6c68c87b",
+                "reference": "912dc2fbe3e3c1e7873313cc801b100b6c68c87b",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.3"
+                "php": ">=8.1"
             },
             "require-dev": {
-                "phpunit/phpunit": "^9.3",
+                "phpunit/phpunit": "^10.0",
                 "symfony/process": "^4.2 || ^5"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "4.0-dev"
+                    "dev-main": "5.0-dev"
                 }
             },
             "autoload": {
@@ -3274,7 +3206,8 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/diff/issues",
-                "source": "https://github.com/sebastianbergmann/diff/tree/4.0.5"
+                "security": "https://github.com/sebastianbergmann/diff/security/policy",
+                "source": "https://github.com/sebastianbergmann/diff/tree/5.0.3"
             },
             "funding": [
                 {
@@ -3282,27 +3215,27 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-05-07T05:35:17+00:00"
+            "time": "2023-05-01T07:48:21+00:00"
         },
         {
             "name": "sebastian/environment",
-            "version": "5.1.5",
+            "version": "6.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/environment.git",
-                "reference": "830c43a844f1f8d5b7a1f6d6076b784454d8b7ed"
+                "reference": "43c751b41d74f96cbbd4e07b7aec9675651e2951"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/830c43a844f1f8d5b7a1f6d6076b784454d8b7ed",
-                "reference": "830c43a844f1f8d5b7a1f6d6076b784454d8b7ed",
+                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/43c751b41d74f96cbbd4e07b7aec9675651e2951",
+                "reference": "43c751b41d74f96cbbd4e07b7aec9675651e2951",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.3"
+                "php": ">=8.1"
             },
             "require-dev": {
-                "phpunit/phpunit": "^9.3"
+                "phpunit/phpunit": "^10.0"
             },
             "suggest": {
                 "ext-posix": "*"
@@ -3310,7 +3243,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "5.1-dev"
+                    "dev-main": "6.0-dev"
                 }
             },
             "autoload": {
@@ -3329,7 +3262,7 @@
                 }
             ],
             "description": "Provides functionality to handle HHVM/PHP environments",
-            "homepage": "http://www.github.com/sebastianbergmann/environment",
+            "homepage": "https://github.com/sebastianbergmann/environment",
             "keywords": [
                 "Xdebug",
                 "environment",
@@ -3337,7 +3270,8 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/environment/issues",
-                "source": "https://github.com/sebastianbergmann/environment/tree/5.1.5"
+                "security": "https://github.com/sebastianbergmann/environment/security/policy",
+                "source": "https://github.com/sebastianbergmann/environment/tree/6.0.1"
             },
             "funding": [
                 {
@@ -3345,34 +3279,34 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-02-03T06:03:51+00:00"
+            "time": "2023-04-11T05:39:26+00:00"
         },
         {
             "name": "sebastian/exporter",
-            "version": "4.0.5",
+            "version": "5.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/exporter.git",
-                "reference": "ac230ed27f0f98f597c8a2b6eb7ac563af5e5b9d"
+                "reference": "f3ec4bf931c0b31e5b413f5b4fc970a7d03338c0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/ac230ed27f0f98f597c8a2b6eb7ac563af5e5b9d",
-                "reference": "ac230ed27f0f98f597c8a2b6eb7ac563af5e5b9d",
+                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/f3ec4bf931c0b31e5b413f5b4fc970a7d03338c0",
+                "reference": "f3ec4bf931c0b31e5b413f5b4fc970a7d03338c0",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.3",
-                "sebastian/recursion-context": "^4.0"
+                "ext-mbstring": "*",
+                "php": ">=8.1",
+                "sebastian/recursion-context": "^5.0"
             },
             "require-dev": {
-                "ext-mbstring": "*",
-                "phpunit/phpunit": "^9.3"
+                "phpunit/phpunit": "^10.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "4.0-dev"
+                    "dev-main": "5.0-dev"
                 }
             },
             "autoload": {
@@ -3414,7 +3348,7 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/exporter/issues",
-                "source": "https://github.com/sebastianbergmann/exporter/tree/4.0.5"
+                "source": "https://github.com/sebastianbergmann/exporter/tree/5.0.0"
             },
             "funding": [
                 {
@@ -3422,38 +3356,35 @@
                     "type": "github"
                 }
             ],
-            "time": "2022-09-14T06:03:37+00:00"
+            "time": "2023-02-03T07:06:49+00:00"
         },
         {
             "name": "sebastian/global-state",
-            "version": "5.0.5",
+            "version": "6.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/global-state.git",
-                "reference": "0ca8db5a5fc9c8646244e629625ac486fa286bf2"
+                "reference": "aab257c712de87b90194febd52e4d184551c2d44"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/global-state/zipball/0ca8db5a5fc9c8646244e629625ac486fa286bf2",
-                "reference": "0ca8db5a5fc9c8646244e629625ac486fa286bf2",
+                "url": "https://api.github.com/repos/sebastianbergmann/global-state/zipball/aab257c712de87b90194febd52e4d184551c2d44",
+                "reference": "aab257c712de87b90194febd52e4d184551c2d44",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.3",
-                "sebastian/object-reflector": "^2.0",
-                "sebastian/recursion-context": "^4.0"
+                "php": ">=8.1",
+                "sebastian/object-reflector": "^3.0",
+                "sebastian/recursion-context": "^5.0"
             },
             "require-dev": {
                 "ext-dom": "*",
-                "phpunit/phpunit": "^9.3"
-            },
-            "suggest": {
-                "ext-uopz": "*"
+                "phpunit/phpunit": "^10.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "5.0-dev"
+                    "dev-main": "6.0-dev"
                 }
             },
             "autoload": {
@@ -3478,7 +3409,7 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/global-state/issues",
-                "source": "https://github.com/sebastianbergmann/global-state/tree/5.0.5"
+                "source": "https://github.com/sebastianbergmann/global-state/tree/6.0.0"
             },
             "funding": [
                 {
@@ -3486,33 +3417,33 @@
                     "type": "github"
                 }
             ],
-            "time": "2022-02-14T08:28:10+00:00"
+            "time": "2023-02-03T07:07:38+00:00"
         },
         {
             "name": "sebastian/lines-of-code",
-            "version": "1.0.3",
+            "version": "2.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/lines-of-code.git",
-                "reference": "c1c2e997aa3146983ed888ad08b15470a2e22ecc"
+                "reference": "17c4d940ecafb3d15d2cf916f4108f664e28b130"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/lines-of-code/zipball/c1c2e997aa3146983ed888ad08b15470a2e22ecc",
-                "reference": "c1c2e997aa3146983ed888ad08b15470a2e22ecc",
+                "url": "https://api.github.com/repos/sebastianbergmann/lines-of-code/zipball/17c4d940ecafb3d15d2cf916f4108f664e28b130",
+                "reference": "17c4d940ecafb3d15d2cf916f4108f664e28b130",
                 "shasum": ""
             },
             "require": {
-                "nikic/php-parser": "^4.6",
-                "php": ">=7.3"
+                "nikic/php-parser": "^4.10",
+                "php": ">=8.1"
             },
             "require-dev": {
-                "phpunit/phpunit": "^9.3"
+                "phpunit/phpunit": "^10.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.0-dev"
+                    "dev-main": "2.0-dev"
                 }
             },
             "autoload": {
@@ -3535,7 +3466,7 @@
             "homepage": "https://github.com/sebastianbergmann/lines-of-code",
             "support": {
                 "issues": "https://github.com/sebastianbergmann/lines-of-code/issues",
-                "source": "https://github.com/sebastianbergmann/lines-of-code/tree/1.0.3"
+                "source": "https://github.com/sebastianbergmann/lines-of-code/tree/2.0.0"
             },
             "funding": [
                 {
@@ -3543,34 +3474,34 @@
                     "type": "github"
                 }
             ],
-            "time": "2020-11-28T06:42:11+00:00"
+            "time": "2023-02-03T07:08:02+00:00"
         },
         {
             "name": "sebastian/object-enumerator",
-            "version": "4.0.4",
+            "version": "5.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/object-enumerator.git",
-                "reference": "5c9eeac41b290a3712d88851518825ad78f45c71"
+                "reference": "202d0e344a580d7f7d04b3fafce6933e59dae906"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/object-enumerator/zipball/5c9eeac41b290a3712d88851518825ad78f45c71",
-                "reference": "5c9eeac41b290a3712d88851518825ad78f45c71",
+                "url": "https://api.github.com/repos/sebastianbergmann/object-enumerator/zipball/202d0e344a580d7f7d04b3fafce6933e59dae906",
+                "reference": "202d0e344a580d7f7d04b3fafce6933e59dae906",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.3",
-                "sebastian/object-reflector": "^2.0",
-                "sebastian/recursion-context": "^4.0"
+                "php": ">=8.1",
+                "sebastian/object-reflector": "^3.0",
+                "sebastian/recursion-context": "^5.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "^9.3"
+                "phpunit/phpunit": "^10.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "4.0-dev"
+                    "dev-main": "5.0-dev"
                 }
             },
             "autoload": {
@@ -3592,7 +3523,7 @@
             "homepage": "https://github.com/sebastianbergmann/object-enumerator/",
             "support": {
                 "issues": "https://github.com/sebastianbergmann/object-enumerator/issues",
-                "source": "https://github.com/sebastianbergmann/object-enumerator/tree/4.0.4"
+                "source": "https://github.com/sebastianbergmann/object-enumerator/tree/5.0.0"
             },
             "funding": [
                 {
@@ -3600,32 +3531,32 @@
                     "type": "github"
                 }
             ],
-            "time": "2020-10-26T13:12:34+00:00"
+            "time": "2023-02-03T07:08:32+00:00"
         },
         {
             "name": "sebastian/object-reflector",
-            "version": "2.0.4",
+            "version": "3.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/object-reflector.git",
-                "reference": "b4f479ebdbf63ac605d183ece17d8d7fe49c15c7"
+                "reference": "24ed13d98130f0e7122df55d06c5c4942a577957"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/object-reflector/zipball/b4f479ebdbf63ac605d183ece17d8d7fe49c15c7",
-                "reference": "b4f479ebdbf63ac605d183ece17d8d7fe49c15c7",
+                "url": "https://api.github.com/repos/sebastianbergmann/object-reflector/zipball/24ed13d98130f0e7122df55d06c5c4942a577957",
+                "reference": "24ed13d98130f0e7122df55d06c5c4942a577957",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.3"
+                "php": ">=8.1"
             },
             "require-dev": {
-                "phpunit/phpunit": "^9.3"
+                "phpunit/phpunit": "^10.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.0-dev"
+                    "dev-main": "3.0-dev"
                 }
             },
             "autoload": {
@@ -3647,7 +3578,7 @@
             "homepage": "https://github.com/sebastianbergmann/object-reflector/",
             "support": {
                 "issues": "https://github.com/sebastianbergmann/object-reflector/issues",
-                "source": "https://github.com/sebastianbergmann/object-reflector/tree/2.0.4"
+                "source": "https://github.com/sebastianbergmann/object-reflector/tree/3.0.0"
             },
             "funding": [
                 {
@@ -3655,32 +3586,32 @@
                     "type": "github"
                 }
             ],
-            "time": "2020-10-26T13:14:26+00:00"
+            "time": "2023-02-03T07:06:18+00:00"
         },
         {
             "name": "sebastian/recursion-context",
-            "version": "4.0.5",
+            "version": "5.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/recursion-context.git",
-                "reference": "e75bd0f07204fec2a0af9b0f3cfe97d05f92efc1"
+                "reference": "05909fb5bc7df4c52992396d0116aed689f93712"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/recursion-context/zipball/e75bd0f07204fec2a0af9b0f3cfe97d05f92efc1",
-                "reference": "e75bd0f07204fec2a0af9b0f3cfe97d05f92efc1",
+                "url": "https://api.github.com/repos/sebastianbergmann/recursion-context/zipball/05909fb5bc7df4c52992396d0116aed689f93712",
+                "reference": "05909fb5bc7df4c52992396d0116aed689f93712",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.3"
+                "php": ">=8.1"
             },
             "require-dev": {
-                "phpunit/phpunit": "^9.3"
+                "phpunit/phpunit": "^10.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "4.0-dev"
+                    "dev-main": "5.0-dev"
                 }
             },
             "autoload": {
@@ -3710,7 +3641,7 @@
             "homepage": "https://github.com/sebastianbergmann/recursion-context",
             "support": {
                 "issues": "https://github.com/sebastianbergmann/recursion-context/issues",
-                "source": "https://github.com/sebastianbergmann/recursion-context/tree/4.0.5"
+                "source": "https://github.com/sebastianbergmann/recursion-context/tree/5.0.0"
             },
             "funding": [
                 {
@@ -3718,87 +3649,32 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-02-03T06:07:39+00:00"
-        },
-        {
-            "name": "sebastian/resource-operations",
-            "version": "3.0.3",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/sebastianbergmann/resource-operations.git",
-                "reference": "0f4443cb3a1d92ce809899753bc0d5d5a8dd19a8"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/resource-operations/zipball/0f4443cb3a1d92ce809899753bc0d5d5a8dd19a8",
-                "reference": "0f4443cb3a1d92ce809899753bc0d5d5a8dd19a8",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=7.3"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "^9.0"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "3.0-dev"
-                }
-            },
-            "autoload": {
-                "classmap": [
-                    "src/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "authors": [
-                {
-                    "name": "Sebastian Bergmann",
-                    "email": "sebastian@phpunit.de"
-                }
-            ],
-            "description": "Provides a list of PHP built-in functions that operate on resources",
-            "homepage": "https://www.github.com/sebastianbergmann/resource-operations",
-            "support": {
-                "issues": "https://github.com/sebastianbergmann/resource-operations/issues",
-                "source": "https://github.com/sebastianbergmann/resource-operations/tree/3.0.3"
-            },
-            "funding": [
-                {
-                    "url": "https://github.com/sebastianbergmann",
-                    "type": "github"
-                }
-            ],
-            "time": "2020-09-28T06:45:17+00:00"
+            "time": "2023-02-03T07:05:40+00:00"
         },
         {
             "name": "sebastian/type",
-            "version": "3.2.1",
+            "version": "4.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/type.git",
-                "reference": "75e2c2a32f5e0b3aef905b9ed0b179b953b3d7c7"
+                "reference": "462699a16464c3944eefc02ebdd77882bd3925bf"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/type/zipball/75e2c2a32f5e0b3aef905b9ed0b179b953b3d7c7",
-                "reference": "75e2c2a32f5e0b3aef905b9ed0b179b953b3d7c7",
+                "url": "https://api.github.com/repos/sebastianbergmann/type/zipball/462699a16464c3944eefc02ebdd77882bd3925bf",
+                "reference": "462699a16464c3944eefc02ebdd77882bd3925bf",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.3"
+                "php": ">=8.1"
             },
             "require-dev": {
-                "phpunit/phpunit": "^9.5"
+                "phpunit/phpunit": "^10.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.2-dev"
+                    "dev-main": "4.0-dev"
                 }
             },
             "autoload": {
@@ -3821,7 +3697,7 @@
             "homepage": "https://github.com/sebastianbergmann/type",
             "support": {
                 "issues": "https://github.com/sebastianbergmann/type/issues",
-                "source": "https://github.com/sebastianbergmann/type/tree/3.2.1"
+                "source": "https://github.com/sebastianbergmann/type/tree/4.0.0"
             },
             "funding": [
                 {
@@ -3829,29 +3705,29 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-02-03T06:13:03+00:00"
+            "time": "2023-02-03T07:10:45+00:00"
         },
         {
             "name": "sebastian/version",
-            "version": "3.0.2",
+            "version": "4.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/version.git",
-                "reference": "c6c1022351a901512170118436c764e473f6de8c"
+                "reference": "c51fa83a5d8f43f1402e3f32a005e6262244ef17"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/version/zipball/c6c1022351a901512170118436c764e473f6de8c",
-                "reference": "c6c1022351a901512170118436c764e473f6de8c",
+                "url": "https://api.github.com/repos/sebastianbergmann/version/zipball/c51fa83a5d8f43f1402e3f32a005e6262244ef17",
+                "reference": "c51fa83a5d8f43f1402e3f32a005e6262244ef17",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.3"
+                "php": ">=8.1"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.0-dev"
+                    "dev-main": "4.0-dev"
                 }
             },
             "autoload": {
@@ -3874,7 +3750,7 @@
             "homepage": "https://github.com/sebastianbergmann/version",
             "support": {
                 "issues": "https://github.com/sebastianbergmann/version/issues",
-                "source": "https://github.com/sebastianbergmann/version/tree/3.0.2"
+                "source": "https://github.com/sebastianbergmann/version/tree/4.0.1"
             },
             "funding": [
                 {
@@ -3882,7 +3758,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2020-09-28T06:39:44+00:00"
+            "time": "2023-02-07T11:34:05+00:00"
         },
         {
             "name": "seld/jsonlint",

--- a/composer.lock
+++ b/composer.lock
@@ -4,34 +4,34 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "fbcce04db557580f7639b4a6c842f0c0",
+    "content-hash": "61e6cf398c1f608dfc037cce1e39082e",
     "packages": [
         {
             "name": "laminas/laminas-stdlib",
-            "version": "3.16.1",
+            "version": "3.17.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laminas/laminas-stdlib.git",
-                "reference": "f4f773641807c7ccee59b758bfe4ac4ba33ecb17"
+                "reference": "dd35c868075bad80b6718959740913e178eb4274"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laminas/laminas-stdlib/zipball/f4f773641807c7ccee59b758bfe4ac4ba33ecb17",
-                "reference": "f4f773641807c7ccee59b758bfe4ac4ba33ecb17",
+                "url": "https://api.github.com/repos/laminas/laminas-stdlib/zipball/dd35c868075bad80b6718959740913e178eb4274",
+                "reference": "dd35c868075bad80b6718959740913e178eb4274",
                 "shasum": ""
             },
             "require": {
-                "php": "~8.0.0 || ~8.1.0 || ~8.2.0"
+                "php": "~8.1.0 || ~8.2.0"
             },
             "conflict": {
                 "zendframework/zend-stdlib": "*"
             },
             "require-dev": {
-                "laminas/laminas-coding-standard": "^2.4.0",
-                "phpbench/phpbench": "^1.2.7",
-                "phpunit/phpunit": "^9.5.26",
-                "psalm/plugin-phpunit": "^0.18.0",
-                "vimeo/psalm": "^5.0.0"
+                "laminas/laminas-coding-standard": "^2.5",
+                "phpbench/phpbench": "^1.2.9",
+                "phpunit/phpunit": "^10.0.16",
+                "psalm/plugin-phpunit": "^0.18.4",
+                "vimeo/psalm": "^5.8"
             },
             "type": "library",
             "autoload": {
@@ -63,7 +63,7 @@
                     "type": "community_bridge"
                 }
             ],
-            "time": "2022-12-03T18:48:01+00:00"
+            "time": "2023-03-20T13:51:37+00:00"
         },
         {
             "name": "webmozart/assert",
@@ -745,16 +745,16 @@
         },
         {
             "name": "doctrine/annotations",
-            "version": "2.0.0",
+            "version": "2.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/annotations.git",
-                "reference": "d02c9f3742044e17d5fa8d28d8402a2d95c33302"
+                "reference": "e157ef3f3124bbf6fe7ce0ffd109e8a8ef284e7f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/annotations/zipball/d02c9f3742044e17d5fa8d28d8402a2d95c33302",
-                "reference": "d02c9f3742044e17d5fa8d28d8402a2d95c33302",
+                "url": "https://api.github.com/repos/doctrine/annotations/zipball/e157ef3f3124bbf6fe7ce0ffd109e8a8ef284e7f",
+                "reference": "e157ef3f3124bbf6fe7ce0ffd109e8a8ef284e7f",
                 "shasum": ""
             },
             "require": {
@@ -815,79 +815,36 @@
             ],
             "support": {
                 "issues": "https://github.com/doctrine/annotations/issues",
-                "source": "https://github.com/doctrine/annotations/tree/2.0.0"
+                "source": "https://github.com/doctrine/annotations/tree/2.0.1"
             },
-            "time": "2022-12-19T18:17:20+00:00"
-        },
-        {
-            "name": "doctrine/deprecations",
-            "version": "v1.0.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/doctrine/deprecations.git",
-                "reference": "0e2a4f1f8cdfc7a92ec3b01c9334898c806b30de"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/deprecations/zipball/0e2a4f1f8cdfc7a92ec3b01c9334898c806b30de",
-                "reference": "0e2a4f1f8cdfc7a92ec3b01c9334898c806b30de",
-                "shasum": ""
-            },
-            "require": {
-                "php": "^7.1|^8.0"
-            },
-            "require-dev": {
-                "doctrine/coding-standard": "^9",
-                "phpunit/phpunit": "^7.5|^8.5|^9.5",
-                "psr/log": "^1|^2|^3"
-            },
-            "suggest": {
-                "psr/log": "Allows logging deprecations via PSR-3 logger implementation"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "Doctrine\\Deprecations\\": "lib/Doctrine/Deprecations"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "description": "A small layer on top of trigger_error(E_USER_DEPRECATED) or PSR-3 logging with options to disable all deprecations or selectively for packages.",
-            "homepage": "https://www.doctrine-project.org/",
-            "support": {
-                "issues": "https://github.com/doctrine/deprecations/issues",
-                "source": "https://github.com/doctrine/deprecations/tree/v1.0.0"
-            },
-            "time": "2022-05-02T15:47:09+00:00"
+            "time": "2023-02-02T22:02:53+00:00"
         },
         {
             "name": "doctrine/instantiator",
-            "version": "1.5.0",
+            "version": "2.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/instantiator.git",
-                "reference": "0a0fa9780f5d4e507415a065172d26a98d02047b"
+                "reference": "c6222283fa3f4ac679f8b9ced9a4e23f163e80d0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/instantiator/zipball/0a0fa9780f5d4e507415a065172d26a98d02047b",
-                "reference": "0a0fa9780f5d4e507415a065172d26a98d02047b",
+                "url": "https://api.github.com/repos/doctrine/instantiator/zipball/c6222283fa3f4ac679f8b9ced9a4e23f163e80d0",
+                "reference": "c6222283fa3f4ac679f8b9ced9a4e23f163e80d0",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.1 || ^8.0"
+                "php": "^8.1"
             },
             "require-dev": {
-                "doctrine/coding-standard": "^9 || ^11",
+                "doctrine/coding-standard": "^11",
                 "ext-pdo": "*",
                 "ext-phar": "*",
-                "phpbench/phpbench": "^0.16 || ^1",
-                "phpstan/phpstan": "^1.4",
-                "phpstan/phpstan-phpunit": "^1",
-                "phpunit/phpunit": "^7.5 || ^8.5 || ^9.5",
-                "vimeo/psalm": "^4.30 || ^5.4"
+                "phpbench/phpbench": "^1.2",
+                "phpstan/phpstan": "^1.9.4",
+                "phpstan/phpstan-phpunit": "^1.3",
+                "phpunit/phpunit": "^9.5.27",
+                "vimeo/psalm": "^5.4"
             },
             "type": "library",
             "autoload": {
@@ -914,7 +871,7 @@
             ],
             "support": {
                 "issues": "https://github.com/doctrine/instantiator/issues",
-                "source": "https://github.com/doctrine/instantiator/tree/1.5.0"
+                "source": "https://github.com/doctrine/instantiator/tree/2.0.0"
             },
             "funding": [
                 {
@@ -930,32 +887,31 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-12-30T00:15:36+00:00"
+            "time": "2022-12-30T00:23:10+00:00"
         },
         {
             "name": "doctrine/lexer",
-            "version": "2.1.0",
+            "version": "3.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/lexer.git",
-                "reference": "39ab8fcf5a51ce4b85ca97c7a7d033eb12831124"
+                "reference": "84a527db05647743d50373e0ec53a152f2cde568"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/lexer/zipball/39ab8fcf5a51ce4b85ca97c7a7d033eb12831124",
-                "reference": "39ab8fcf5a51ce4b85ca97c7a7d033eb12831124",
+                "url": "https://api.github.com/repos/doctrine/lexer/zipball/84a527db05647743d50373e0ec53a152f2cde568",
+                "reference": "84a527db05647743d50373e0ec53a152f2cde568",
                 "shasum": ""
             },
             "require": {
-                "doctrine/deprecations": "^1.0",
-                "php": "^7.1 || ^8.0"
+                "php": "^8.1"
             },
             "require-dev": {
-                "doctrine/coding-standard": "^9 || ^10",
-                "phpstan/phpstan": "^1.3",
-                "phpunit/phpunit": "^7.5 || ^8.5 || ^9.5",
+                "doctrine/coding-standard": "^10",
+                "phpstan/phpstan": "^1.9",
+                "phpunit/phpunit": "^9.5",
                 "psalm/plugin-phpunit": "^0.18.3",
-                "vimeo/psalm": "^4.11 || ^5.0"
+                "vimeo/psalm": "^5.0"
             },
             "type": "library",
             "autoload": {
@@ -992,7 +948,7 @@
             ],
             "support": {
                 "issues": "https://github.com/doctrine/lexer/issues",
-                "source": "https://github.com/doctrine/lexer/tree/2.1.0"
+                "source": "https://github.com/doctrine/lexer/tree/3.0.0"
             },
             "funding": [
                 {
@@ -1008,7 +964,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-12-14T08:49:07+00:00"
+            "time": "2022-12-15T16:57:16+00:00"
         },
         {
             "name": "felixfbecker/advanced-json-rpc",
@@ -1113,16 +1069,16 @@
         },
         {
             "name": "fidry/cpu-core-counter",
-            "version": "0.4.1",
+            "version": "0.5.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/theofidry/cpu-core-counter.git",
-                "reference": "79261cc280aded96d098e1b0e0ba0c4881b432c2"
+                "reference": "b58e5a3933e541dc286cc91fc4f3898bbc6f1623"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/theofidry/cpu-core-counter/zipball/79261cc280aded96d098e1b0e0ba0c4881b432c2",
-                "reference": "79261cc280aded96d098e1b0e0ba0c4881b432c2",
+                "url": "https://api.github.com/repos/theofidry/cpu-core-counter/zipball/b58e5a3933e541dc286cc91fc4f3898bbc6f1623",
+                "reference": "b58e5a3933e541dc286cc91fc4f3898bbc6f1623",
                 "shasum": ""
             },
             "require": {
@@ -1162,7 +1118,7 @@
             ],
             "support": {
                 "issues": "https://github.com/theofidry/cpu-core-counter/issues",
-                "source": "https://github.com/theofidry/cpu-core-counter/tree/0.4.1"
+                "source": "https://github.com/theofidry/cpu-core-counter/tree/0.5.1"
             },
             "funding": [
                 {
@@ -1170,7 +1126,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2022-12-16T22:01:02+00:00"
+            "time": "2022-12-24T12:35:10+00:00"
         },
         {
             "name": "laminas/laminas-coding-standard",
@@ -1569,26 +1525,26 @@
         },
         {
             "name": "laminas/laminas-servicemanager",
-            "version": "3.20.0",
+            "version": "3.21.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laminas/laminas-servicemanager.git",
-                "reference": "bc2c2cbe2dd90db8b9d16b0618f542692b76ab59"
+                "reference": "625f2aa3bc6dd02688b2da5155b3a69870812bda"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laminas/laminas-servicemanager/zipball/bc2c2cbe2dd90db8b9d16b0618f542692b76ab59",
-                "reference": "bc2c2cbe2dd90db8b9d16b0618f542692b76ab59",
+                "url": "https://api.github.com/repos/laminas/laminas-servicemanager/zipball/625f2aa3bc6dd02688b2da5155b3a69870812bda",
+                "reference": "625f2aa3bc6dd02688b2da5155b3a69870812bda",
                 "shasum": ""
             },
             "require": {
-                "laminas/laminas-stdlib": "^3.2.1",
-                "php": "~8.0.0 || ~8.1.0 || ~8.2.0",
+                "laminas/laminas-stdlib": "^3.17",
+                "php": "~8.1.0 || ~8.2.0",
                 "psr/container": "^1.0"
             },
             "conflict": {
                 "ext-psr": "*",
-                "laminas/laminas-code": "<3.3.1",
+                "laminas/laminas-code": "<4.10.0",
                 "zendframework/zend-code": "<3.3.1",
                 "zendframework/zend-servicemanager": "*"
             },
@@ -1600,18 +1556,19 @@
             },
             "require-dev": {
                 "composer/package-versions-deprecated": "^1.11.99.5",
-                "laminas/laminas-coding-standard": "~2.4.0",
+                "friendsofphp/proxy-manager-lts": "^1.0.14",
+                "laminas/laminas-code": "^4.10.0",
+                "laminas/laminas-coding-standard": "~2.5.0",
                 "laminas/laminas-container-config-test": "^0.8",
                 "laminas/laminas-dependency-plugin": "^2.2",
-                "mikey179/vfsstream": "^1.6.11@alpha",
-                "ocramius/proxy-manager": "^2.14.1",
-                "phpbench/phpbench": "^1.2.7",
-                "phpunit/phpunit": "^9.5.26",
-                "psalm/plugin-phpunit": "^0.18.0",
-                "vimeo/psalm": "^5.0.0"
+                "mikey179/vfsstream": "^1.6.11",
+                "phpbench/phpbench": "^1.2.9",
+                "phpunit/phpunit": "^10.0.17",
+                "psalm/plugin-phpunit": "^0.18.4",
+                "vimeo/psalm": "^5.8.0"
             },
             "suggest": {
-                "ocramius/proxy-manager": "ProxyManager ^2.1.1 to handle lazy initialization of services"
+                "friendsofphp/proxy-manager-lts": "ProxyManager ^2.1.1 to handle lazy initialization of services"
             },
             "bin": [
                 "bin/generate-deps-for-config-factory",
@@ -1655,20 +1612,20 @@
                     "type": "community_bridge"
                 }
             ],
-            "time": "2022-12-01T17:03:38+00:00"
+            "time": "2023-05-14T12:24:54+00:00"
         },
         {
             "name": "myclabs/deep-copy",
-            "version": "1.11.0",
+            "version": "1.11.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/myclabs/DeepCopy.git",
-                "reference": "14daed4296fae74d9e3201d2c4925d1acb7aa614"
+                "reference": "7284c22080590fb39f2ffa3e9057f10a4ddd0e0c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/14daed4296fae74d9e3201d2c4925d1acb7aa614",
-                "reference": "14daed4296fae74d9e3201d2c4925d1acb7aa614",
+                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/7284c22080590fb39f2ffa3e9057f10a4ddd0e0c",
+                "reference": "7284c22080590fb39f2ffa3e9057f10a4ddd0e0c",
                 "shasum": ""
             },
             "require": {
@@ -1706,7 +1663,7 @@
             ],
             "support": {
                 "issues": "https://github.com/myclabs/DeepCopy/issues",
-                "source": "https://github.com/myclabs/DeepCopy/tree/1.11.0"
+                "source": "https://github.com/myclabs/DeepCopy/tree/1.11.1"
             },
             "funding": [
                 {
@@ -1714,20 +1671,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-03-03T13:19:32+00:00"
+            "time": "2023-03-08T13:26:56+00:00"
         },
         {
             "name": "netresearch/jsonmapper",
-            "version": "v4.1.0",
+            "version": "v4.2.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/cweiske/jsonmapper.git",
-                "reference": "cfa81ea1d35294d64adb9c68aa4cb9e92400e53f"
+                "reference": "f60565f8c0566a31acf06884cdaa591867ecc956"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/cweiske/jsonmapper/zipball/cfa81ea1d35294d64adb9c68aa4cb9e92400e53f",
-                "reference": "cfa81ea1d35294d64adb9c68aa4cb9e92400e53f",
+                "url": "https://api.github.com/repos/cweiske/jsonmapper/zipball/f60565f8c0566a31acf06884cdaa591867ecc956",
+                "reference": "f60565f8c0566a31acf06884cdaa591867ecc956",
                 "shasum": ""
             },
             "require": {
@@ -1763,22 +1720,22 @@
             "support": {
                 "email": "cweiske@cweiske.de",
                 "issues": "https://github.com/cweiske/jsonmapper/issues",
-                "source": "https://github.com/cweiske/jsonmapper/tree/v4.1.0"
+                "source": "https://github.com/cweiske/jsonmapper/tree/v4.2.0"
             },
-            "time": "2022-12-08T20:46:14+00:00"
+            "time": "2023-04-09T17:37:40+00:00"
         },
         {
             "name": "nikic/php-parser",
-            "version": "v4.15.3",
+            "version": "v4.15.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/nikic/PHP-Parser.git",
-                "reference": "570e980a201d8ed0236b0a62ddf2c9cbb2034039"
+                "reference": "6bb5176bc4af8bcb7d926f88718db9b96a2d4290"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/570e980a201d8ed0236b0a62ddf2c9cbb2034039",
-                "reference": "570e980a201d8ed0236b0a62ddf2c9cbb2034039",
+                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/6bb5176bc4af8bcb7d926f88718db9b96a2d4290",
+                "reference": "6bb5176bc4af8bcb7d926f88718db9b96a2d4290",
                 "shasum": ""
             },
             "require": {
@@ -1819,9 +1776,9 @@
             ],
             "support": {
                 "issues": "https://github.com/nikic/PHP-Parser/issues",
-                "source": "https://github.com/nikic/PHP-Parser/tree/v4.15.3"
+                "source": "https://github.com/nikic/PHP-Parser/tree/v4.15.4"
             },
-            "time": "2023-01-16T22:05:37+00:00"
+            "time": "2023-03-05T19:49:14+00:00"
         },
         {
             "name": "phar-io/manifest",
@@ -1987,25 +1944,25 @@
         },
         {
             "name": "phpbench/dom",
-            "version": "0.3.2",
+            "version": "0.3.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpbench/dom.git",
-                "reference": "b013b717832ddbaadf2a40984b04bc66af9a7110"
+                "reference": "786a96db538d0def931f5b19225233ec42ec7a72"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpbench/dom/zipball/b013b717832ddbaadf2a40984b04bc66af9a7110",
-                "reference": "b013b717832ddbaadf2a40984b04bc66af9a7110",
+                "url": "https://api.github.com/repos/phpbench/dom/zipball/786a96db538d0def931f5b19225233ec42ec7a72",
+                "reference": "786a96db538d0def931f5b19225233ec42ec7a72",
                 "shasum": ""
             },
             "require": {
                 "ext-dom": "*",
-                "php": "^7.2||^8.0"
+                "php": "^7.3||^8.0"
             },
             "require-dev": {
-                "friendsofphp/php-cs-fixer": "^2.18",
-                "phpstan/phpstan": "^0.12.83",
+                "friendsofphp/php-cs-fixer": "^3.14",
+                "phpstan/phpstan": "^1.10",
                 "phpunit/phpunit": "^8.0||^9.0"
             },
             "type": "library",
@@ -2032,22 +1989,22 @@
             "description": "DOM wrapper to simplify working with the PHP DOM implementation",
             "support": {
                 "issues": "https://github.com/phpbench/dom/issues",
-                "source": "https://github.com/phpbench/dom/tree/0.3.2"
+                "source": "https://github.com/phpbench/dom/tree/0.3.3"
             },
-            "time": "2021-09-24T15:26:07+00:00"
+            "time": "2023-03-06T23:46:57+00:00"
         },
         {
             "name": "phpbench/phpbench",
-            "version": "1.2.8",
+            "version": "1.2.10",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpbench/phpbench.git",
-                "reference": "3f7b3c200f86727de7a14bde94adb68a88e1bafc"
+                "reference": "95206f92479674599a75e02b74b9933e2d9883aa"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpbench/phpbench/zipball/3f7b3c200f86727de7a14bde94adb68a88e1bafc",
-                "reference": "3f7b3c200f86727de7a14bde94adb68a88e1bafc",
+                "url": "https://api.github.com/repos/phpbench/phpbench/zipball/95206f92479674599a75e02b74b9933e2d9883aa",
+                "reference": "95206f92479674599a75e02b74b9933e2d9883aa",
                 "shasum": ""
             },
             "require": {
@@ -2058,9 +2015,9 @@
                 "ext-reflection": "*",
                 "ext-spl": "*",
                 "ext-tokenizer": "*",
-                "php": "^7.3 || ^8.0",
+                "php": "^7.4 || ^8.0",
                 "phpbench/container": "^2.1",
-                "phpbench/dom": "~0.3.1",
+                "phpbench/dom": "~0.3.3",
                 "psr/log": "^1.1 || ^2.0 || ^3.0",
                 "seld/jsonlint": "^1.1",
                 "symfony/console": "^4.2 || ^5.0  || ^6.0",
@@ -2078,7 +2035,7 @@
                 "phpstan/extension-installer": "^1.1",
                 "phpstan/phpstan": "^1.0",
                 "phpstan/phpstan-phpunit": "^1.0",
-                "phpunit/phpunit": "^8.5.8 || ^9.0",
+                "phpunit/phpunit": "^9.0",
                 "symfony/error-handler": "^5.2 || ^6.0",
                 "symfony/var-dumper": "^4.0 || ^5.0 || ^6.0"
             },
@@ -2116,7 +2073,7 @@
             "description": "PHP Benchmarking Framework",
             "support": {
                 "issues": "https://github.com/phpbench/phpbench/issues",
-                "source": "https://github.com/phpbench/phpbench/tree/1.2.8"
+                "source": "https://github.com/phpbench/phpbench/tree/1.2.10"
             },
             "funding": [
                 {
@@ -2124,7 +2081,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-01-14T13:08:42+00:00"
+            "time": "2023-03-24T08:52:55+00:00"
         },
         {
             "name": "phpdocumentor/reflection-common",
@@ -2337,23 +2294,23 @@
         },
         {
             "name": "phpunit/php-code-coverage",
-            "version": "9.2.24",
+            "version": "9.2.26",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
-                "reference": "2cf940ebc6355a9d430462811b5aaa308b174bed"
+                "reference": "443bc6912c9bd5b409254a40f4b0f4ced7c80ea1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/2cf940ebc6355a9d430462811b5aaa308b174bed",
-                "reference": "2cf940ebc6355a9d430462811b5aaa308b174bed",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/443bc6912c9bd5b409254a40f4b0f4ced7c80ea1",
+                "reference": "443bc6912c9bd5b409254a40f4b0f4ced7c80ea1",
                 "shasum": ""
             },
             "require": {
                 "ext-dom": "*",
                 "ext-libxml": "*",
                 "ext-xmlwriter": "*",
-                "nikic/php-parser": "^4.14",
+                "nikic/php-parser": "^4.15",
                 "php": ">=7.3",
                 "phpunit/php-file-iterator": "^3.0.3",
                 "phpunit/php-text-template": "^2.0.2",
@@ -2368,8 +2325,8 @@
                 "phpunit/phpunit": "^9.3"
             },
             "suggest": {
-                "ext-pcov": "*",
-                "ext-xdebug": "*"
+                "ext-pcov": "PHP extension that provides line coverage",
+                "ext-xdebug": "PHP extension that provides line coverage as well as branch and path coverage"
             },
             "type": "library",
             "extra": {
@@ -2402,7 +2359,7 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/php-code-coverage/issues",
-                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/9.2.24"
+                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/9.2.26"
             },
             "funding": [
                 {
@@ -2410,7 +2367,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-01-26T08:26:55+00:00"
+            "time": "2023-03-06T12:58:08+00:00"
         },
         {
             "name": "phpunit/php-file-iterator",
@@ -2655,16 +2612,16 @@
         },
         {
             "name": "phpunit/phpunit",
-            "version": "9.5.28",
+            "version": "9.6.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "954ca3113a03bf780d22f07bf055d883ee04b65e"
+                "reference": "17d621b3aff84d0c8b62539e269e87d8d5baa76e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/954ca3113a03bf780d22f07bf055d883ee04b65e",
-                "reference": "954ca3113a03bf780d22f07bf055d883ee04b65e",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/17d621b3aff84d0c8b62539e269e87d8d5baa76e",
+                "reference": "17d621b3aff84d0c8b62539e269e87d8d5baa76e",
                 "shasum": ""
             },
             "require": {
@@ -2697,8 +2654,8 @@
                 "sebastian/version": "^3.0.2"
             },
             "suggest": {
-                "ext-soap": "*",
-                "ext-xdebug": "*"
+                "ext-soap": "To be able to generate mocks based on WSDL files",
+                "ext-xdebug": "PHP extension that provides line coverage as well as branch and path coverage"
             },
             "bin": [
                 "phpunit"
@@ -2706,7 +2663,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "9.5-dev"
+                    "dev-master": "9.6-dev"
                 }
             },
             "autoload": {
@@ -2737,7 +2694,8 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/phpunit/issues",
-                "source": "https://github.com/sebastianbergmann/phpunit/tree/9.5.28"
+                "security": "https://github.com/sebastianbergmann/phpunit/security/policy",
+                "source": "https://github.com/sebastianbergmann/phpunit/tree/9.6.8"
             },
             "funding": [
                 {
@@ -2753,7 +2711,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-01-14T12:32:24+00:00"
+            "time": "2023-05-11T05:14:45+00:00"
         },
         {
             "name": "psalm/plugin-phpunit",
@@ -3262,16 +3220,16 @@
         },
         {
             "name": "sebastian/diff",
-            "version": "4.0.4",
+            "version": "4.0.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/diff.git",
-                "reference": "3461e3fccc7cfdfc2720be910d3bd73c69be590d"
+                "reference": "74be17022044ebaaecfdf0c5cd504fc9cd5a7131"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/3461e3fccc7cfdfc2720be910d3bd73c69be590d",
-                "reference": "3461e3fccc7cfdfc2720be910d3bd73c69be590d",
+                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/74be17022044ebaaecfdf0c5cd504fc9cd5a7131",
+                "reference": "74be17022044ebaaecfdf0c5cd504fc9cd5a7131",
                 "shasum": ""
             },
             "require": {
@@ -3316,7 +3274,7 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/diff/issues",
-                "source": "https://github.com/sebastianbergmann/diff/tree/4.0.4"
+                "source": "https://github.com/sebastianbergmann/diff/tree/4.0.5"
             },
             "funding": [
                 {
@@ -3324,20 +3282,20 @@
                     "type": "github"
                 }
             ],
-            "time": "2020-10-26T13:10:38+00:00"
+            "time": "2023-05-07T05:35:17+00:00"
         },
         {
             "name": "sebastian/environment",
-            "version": "5.1.4",
+            "version": "5.1.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/environment.git",
-                "reference": "1b5dff7bb151a4db11d49d90e5408e4e938270f7"
+                "reference": "830c43a844f1f8d5b7a1f6d6076b784454d8b7ed"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/1b5dff7bb151a4db11d49d90e5408e4e938270f7",
-                "reference": "1b5dff7bb151a4db11d49d90e5408e4e938270f7",
+                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/830c43a844f1f8d5b7a1f6d6076b784454d8b7ed",
+                "reference": "830c43a844f1f8d5b7a1f6d6076b784454d8b7ed",
                 "shasum": ""
             },
             "require": {
@@ -3379,7 +3337,7 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/environment/issues",
-                "source": "https://github.com/sebastianbergmann/environment/tree/5.1.4"
+                "source": "https://github.com/sebastianbergmann/environment/tree/5.1.5"
             },
             "funding": [
                 {
@@ -3387,7 +3345,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2022-04-03T09:37:03+00:00"
+            "time": "2023-02-03T06:03:51+00:00"
         },
         {
             "name": "sebastian/exporter",
@@ -3701,16 +3659,16 @@
         },
         {
             "name": "sebastian/recursion-context",
-            "version": "4.0.4",
+            "version": "4.0.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/recursion-context.git",
-                "reference": "cd9d8cf3c5804de4341c283ed787f099f5506172"
+                "reference": "e75bd0f07204fec2a0af9b0f3cfe97d05f92efc1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/recursion-context/zipball/cd9d8cf3c5804de4341c283ed787f099f5506172",
-                "reference": "cd9d8cf3c5804de4341c283ed787f099f5506172",
+                "url": "https://api.github.com/repos/sebastianbergmann/recursion-context/zipball/e75bd0f07204fec2a0af9b0f3cfe97d05f92efc1",
+                "reference": "e75bd0f07204fec2a0af9b0f3cfe97d05f92efc1",
                 "shasum": ""
             },
             "require": {
@@ -3749,10 +3707,10 @@
                 }
             ],
             "description": "Provides functionality to recursively process PHP variables",
-            "homepage": "http://www.github.com/sebastianbergmann/recursion-context",
+            "homepage": "https://github.com/sebastianbergmann/recursion-context",
             "support": {
                 "issues": "https://github.com/sebastianbergmann/recursion-context/issues",
-                "source": "https://github.com/sebastianbergmann/recursion-context/tree/4.0.4"
+                "source": "https://github.com/sebastianbergmann/recursion-context/tree/4.0.5"
             },
             "funding": [
                 {
@@ -3760,7 +3718,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2020-10-26T13:17:30+00:00"
+            "time": "2023-02-03T06:07:39+00:00"
         },
         {
             "name": "sebastian/resource-operations",
@@ -3819,16 +3777,16 @@
         },
         {
             "name": "sebastian/type",
-            "version": "3.2.0",
+            "version": "3.2.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/type.git",
-                "reference": "fb3fe09c5f0bae6bc27ef3ce933a1e0ed9464b6e"
+                "reference": "75e2c2a32f5e0b3aef905b9ed0b179b953b3d7c7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/type/zipball/fb3fe09c5f0bae6bc27ef3ce933a1e0ed9464b6e",
-                "reference": "fb3fe09c5f0bae6bc27ef3ce933a1e0ed9464b6e",
+                "url": "https://api.github.com/repos/sebastianbergmann/type/zipball/75e2c2a32f5e0b3aef905b9ed0b179b953b3d7c7",
+                "reference": "75e2c2a32f5e0b3aef905b9ed0b179b953b3d7c7",
                 "shasum": ""
             },
             "require": {
@@ -3863,7 +3821,7 @@
             "homepage": "https://github.com/sebastianbergmann/type",
             "support": {
                 "issues": "https://github.com/sebastianbergmann/type/issues",
-                "source": "https://github.com/sebastianbergmann/type/tree/3.2.0"
+                "source": "https://github.com/sebastianbergmann/type/tree/3.2.1"
             },
             "funding": [
                 {
@@ -3871,7 +3829,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2022-09-12T14:47:03+00:00"
+            "time": "2023-02-03T06:13:03+00:00"
         },
         {
             "name": "sebastian/version",
@@ -3928,16 +3886,16 @@
         },
         {
             "name": "seld/jsonlint",
-            "version": "1.9.0",
+            "version": "1.10.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Seldaek/jsonlint.git",
-                "reference": "4211420d25eba80712bff236a98960ef68b866b7"
+                "reference": "594fd6462aad8ecee0b45ca5045acea4776667f1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Seldaek/jsonlint/zipball/4211420d25eba80712bff236a98960ef68b866b7",
-                "reference": "4211420d25eba80712bff236a98960ef68b866b7",
+                "url": "https://api.github.com/repos/Seldaek/jsonlint/zipball/594fd6462aad8ecee0b45ca5045acea4776667f1",
+                "reference": "594fd6462aad8ecee0b45ca5045acea4776667f1",
                 "shasum": ""
             },
             "require": {
@@ -3976,7 +3934,7 @@
             ],
             "support": {
                 "issues": "https://github.com/Seldaek/jsonlint/issues",
-                "source": "https://github.com/Seldaek/jsonlint/tree/1.9.0"
+                "source": "https://github.com/Seldaek/jsonlint/tree/1.10.0"
             },
             "funding": [
                 {
@@ -3988,7 +3946,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-04-01T13:37:23+00:00"
+            "time": "2023-05-11T13:16:46+00:00"
         },
         {
             "name": "slevomat/coding-standard",
@@ -4053,26 +4011,25 @@
         },
         {
             "name": "spatie/array-to-xml",
-            "version": "2.17.1",
+            "version": "3.1.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/spatie/array-to-xml.git",
-                "reference": "5cbec9c6ab17e320c58a259f0cebe88bde4a7c46"
+                "reference": "e210b98957987c755372465be105d32113f339a4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/spatie/array-to-xml/zipball/5cbec9c6ab17e320c58a259f0cebe88bde4a7c46",
-                "reference": "5cbec9c6ab17e320c58a259f0cebe88bde4a7c46",
+                "url": "https://api.github.com/repos/spatie/array-to-xml/zipball/e210b98957987c755372465be105d32113f339a4",
+                "reference": "e210b98957987c755372465be105d32113f339a4",
                 "shasum": ""
             },
             "require": {
                 "ext-dom": "*",
-                "php": "^7.4|^8.0"
+                "php": "^8.0"
             },
             "require-dev": {
                 "mockery/mockery": "^1.2",
                 "pestphp/pest": "^1.21",
-                "phpunit/phpunit": "^9.0",
                 "spatie/pest-plugin-snapshots": "^1.1"
             },
             "type": "library",
@@ -4101,7 +4058,7 @@
                 "xml"
             ],
             "support": {
-                "source": "https://github.com/spatie/array-to-xml/tree/2.17.1"
+                "source": "https://github.com/spatie/array-to-xml/tree/3.1.6"
             },
             "funding": [
                 {
@@ -4113,20 +4070,20 @@
                     "type": "github"
                 }
             ],
-            "time": "2022-12-26T08:22:07+00:00"
+            "time": "2023-05-11T14:04:07+00:00"
         },
         {
             "name": "squizlabs/php_codesniffer",
-            "version": "3.7.1",
+            "version": "3.7.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/squizlabs/PHP_CodeSniffer.git",
-                "reference": "1359e176e9307e906dc3d890bcc9603ff6d90619"
+                "reference": "ed8e00df0a83aa96acf703f8c2979ff33341f879"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/1359e176e9307e906dc3d890bcc9603ff6d90619",
-                "reference": "1359e176e9307e906dc3d890bcc9603ff6d90619",
+                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/ed8e00df0a83aa96acf703f8c2979ff33341f879",
+                "reference": "ed8e00df0a83aa96acf703f8c2979ff33341f879",
                 "shasum": ""
             },
             "require": {
@@ -4162,31 +4119,33 @@
             "homepage": "https://github.com/squizlabs/PHP_CodeSniffer",
             "keywords": [
                 "phpcs",
-                "standards"
+                "standards",
+                "static analysis"
             ],
             "support": {
                 "issues": "https://github.com/squizlabs/PHP_CodeSniffer/issues",
                 "source": "https://github.com/squizlabs/PHP_CodeSniffer",
                 "wiki": "https://github.com/squizlabs/PHP_CodeSniffer/wiki"
             },
-            "time": "2022-06-18T07:21:10+00:00"
+            "time": "2023-02-22T23:07:41+00:00"
         },
         {
             "name": "symfony/console",
-            "version": "v6.0.19",
+            "version": "v6.2.10",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/console.git",
-                "reference": "c3ebc83d031b71c39da318ca8b7a07ecc67507ed"
+                "reference": "12288d9f4500f84a4d02254d4aa968b15488476f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/console/zipball/c3ebc83d031b71c39da318ca8b7a07ecc67507ed",
-                "reference": "c3ebc83d031b71c39da318ca8b7a07ecc67507ed",
+                "url": "https://api.github.com/repos/symfony/console/zipball/12288d9f4500f84a4d02254d4aa968b15488476f",
+                "reference": "12288d9f4500f84a4d02254d4aa968b15488476f",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.0.2",
+                "php": ">=8.1",
+                "symfony/deprecation-contracts": "^2.1|^3",
                 "symfony/polyfill-mbstring": "~1.0",
                 "symfony/service-contracts": "^1.1|^2|^3",
                 "symfony/string": "^5.4|^6.0"
@@ -4243,12 +4202,12 @@
             "homepage": "https://symfony.com",
             "keywords": [
                 "cli",
-                "command line",
+                "command-line",
                 "console",
                 "terminal"
             ],
             "support": {
-                "source": "https://github.com/symfony/console/tree/v6.0.19"
+                "source": "https://github.com/symfony/console/tree/v6.2.10"
             },
             "funding": [
                 {
@@ -4264,29 +4223,29 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-01-01T08:36:10+00:00"
+            "time": "2023-04-28T13:37:43+00:00"
         },
         {
             "name": "symfony/deprecation-contracts",
-            "version": "v3.0.2",
+            "version": "v3.2.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/deprecation-contracts.git",
-                "reference": "26954b3d62a6c5fd0ea8a2a00c0353a14978d05c"
+                "reference": "e2d1534420bd723d0ef5aec58a22c5fe60ce6f5e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/deprecation-contracts/zipball/26954b3d62a6c5fd0ea8a2a00c0353a14978d05c",
-                "reference": "26954b3d62a6c5fd0ea8a2a00c0353a14978d05c",
+                "url": "https://api.github.com/repos/symfony/deprecation-contracts/zipball/e2d1534420bd723d0ef5aec58a22c5fe60ce6f5e",
+                "reference": "e2d1534420bd723d0ef5aec58a22c5fe60ce6f5e",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.0.2"
+                "php": ">=8.1"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "3.0-dev"
+                    "dev-main": "3.3-dev"
                 },
                 "thanks": {
                     "name": "symfony/contracts",
@@ -4315,7 +4274,7 @@
             "description": "A generic function and convention to trigger deprecation notices",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/deprecation-contracts/tree/v3.0.2"
+                "source": "https://github.com/symfony/deprecation-contracts/tree/v3.2.1"
             },
             "funding": [
                 {
@@ -4331,24 +4290,24 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-01-02T09:55:41+00:00"
+            "time": "2023-03-01T10:25:55+00:00"
         },
         {
             "name": "symfony/filesystem",
-            "version": "v6.0.19",
+            "version": "v6.2.10",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/filesystem.git",
-                "reference": "3d49eec03fda1f0fc19b7349fbbe55ebc1004214"
+                "reference": "fd588debf7d1bc16a2c84b4b3b71145d9946b894"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/filesystem/zipball/3d49eec03fda1f0fc19b7349fbbe55ebc1004214",
-                "reference": "3d49eec03fda1f0fc19b7349fbbe55ebc1004214",
+                "url": "https://api.github.com/repos/symfony/filesystem/zipball/fd588debf7d1bc16a2c84b4b3b71145d9946b894",
+                "reference": "fd588debf7d1bc16a2c84b4b3b71145d9946b894",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.0.2",
+                "php": ">=8.1",
                 "symfony/polyfill-ctype": "~1.8",
                 "symfony/polyfill-mbstring": "~1.8"
             },
@@ -4378,7 +4337,7 @@
             "description": "Provides basic utilities for the filesystem",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/filesystem/tree/v6.0.19"
+                "source": "https://github.com/symfony/filesystem/tree/v6.2.10"
             },
             "funding": [
                 {
@@ -4394,24 +4353,27 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-01-20T17:44:14+00:00"
+            "time": "2023-04-18T13:46:08+00:00"
         },
         {
             "name": "symfony/finder",
-            "version": "v6.0.19",
+            "version": "v6.2.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/finder.git",
-                "reference": "5cc9cac6586fc0c28cd173780ca696e419fefa11"
+                "reference": "20808dc6631aecafbe67c186af5dcb370be3a0eb"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/finder/zipball/5cc9cac6586fc0c28cd173780ca696e419fefa11",
-                "reference": "5cc9cac6586fc0c28cd173780ca696e419fefa11",
+                "url": "https://api.github.com/repos/symfony/finder/zipball/20808dc6631aecafbe67c186af5dcb370be3a0eb",
+                "reference": "20808dc6631aecafbe67c186af5dcb370be3a0eb",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.0.2"
+                "php": ">=8.1"
+            },
+            "require-dev": {
+                "symfony/filesystem": "^6.0"
             },
             "type": "library",
             "autoload": {
@@ -4439,7 +4401,7 @@
             "description": "Finds files and directories via an intuitive fluent interface",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/finder/tree/v6.0.19"
+                "source": "https://github.com/symfony/finder/tree/v6.2.7"
             },
             "funding": [
                 {
@@ -4455,24 +4417,24 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-01-20T17:44:14+00:00"
+            "time": "2023-02-16T09:57:23+00:00"
         },
         {
             "name": "symfony/options-resolver",
-            "version": "v6.0.19",
+            "version": "v6.2.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/options-resolver.git",
-                "reference": "6a180d1c45e0d9797470ca9eb46215692de00fa3"
+                "reference": "aa0e85b53bbb2b4951960efd61d295907eacd629"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/options-resolver/zipball/6a180d1c45e0d9797470ca9eb46215692de00fa3",
-                "reference": "6a180d1c45e0d9797470ca9eb46215692de00fa3",
+                "url": "https://api.github.com/repos/symfony/options-resolver/zipball/aa0e85b53bbb2b4951960efd61d295907eacd629",
+                "reference": "aa0e85b53bbb2b4951960efd61d295907eacd629",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.0.2",
+                "php": ">=8.1",
                 "symfony/deprecation-contracts": "^2.1|^3"
             },
             "type": "library",
@@ -4506,7 +4468,7 @@
                 "options"
             ],
             "support": {
-                "source": "https://github.com/symfony/options-resolver/tree/v6.0.19"
+                "source": "https://github.com/symfony/options-resolver/tree/v6.2.7"
             },
             "funding": [
                 {
@@ -4522,7 +4484,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-01-01T08:36:10+00:00"
+            "time": "2023-02-14T08:44:56+00:00"
         },
         {
             "name": "symfony/polyfill-ctype",
@@ -4856,20 +4818,20 @@
         },
         {
             "name": "symfony/process",
-            "version": "v6.0.19",
+            "version": "v6.2.10",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/process.git",
-                "reference": "2114fd60f26a296cc403a7939ab91478475a33d4"
+                "reference": "b34cdbc9c5e75d45a3703e63a48ad07aafa8bf2e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/process/zipball/2114fd60f26a296cc403a7939ab91478475a33d4",
-                "reference": "2114fd60f26a296cc403a7939ab91478475a33d4",
+                "url": "https://api.github.com/repos/symfony/process/zipball/b34cdbc9c5e75d45a3703e63a48ad07aafa8bf2e",
+                "reference": "b34cdbc9c5e75d45a3703e63a48ad07aafa8bf2e",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.0.2"
+                "php": ">=8.1"
             },
             "type": "library",
             "autoload": {
@@ -4897,7 +4859,7 @@
             "description": "Executes commands in sub-processes",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/process/tree/v6.0.19"
+                "source": "https://github.com/symfony/process/tree/v6.2.10"
             },
             "funding": [
                 {
@@ -4913,7 +4875,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-01-01T08:36:10+00:00"
+            "time": "2023-04-18T13:56:57+00:00"
         },
         {
             "name": "symfony/service-contracts",
@@ -5000,20 +4962,20 @@
         },
         {
             "name": "symfony/string",
-            "version": "v6.0.19",
+            "version": "v6.2.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/string.git",
-                "reference": "d9e72497367c23e08bf94176d2be45b00a9d232a"
+                "reference": "193e83bbd6617d6b2151c37fff10fa7168ebddef"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/string/zipball/d9e72497367c23e08bf94176d2be45b00a9d232a",
-                "reference": "d9e72497367c23e08bf94176d2be45b00a9d232a",
+                "url": "https://api.github.com/repos/symfony/string/zipball/193e83bbd6617d6b2151c37fff10fa7168ebddef",
+                "reference": "193e83bbd6617d6b2151c37fff10fa7168ebddef",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.0.2",
+                "php": ">=8.1",
                 "symfony/polyfill-ctype": "~1.8",
                 "symfony/polyfill-intl-grapheme": "~1.0",
                 "symfony/polyfill-intl-normalizer": "~1.0",
@@ -5025,6 +4987,7 @@
             "require-dev": {
                 "symfony/error-handler": "^5.4|^6.0",
                 "symfony/http-client": "^5.4|^6.0",
+                "symfony/intl": "^6.2",
                 "symfony/translation-contracts": "^2.0|^3.0",
                 "symfony/var-exporter": "^5.4|^6.0"
             },
@@ -5065,7 +5028,7 @@
                 "utf8"
             ],
             "support": {
-                "source": "https://github.com/symfony/string/tree/v6.0.19"
+                "source": "https://github.com/symfony/string/tree/v6.2.8"
             },
             "funding": [
                 {
@@ -5081,7 +5044,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-01-01T08:36:10+00:00"
+            "time": "2023-03-20T16:06:02+00:00"
         },
         {
             "name": "theseer/tokenizer",
@@ -5135,22 +5098,22 @@
         },
         {
             "name": "vimeo/psalm",
-            "version": "5.6.0",
+            "version": "5.11.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/vimeo/psalm.git",
-                "reference": "e784128902dfe01d489c4123d69918a9f3c1eac5"
+                "reference": "c9b192ab8400fdaf04b2b13d110575adc879aa90"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/vimeo/psalm/zipball/e784128902dfe01d489c4123d69918a9f3c1eac5",
-                "reference": "e784128902dfe01d489c4123d69918a9f3c1eac5",
+                "url": "https://api.github.com/repos/vimeo/psalm/zipball/c9b192ab8400fdaf04b2b13d110575adc879aa90",
+                "reference": "c9b192ab8400fdaf04b2b13d110575adc879aa90",
                 "shasum": ""
             },
             "require": {
                 "amphp/amp": "^2.4.2",
                 "amphp/byte-stream": "^1.5",
-                "composer/package-versions-deprecated": "^1.10.0",
+                "composer-runtime-api": "^2",
                 "composer/semver": "^1.4 || ^2.0 || ^3.0",
                 "composer/xdebug-handler": "^2.0 || ^3.0",
                 "dnoegel/php-xdg-base-dir": "^0.1.1",
@@ -5163,12 +5126,12 @@
                 "ext-tokenizer": "*",
                 "felixfbecker/advanced-json-rpc": "^3.1",
                 "felixfbecker/language-server-protocol": "^1.5.2",
-                "fidry/cpu-core-counter": "^0.4.0",
+                "fidry/cpu-core-counter": "^0.4.1 || ^0.5.1",
                 "netresearch/jsonmapper": "^1.0 || ^2.0 || ^3.0 || ^4.0",
-                "nikic/php-parser": "^4.13",
+                "nikic/php-parser": "^4.14",
                 "php": "^7.4 || ~8.0.0 || ~8.1.0 || ~8.2.0",
                 "sebastian/diff": "^4.0 || ^5.0",
-                "spatie/array-to-xml": "^2.17.0",
+                "spatie/array-to-xml": "^2.17.0 || ^3.0",
                 "symfony/console": "^4.1.6 || ^5.0 || ^6.0",
                 "symfony/filesystem": "^5.4 || ^6.0"
             },
@@ -5176,14 +5139,15 @@
                 "psalm/psalm": "self.version"
             },
             "require-dev": {
+                "amphp/phpunit-util": "^2.0",
                 "bamarni/composer-bin-plugin": "^1.4",
-                "brianium/paratest": "^6.0",
+                "brianium/paratest": "^6.9",
                 "ext-curl": "*",
                 "mockery/mockery": "^1.5",
                 "nunomaduro/mock-final-classes": "^1.1",
                 "php-parallel-lint/php-parallel-lint": "^1.2",
                 "phpstan/phpdoc-parser": "^1.6",
-                "phpunit/phpunit": "^9.5",
+                "phpunit/phpunit": "^9.6",
                 "psalm/plugin-mockery": "^1.1",
                 "psalm/plugin-phpunit": "^0.18",
                 "slevomat/coding-standard": "^8.4",
@@ -5229,34 +5193,35 @@
             "keywords": [
                 "code",
                 "inspection",
-                "php"
+                "php",
+                "static analysis"
             ],
             "support": {
                 "issues": "https://github.com/vimeo/psalm/issues",
-                "source": "https://github.com/vimeo/psalm/tree/5.6.0"
+                "source": "https://github.com/vimeo/psalm/tree/5.11.0"
             },
-            "time": "2023-01-23T20:32:47+00:00"
+            "time": "2023-05-04T21:35:44+00:00"
         },
         {
             "name": "webimpress/coding-standard",
-            "version": "1.2.4",
+            "version": "1.3.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/webimpress/coding-standard.git",
-                "reference": "cd0c4b0b97440c337c1f7da17b524674ca2f9ca9"
+                "reference": "b26557e2386711ecb74f22718f4b4bde5ddbc899"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/webimpress/coding-standard/zipball/cd0c4b0b97440c337c1f7da17b524674ca2f9ca9",
-                "reference": "cd0c4b0b97440c337c1f7da17b524674ca2f9ca9",
+                "url": "https://api.github.com/repos/webimpress/coding-standard/zipball/b26557e2386711ecb74f22718f4b4bde5ddbc899",
+                "reference": "b26557e2386711ecb74f22718f4b4bde5ddbc899",
                 "shasum": ""
             },
             "require": {
                 "php": "^7.3 || ^8.0",
-                "squizlabs/php_codesniffer": "^3.6.2"
+                "squizlabs/php_codesniffer": "^3.7.2"
             },
             "require-dev": {
-                "phpunit/phpunit": "^9.5.13"
+                "phpunit/phpunit": "^9.6.4"
             },
             "type": "phpcodesniffer-standard",
             "extra": {
@@ -5282,7 +5247,7 @@
             ],
             "support": {
                 "issues": "https://github.com/webimpress/coding-standard/issues",
-                "source": "https://github.com/webimpress/coding-standard/tree/1.2.4"
+                "source": "https://github.com/webimpress/coding-standard/tree/1.3.1"
             },
             "funding": [
                 {
@@ -5290,7 +5255,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2022-02-15T19:52:12+00:00"
+            "time": "2023-03-09T15:05:18+00:00"
         },
         {
             "name": "webimpress/safe-writer",
@@ -5407,11 +5372,11 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": "~8.0.0 || ~8.1.0 || ~8.2.0"
+        "php": "~8.1.0 || ~8.2.0"
     },
     "platform-dev": [],
     "platform-overrides": {
-        "php": "8.0.99"
+        "php": "8.1.99"
     },
     "plugin-api-version": "2.3.0"
 }

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,26 +1,31 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd" bootstrap="./vendor/autoload.php" colors="true">
-  <coverage includeUncoveredFiles="true">
-    <include>
-      <directory suffix=".php">./src</directory>
-    </include>
-  </coverage>
-  <testsuites>
-    <testsuite name="laminas-hydrator Test Suite">
-      <directory>./test/</directory>
-    </testsuite>
-  </testsuites>
-  <groups>
-    <exclude>
-      <group>disable</group>
-    </exclude>
-  </groups>
-  <php>
-    <ini name="date.timezone" value="UTC"/>
-    <!-- OB_ENABLED should be enabled for some tests to check if all
-             functionality works as expected. Such tests include those for
-             Laminas\Soap and Laminas\Session, which require that headers not be sent
-             in order to work. -->
-    <env name="TESTS_LAMINAS_OB_ENABLED" value="false"/>
-  </php>
+<phpunit
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
+    bootstrap="./vendor/autoload.php"
+    colors="true"
+    displayDetailsOnTestsThatTriggerWarnings="true"
+    displayDetailsOnTestsThatTriggerNotices="true"
+    displayDetailsOnTestsThatTriggerErrors="true"
+    displayDetailsOnTestsThatTriggerDeprecations="true"
+    displayDetailsOnSkippedTests="true"
+    displayDetailsOnIncompleteTests="true"
+    failOnNotice="true"
+    failOnDeprecation="true"
+    failOnWarning="true"
+>
+    <coverage includeUncoveredFiles="true"/>
+    <testsuites>
+        <testsuite name="laminas-hydrator Test Suite">
+            <directory>./test/</directory>
+        </testsuite>
+    </testsuites>
+    <php>
+        <ini name="date.timezone" value="UTC"/>
+    </php>
+    <source>
+        <include>
+            <directory suffix=".php">./src</directory>
+        </include>
+    </source>
 </phpunit>

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -56,8 +56,8 @@
     </DocblockTypeContradiction>
     <MixedArgument>
       <code>$options</code>
-      <code>$options['methodExistsCheck']</code>
-      <code>$options['underscoreSeparatedKeys']</code>
+      <code><![CDATA[$options['methodExistsCheck']]]></code>
+      <code><![CDATA[$options['underscoreSeparatedKeys']]]></code>
     </MixedArgument>
     <MixedArgumentTypeCoercion>
       <code>$property</code>
@@ -105,6 +105,11 @@
       <code>ClassMethods::class</code>
       <code>ObjectProperty::class</code>
       <code>Reflection::class</code>
+    </DeprecatedClass>
+  </file>
+  <file src="src/HydratorPluginManagerFactory.php">
+    <DeprecatedClass>
+      <code><![CDATA[new Config($config['hydrators'])]]></code>
     </DeprecatedClass>
   </file>
   <file src="src/Iterator/HydratingIteratorIterator.php">
@@ -221,19 +226,6 @@
       <code>new $class()</code>
     </InvalidStringClass>
   </file>
-  <file src="src/Strategy/BackedEnumStrategy.php">
-    <MixedInferredReturnType>
-      <code>T</code>
-    </MixedInferredReturnType>
-    <MixedReturnStatement>
-      <code><![CDATA[$this->enumClass::from($value)]]></code>
-    </MixedReturnStatement>
-    <UndefinedClass>
-      <code><![CDATA[$this->enumClass]]></code>
-      <code><![CDATA[$value->value]]></code>
-      <code>string</code>
-    </UndefinedClass>
-  </file>
   <file src="src/Strategy/BooleanStrategy.php">
     <DocblockTypeContradiction>
       <code><![CDATA[! is_int($falseValue) && ! is_string($falseValue)]]></code>
@@ -332,8 +324,8 @@
   </file>
   <file src="test/ArraySerializableHydratorTest.php">
     <InvalidArgument>
-      <code>'thisIsNotAnObject'</code>
-      <code>'thisIsNotAnObject'</code>
+      <code><![CDATA['thisIsNotAnObject']]></code>
+      <code><![CDATA['thisIsNotAnObject']]></code>
     </InvalidArgument>
   </file>
   <file src="test/ArraySerializableTest.php">
@@ -344,9 +336,9 @@
   <file src="test/ClassMethodsHydratorTest.php">
     <InvalidArgument>
       <code>$options</code>
-      <code>'invalid options'</code>
-      <code>'non-object'</code>
-      <code>'non-object'</code>
+      <code><![CDATA['invalid options']]></code>
+      <code><![CDATA['non-object']]></code>
+      <code><![CDATA['non-object']]></code>
     </InvalidArgument>
   </file>
   <file src="test/ClassMethodsTest.php">
@@ -431,11 +423,11 @@
   </file>
   <file src="test/HydratorStrategyTest.php">
     <MixedArgument>
-      <code>$attributes['entities']</code>
-      <code>$attributes['entities']</code>
+      <code><![CDATA[$attributes['entities']]]></code>
+      <code><![CDATA[$attributes['entities']]]></code>
     </MixedArgument>
     <MixedArrayAssignment>
-      <code>$attributes['entities'][]</code>
+      <code><![CDATA[$attributes['entities'][]]]></code>
     </MixedArrayAssignment>
     <UndefinedInterfaceMethod>
       <code>addStrategy</code>
@@ -470,12 +462,12 @@
   </file>
   <file src="test/Iterator/HydratingArrayIteratorTest.php">
     <ArgumentTypeCoercion>
-      <code>'not a real class'</code>
+      <code><![CDATA['not a real class']]></code>
     </ArgumentTypeCoercion>
   </file>
   <file src="test/Iterator/HydratingIteratorIteratorTest.php">
     <ArgumentTypeCoercion>
-      <code>'not a real class'</code>
+      <code><![CDATA['not a real class']]></code>
     </ArgumentTypeCoercion>
   </file>
   <file src="test/NamingStrategy/UnderscoreNamingStrategy/CamelCaseToUnderscoreFilterTest.php">
@@ -507,8 +499,8 @@
       <code>assertObjectHasAttribute</code>
     </DeprecatedMethod>
     <InvalidArgument>
-      <code>'thisIsNotAnObject'</code>
-      <code>'thisIsNotAnObject'</code>
+      <code><![CDATA['thisIsNotAnObject']]></code>
+      <code><![CDATA['thisIsNotAnObject']]></code>
     </InvalidArgument>
   </file>
   <file src="test/ObjectPropertyTest.php">
@@ -558,36 +550,6 @@
       <code>$factories</code>
       <code>$instance</code>
     </MixedAssignment>
-  </file>
-  <file src="test/Strategy/BackedEnumStrategyTest.php">
-    <MixedArgument>
-      <code>TestBackedEnum::class</code>
-      <code>TestBackedEnum::class</code>
-      <code>TestBackedEnum::class</code>
-      <code>TestBackedEnum::class</code>
-      <code>TestBackedEnum::class</code>
-      <code>TestBackedEnum::class</code>
-    </MixedArgument>
-    <MixedAssignment>
-      <code>$expected</code>
-    </MixedAssignment>
-    <MixedOperand>
-      <code>TestBackedEnum::class</code>
-    </MixedOperand>
-    <UndefinedClass>
-      <code>TestBackedEnum</code>
-      <code>TestBackedEnum</code>
-      <code>TestBackedEnum</code>
-      <code>TestBackedEnum</code>
-      <code>TestBackedEnum</code>
-      <code>TestBackedEnum</code>
-      <code>TestBackedEnum</code>
-      <code>TestBackedEnum</code>
-      <code>TestBackedEnum</code>
-      <code>TestBackedEnum</code>
-      <code>TestBackedEnum</code>
-      <code>TestUnitEnum</code>
-    </UndefinedClass>
   </file>
   <file src="test/Strategy/BooleanStrategyTest.php">
     <InvalidArgument>

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -375,6 +375,7 @@
   </file>
   <file src="test/ArraySerializableTest.php">
     <DeprecatedClass>
+      <code>ArraySerializable::class</code>
       <code>new ArraySerializable()</code>
     </DeprecatedClass>
   </file>
@@ -388,6 +389,7 @@
   </file>
   <file src="test/ClassMethodsTest.php">
     <DeprecatedClass>
+      <code>ClassMethods::class</code>
       <code>new ClassMethods()</code>
     </DeprecatedClass>
   </file>
@@ -595,6 +597,7 @@
   </file>
   <file src="test/ObjectPropertyTest.php">
     <DeprecatedClass>
+      <code>ObjectProperty::class</code>
       <code>new ObjectProperty()</code>
     </DeprecatedClass>
   </file>
@@ -606,6 +609,7 @@
   </file>
   <file src="test/ReflectionTest.php">
     <DeprecatedClass>
+      <code>Reflection::class</code>
       <code>new Reflection()</code>
     </DeprecatedClass>
   </file>

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -70,6 +70,9 @@
     <MixedMethodCall>
       <code><![CDATA[$this->hydrationMethodsCache[$propertyFqn]]]></code>
     </MixedMethodCall>
+    <PossiblyUnusedMethod>
+      <code>getMethodExistsCheck</code>
+    </PossiblyUnusedMethod>
   </file>
   <file src="src/DelegatingHydrator.php">
     <MixedInferredReturnType>
@@ -99,6 +102,16 @@
       <code>$filter</code>
     </MixedAssignment>
   </file>
+  <file src="src/Filter/FilterEnabledInterface.php">
+    <PossiblyUnusedMethod>
+      <code>hasFilter</code>
+    </PossiblyUnusedMethod>
+  </file>
+  <file src="src/HydratorAwareInterface.php">
+    <UnusedClass>
+      <code>HydratorAwareInterface</code>
+    </UnusedClass>
+  </file>
   <file src="src/HydratorPluginManager.php">
     <DeprecatedClass>
       <code>ArraySerializable::class</code>
@@ -106,11 +119,22 @@
       <code>ObjectProperty::class</code>
       <code>Reflection::class</code>
     </DeprecatedClass>
+    <PossiblyUnusedProperty>
+      <code>$shareByDefault</code>
+    </PossiblyUnusedProperty>
   </file>
   <file src="src/HydratorPluginManagerFactory.php">
     <DeprecatedClass>
       <code><![CDATA[new Config($config['hydrators'])]]></code>
     </DeprecatedClass>
+    <UnusedParam>
+      <code>$name</code>
+    </UnusedParam>
+  </file>
+  <file src="src/HydratorProviderInterface.php">
+    <PossiblyUnusedMethod>
+      <code>getHydratorConfig</code>
+    </PossiblyUnusedMethod>
   </file>
   <file src="src/Iterator/HydratingIteratorIterator.php">
     <InvalidArgument>
@@ -129,6 +153,9 @@
       <code>addServiceManager</code>
       <code>get</code>
     </MixedMethodCall>
+    <UnusedClass>
+      <code>Module</code>
+    </UnusedClass>
   </file>
   <file src="src/NamingStrategy/MapNamingStrategy.php">
     <MissingClosureParamType>
@@ -226,6 +253,11 @@
       <code>new $class()</code>
     </InvalidStringClass>
   </file>
+  <file src="src/StandaloneHydratorPluginManagerFactory.php">
+    <UnusedParam>
+      <code>$container</code>
+    </UnusedParam>
+  </file>
   <file src="src/Strategy/BooleanStrategy.php">
     <DocblockTypeContradiction>
       <code><![CDATA[! is_int($falseValue) && ! is_string($falseValue)]]></code>
@@ -316,6 +348,11 @@
       <code>$value</code>
     </MixedAssignment>
   </file>
+  <file src="src/Strategy/StrategyEnabledInterface.php">
+    <PossiblyUnusedMethod>
+      <code>removeStrategy</code>
+    </PossiblyUnusedMethod>
+  </file>
   <file src="test/Aggregate/HydratorListenerTest.php">
     <InternalMethod>
       <code>onExtract</code>
@@ -365,6 +402,32 @@
       <code>$orFilters</code>
       <code>$value</code>
     </MixedAssignment>
+  </file>
+  <file src="test/Filter/NumberOfParameterFilterTest.php">
+    <PossiblyUnusedMethod>
+      <code>methodWithNoParameters</code>
+      <code>methodWithOptionalParameters</code>
+    </PossiblyUnusedMethod>
+    <PossiblyUnusedParam>
+      <code>$parameter</code>
+    </PossiblyUnusedParam>
+  </file>
+  <file src="test/Filter/OptionalParametersFilterTest.php">
+    <PossiblyUnusedMethod>
+      <code>methodWithMultipleMandatoryParameters</code>
+      <code>methodWithMultipleOptionalParameters</code>
+      <code>methodWithSingleMandatoryParameter</code>
+      <code>methodWithSingleOptionalParameter</code>
+      <code>methodWithoutParameters</code>
+    </PossiblyUnusedMethod>
+    <PossiblyUnusedParam>
+      <code>$otherParameter</code>
+      <code>$otherParameter</code>
+      <code>$parameter</code>
+      <code>$parameter</code>
+      <code>$parameter</code>
+      <code>$parameter</code>
+    </PossiblyUnusedParam>
   </file>
   <file src="test/HydratorAwareTraitTest.php">
     <InvalidArgument>

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -353,6 +353,11 @@
       <code>removeStrategy</code>
     </PossiblyUnusedMethod>
   </file>
+  <file src="test/Aggregate/AggregateHydratorFunctionalTest.php">
+    <PossiblyUnusedMethod>
+      <code>getHydratorSet</code>
+    </PossiblyUnusedMethod>
+  </file>
   <file src="test/Aggregate/HydratorListenerTest.php">
     <InternalMethod>
       <code>onExtract</code>
@@ -364,6 +369,9 @@
       <code><![CDATA['thisIsNotAnObject']]></code>
       <code><![CDATA['thisIsNotAnObject']]></code>
     </InvalidArgument>
+    <PossiblyUnusedMethod>
+      <code>arrayDataProvider</code>
+    </PossiblyUnusedMethod>
   </file>
   <file src="test/ArraySerializableTest.php">
     <DeprecatedClass>
@@ -391,9 +399,7 @@
     <MixedArgumentTypeCoercion>
       <code>$andFilters</code>
       <code>$andFilters</code>
-      <code>$andFilters</code>
       <code>$name</code>
-      <code>$orFilters</code>
       <code>$orFilters</code>
       <code>$orFilters</code>
     </MixedArgumentTypeCoercion>
@@ -402,6 +408,16 @@
       <code>$orFilters</code>
       <code>$value</code>
     </MixedAssignment>
+    <PossiblyUnusedMethod>
+      <code>invalidFiltersProvider</code>
+      <code>providerCompositionFiltering</code>
+      <code>validFiltersProvider</code>
+    </PossiblyUnusedMethod>
+  </file>
+  <file src="test/Filter/MethodMatchFilterTest.php">
+    <PossiblyUnusedMethod>
+      <code>providerFilter</code>
+    </PossiblyUnusedMethod>
   </file>
   <file src="test/Filter/NumberOfParameterFilterTest.php">
     <PossiblyUnusedMethod>
@@ -414,6 +430,7 @@
   </file>
   <file src="test/Filter/OptionalParametersFilterTest.php">
     <PossiblyUnusedMethod>
+      <code>methodProvider</code>
       <code>methodWithMultipleMandatoryParameters</code>
       <code>methodWithMultipleOptionalParameters</code>
       <code>methodWithSingleMandatoryParameter</code>
@@ -428,20 +445,6 @@
       <code>$parameter</code>
       <code>$parameter</code>
     </PossiblyUnusedParam>
-  </file>
-  <file src="test/HydratorAwareTraitTest.php">
-    <InvalidArgument>
-      <code>HydratorAwareTrait::class</code>
-      <code>HydratorAwareTrait::class</code>
-    </InvalidArgument>
-    <MixedMethodCall>
-      <code>getHydrator</code>
-      <code>getHydrator</code>
-      <code>getHydrator</code>
-      <code>getHydrator</code>
-      <code>setHydrator</code>
-      <code>setHydrator</code>
-    </MixedMethodCall>
   </file>
   <file src="test/HydratorClosureStrategyTest.php">
     <MissingClosureParamType>
@@ -492,6 +495,9 @@
     <MixedArrayAssignment>
       <code><![CDATA[$attributes['entities'][]]]></code>
     </MixedArrayAssignment>
+    <PossiblyUnusedMethod>
+      <code>underscoreHandlingDataProvider</code>
+    </PossiblyUnusedMethod>
     <UndefinedInterfaceMethod>
       <code>addStrategy</code>
       <code>addStrategy</code>
@@ -522,6 +528,9 @@
       <code>$property</code>
       <code>$property</code>
     </MixedArgument>
+    <PossiblyUnusedMethod>
+      <code>filterProvider</code>
+    </PossiblyUnusedMethod>
   </file>
   <file src="test/Iterator/HydratingArrayIteratorTest.php">
     <ArgumentTypeCoercion>
@@ -532,6 +541,17 @@
     <ArgumentTypeCoercion>
       <code><![CDATA['not a real class']]></code>
     </ArgumentTypeCoercion>
+  </file>
+  <file src="test/NamingStrategy/IdentityNamingStrategyTest.php">
+    <PossiblyUnusedMethod>
+      <code>getTestedNames</code>
+    </PossiblyUnusedMethod>
+  </file>
+  <file src="test/NamingStrategy/MapNamingStrategyTest.php">
+    <PossiblyUnusedMethod>
+      <code>invalidKeyArrays</code>
+      <code>invalidMapValues</code>
+    </PossiblyUnusedMethod>
   </file>
   <file src="test/NamingStrategy/UnderscoreNamingStrategy/CamelCaseToUnderscoreFilterTest.php">
     <InternalClass>
@@ -544,6 +564,11 @@
       <code>filter</code>
       <code>filter</code>
     </InternalMethod>
+    <PossiblyUnusedMethod>
+      <code>nonUnicodeProvider</code>
+      <code>unicodeProvider</code>
+      <code>unicodeProviderWithoutMbStrings</code>
+    </PossiblyUnusedMethod>
   </file>
   <file src="test/NamingStrategy/UnderscoreNamingStrategy/UnderscoreToCamelCaseFilterTest.php">
     <InternalClass>
@@ -556,11 +581,13 @@
       <code>filter</code>
       <code>filter</code>
     </InternalMethod>
+    <PossiblyUnusedMethod>
+      <code>nonUnicodeProvider</code>
+      <code>unicodeProvider</code>
+      <code>unicodeWithoutMbStringsProvider</code>
+    </PossiblyUnusedMethod>
   </file>
   <file src="test/ObjectPropertyHydratorTest.php">
-    <DeprecatedMethod>
-      <code>assertObjectHasAttribute</code>
-    </DeprecatedMethod>
     <InvalidArgument>
       <code><![CDATA['thisIsNotAnObject']]></code>
       <code><![CDATA['thisIsNotAnObject']]></code>
@@ -605,7 +632,6 @@
       <code>$factories</code>
     </MixedArgument>
     <MixedArrayAccess>
-      <code>$factories[$class]</code>
       <code>$factories[Hydrator\DelegatingHydrator::class]</code>
     </MixedArrayAccess>
     <MixedAssignment>
@@ -613,6 +639,9 @@
       <code>$factories</code>
       <code>$instance</code>
     </MixedAssignment>
+    <PossiblyUnusedMethod>
+      <code>knownServices</code>
+    </PossiblyUnusedMethod>
   </file>
   <file src="test/Strategy/BooleanStrategyTest.php">
     <InvalidArgument>
@@ -634,6 +663,12 @@
     <MixedMethodCall>
       <code>hydrate</code>
     </MixedMethodCall>
+    <PossiblyUnusedMethod>
+      <code>providerInvalidObjectClassName</code>
+      <code>providerInvalidObjectForExtraction</code>
+      <code>providerInvalidValueForExtraction</code>
+      <code>providerInvalidValueForHydration</code>
+    </PossiblyUnusedMethod>
   </file>
   <file src="test/Strategy/DateTimeFormatterStrategyTest.php">
     <MixedAssignment>
@@ -648,11 +683,24 @@
       <code>getName</code>
       <code>getTimezone</code>
     </MixedMethodCall>
+    <PossiblyUnusedMethod>
+      <code>formatsWithSpecialCharactersProvider</code>
+      <code>invalidValuesForHydration</code>
+      <code>validUnHydratableValues</code>
+    </PossiblyUnusedMethod>
   </file>
   <file src="test/Strategy/DateTimeImmutableFormatterStrategyTest.php">
     <MixedMethodCall>
       <code>format</code>
     </MixedMethodCall>
+    <PossiblyUnusedMethod>
+      <code>dataProviderForInvalidDateValues</code>
+    </PossiblyUnusedMethod>
+  </file>
+  <file src="test/Strategy/ExplodeStrategyTest.php">
+    <PossiblyUnusedMethod>
+      <code>getValidHydratedValues</code>
+    </PossiblyUnusedMethod>
   </file>
   <file src="test/Strategy/HydratorStrategyTest.php">
     <MissingClosureParamType>
@@ -670,6 +718,13 @@
     <MixedMethodCall>
       <code>hydrate</code>
     </MixedMethodCall>
+    <PossiblyUnusedMethod>
+      <code>providerEmptyOrSameObjects</code>
+      <code>providerInvalidObjectClassName</code>
+      <code>providerInvalidObjectForExtraction</code>
+      <code>providerInvalidValueForExtraction</code>
+      <code>providerInvalidValueForHydration</code>
+    </PossiblyUnusedMethod>
   </file>
   <file src="test/Strategy/SerializableStrategyTest.php">
     <MixedAssignment>

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<files psalm-version="5.6.0@e784128902dfe01d489c4123d69918a9f3c1eac5">
+<files psalm-version="5.11.0@c9b192ab8400fdaf04b2b13d110575adc879aa90">
   <file src="src/Aggregate/AggregateHydrator.php">
     <DocblockTypeContradiction>
-      <code>null === $this-&gt;eventManager</code>
+      <code><![CDATA[null === $this->eventManager]]></code>
     </DocblockTypeContradiction>
     <MissingConstructor>
       <code>$eventManager</code>
@@ -52,7 +52,7 @@
   <file src="src/ClassMethodsHydrator.php">
     <DocblockTypeContradiction>
       <code>$options instanceof Traversable</code>
-      <code>null === $this-&gt;extractionMethodsCache[$objectClass]</code>
+      <code><![CDATA[null === $this->extractionMethodsCache[$objectClass]]]></code>
     </DocblockTypeContradiction>
     <MixedArgument>
       <code>$options</code>
@@ -68,7 +68,7 @@
       <code>$values[$realAttributeName]</code>
     </MixedAssignment>
     <MixedMethodCall>
-      <code>$this-&gt;hydrationMethodsCache[$propertyFqn]</code>
+      <code><![CDATA[$this->hydrationMethodsCache[$propertyFqn]]]></code>
     </MixedMethodCall>
   </file>
   <file src="src/DelegatingHydrator.php">
@@ -76,7 +76,7 @@
       <code>HydratorInterface</code>
     </MixedInferredReturnType>
     <MixedReturnStatement>
-      <code>$this-&gt;hydrators-&gt;get($object::class)</code>
+      <code><![CDATA[$this->hydrators->get($object::class)]]></code>
     </MixedReturnStatement>
   </file>
   <file src="src/DelegatingHydratorFactory.php">
@@ -84,9 +84,9 @@
       <code>ContainerInterface</code>
     </MixedInferredReturnType>
     <MixedReturnStatement>
-      <code>$container-&gt;get('HydratorManager')</code>
-      <code>$container-&gt;get('Zend\Hydrator\HydratorPluginManager')</code>
-      <code>$container-&gt;get(HydratorPluginManager::class)</code>
+      <code><![CDATA[$container->get('HydratorManager')]]></code>
+      <code><![CDATA[$container->get('Zend\Hydrator\HydratorPluginManager')]]></code>
+      <code><![CDATA[$container->get(HydratorPluginManager::class)]]></code>
     </MixedReturnStatement>
   </file>
   <file src="src/Filter/FilterComposite.php">
@@ -143,8 +143,8 @@
   </file>
   <file src="src/NamingStrategy/UnderscoreNamingStrategy/StringSupportTrait.php">
     <DocblockTypeContradiction>
-      <code>$this-&gt;mbStringSupport === null</code>
-      <code>$this-&gt;pcreUnicodeSupport === null</code>
+      <code><![CDATA[$this->mbStringSupport === null]]></code>
+      <code><![CDATA[$this->pcreUnicodeSupport === null]]></code>
     </DocblockTypeContradiction>
     <MissingConstructor>
       <code>$mbStringSupport</code>
@@ -168,7 +168,7 @@
       <code>$value[0]</code>
     </MixedArgument>
     <MixedArgumentTypeCoercion>
-      <code>$pcreInfo-&gt;replacement</code>
+      <code><![CDATA[$pcreInfo->replacement]]></code>
     </MixedArgumentTypeCoercion>
     <MixedArrayAccess>
       <code>$matches[2]</code>
@@ -192,7 +192,7 @@
       <code>$value</code>
     </MixedAssignment>
     <UnsupportedReferenceUsage>
-      <code>$properties = &amp;self::$skippedPropertiesCache[$object::class]</code>
+      <code><![CDATA[$properties = &self::$skippedPropertiesCache[$object::class]]]></code>
     </UnsupportedReferenceUsage>
   </file>
   <file src="src/Reflection.php">
@@ -226,19 +226,19 @@
       <code>T</code>
     </MixedInferredReturnType>
     <MixedReturnStatement>
-      <code>$this-&gt;enumClass::from($value)</code>
+      <code><![CDATA[$this->enumClass::from($value)]]></code>
     </MixedReturnStatement>
     <UndefinedClass>
-      <code>$this-&gt;enumClass</code>
-      <code>$value-&gt;value</code>
+      <code><![CDATA[$this->enumClass]]></code>
+      <code><![CDATA[$value->value]]></code>
       <code>string</code>
     </UndefinedClass>
   </file>
   <file src="src/Strategy/BooleanStrategy.php">
     <DocblockTypeContradiction>
-      <code>! is_int($falseValue) &amp;&amp; ! is_string($falseValue)</code>
-      <code>! is_int($trueValue) &amp;&amp; ! is_string($trueValue)</code>
-      <code>! is_string($value) &amp;&amp; ! is_int($value)</code>
+      <code><![CDATA[! is_int($falseValue) && ! is_string($falseValue)]]></code>
+      <code><![CDATA[! is_int($trueValue) && ! is_string($trueValue)]]></code>
+      <code><![CDATA[! is_string($value) && ! is_int($value)]]></code>
       <code>is_bool($value)</code>
     </DocblockTypeContradiction>
     <MoreSpecificImplementedParamType>
@@ -248,7 +248,7 @@
   </file>
   <file src="src/Strategy/CollectionStrategy.php">
     <ArgumentTypeCoercion>
-      <code>$this-&gt;objectClassName</code>
+      <code><![CDATA[$this->objectClassName]]></code>
     </ArgumentTypeCoercion>
     <DocblockTypeContradiction>
       <code>is_array($value)</code>
@@ -287,7 +287,7 @@
   </file>
   <file src="src/Strategy/HydratorStrategy.php">
     <ArgumentTypeCoercion>
-      <code>$this-&gt;objectClassName</code>
+      <code><![CDATA[$this->objectClassName]]></code>
     </ArgumentTypeCoercion>
     <DocblockTypeContradiction>
       <code>gettype($value)</code>
@@ -308,7 +308,7 @@
   <file src="src/Strategy/SerializableStrategy.php">
     <DocblockTypeContradiction>
       <code>iterator_to_array($serializerOptions)</code>
-      <code>null === $this-&gt;serializer</code>
+      <code><![CDATA[null === $this->serializer]]></code>
     </DocblockTypeContradiction>
     <MixedArgument>
       <code>$serializerOptions</code>
@@ -421,7 +421,7 @@
       <code>removeStrategy</code>
     </UndefinedInterfaceMethod>
     <UndefinedPropertyFetch>
-      <code>$entity-&gt;field3</code>
+      <code><![CDATA[$entity->field3]]></code>
     </UndefinedPropertyFetch>
   </file>
   <file src="test/HydratorObjectPropertyTest.php">
@@ -503,6 +503,9 @@
     </InternalMethod>
   </file>
   <file src="test/ObjectPropertyHydratorTest.php">
+    <DeprecatedMethod>
+      <code>assertObjectHasAttribute</code>
+    </DeprecatedMethod>
     <InvalidArgument>
       <code>'thisIsNotAnObject'</code>
       <code>'thisIsNotAnObject'</code>

--- a/psalm.xml
+++ b/psalm.xml
@@ -1,11 +1,13 @@
 <?xml version="1.0"?>
 <psalm
     errorLevel="1"
-    findUnusedPsalmSuppress="true"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xmlns="https://getpsalm.org/schema/config"
     xsi:schemaLocation="https://getpsalm.org/schema/config vendor/vimeo/psalm/config.xsd"
     errorBaseline="psalm-baseline.xml"
+    findUnusedPsalmSuppress="true"
+    findUnusedBaselineEntry="true"
+    findUnusedCode="true"
 >
     <projectFiles>
         <directory name="src"/>

--- a/src/Exception/ExtensionNotLoadedException.php
+++ b/src/Exception/ExtensionNotLoadedException.php
@@ -6,6 +6,10 @@ namespace Laminas\Hydrator\Exception;
 
 /**
  * Extension not loaded exception
+ *
+ * @deprecated This class is not used anywhere and will be removed in version 5.0
+ *
+ * @psalm-suppress UnusedClass
  */
 class ExtensionNotLoadedException extends RuntimeException
 {

--- a/src/Exception/InvalidCallbackException.php
+++ b/src/Exception/InvalidCallbackException.php
@@ -6,6 +6,10 @@ namespace Laminas\Hydrator\Exception;
 
 /**
  * Invalid callback exception
+ *
+ * @deprecated This class is not used anywhere and will be removed in version 5.0
+ *
+ * @psalm-suppress UnusedClass
  */
 class InvalidCallbackException extends DomainException
 {

--- a/src/Exception/LogicException.php
+++ b/src/Exception/LogicException.php
@@ -6,6 +6,10 @@ namespace Laminas\Hydrator\Exception;
 
 /**
  * Logic exception
+ *
+ * @deprecated This class is not used anywhere and will be removed in version 5.0
+ *
+ * @psalm-suppress UnusedClass
  */
 class LogicException extends \LogicException implements ExceptionInterface
 {

--- a/src/HydratorPluginManager.php
+++ b/src/HydratorPluginManager.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Laminas\Hydrator;
 
 use Laminas\ServiceManager\AbstractPluginManager;
-use Laminas\ServiceManager\ConfigInterface;
 use Laminas\ServiceManager\Exception\InvalidServiceException;
 use Laminas\ServiceManager\Factory\InvokableFactory;
 
@@ -18,7 +17,6 @@ use function sprintf;
  *
  * Enforces that adapters retrieved are instances of HydratorInterface
  *
- * @psalm-import-type FactoriesConfigurationType from ConfigInterface
  * @extends AbstractPluginManager<HydratorInterface>
  */
 class HydratorPluginManager extends AbstractPluginManager implements HydratorPluginManagerInterface
@@ -26,7 +24,7 @@ class HydratorPluginManager extends AbstractPluginManager implements HydratorPlu
     /**
      * Default aliases
      *
-     * @var string[]
+     * @inheritDoc
      */
     protected $aliases = [
         ArraySerializable::class    => ArraySerializableHydrator::class,
@@ -75,7 +73,7 @@ class HydratorPluginManager extends AbstractPluginManager implements HydratorPlu
     /**
      * Default factory-based adapters
      *
-     * @var FactoriesConfigurationType
+     * @inheritDoc
      */
     protected $factories = [
         ArraySerializableHydrator::class => InvokableFactory::class,

--- a/src/HydratorPluginManagerFactory.php
+++ b/src/HydratorPluginManagerFactory.php
@@ -34,7 +34,7 @@ class HydratorPluginManagerFactory
      */
     public function __invoke(ContainerInterface $container, string $name, ?array $options = []): HydratorPluginManager
     {
-        if (! class_exists(Config::class)) {
+        if (! class_exists(ServiceManager::class)) {
             throw new Exception\DomainException(sprintf(
                 '%s requires the laminas/laminas-servicemanager package, which is not installed.'
                 . ' If you do not want to install that package, you can use the %s instead;'

--- a/src/ReflectionHydrator.php
+++ b/src/ReflectionHydrator.php
@@ -73,7 +73,6 @@ class ReflectionHydrator extends AbstractHydrator
         $reflProperties                 = $reflClass->getProperties();
 
         foreach ($reflProperties as $property) {
-            $property->setAccessible(true);
             static::$reflProperties[$class][$property->getName()] = $property;
         }
 

--- a/src/StandaloneHydratorPluginManager.php
+++ b/src/StandaloneHydratorPluginManager.php
@@ -66,7 +66,6 @@ final class StandaloneHydratorPluginManager implements HydratorPluginManagerInte
 
     public function __construct()
     {
-        /** @psalm-suppress UnusedClosureParam */
         $invokableFactory = static fn(ContainerInterface $container, string $class): object => new $class();
 
         $this->factories = [

--- a/test/Aggregate/AggregateHydratorFunctionalTest.php
+++ b/test/Aggregate/AggregateHydratorFunctionalTest.php
@@ -12,6 +12,7 @@ use Laminas\Hydrator\ArraySerializableHydrator;
 use Laminas\Hydrator\ClassMethodsHydrator;
 use Laminas\Hydrator\HydratorInterface;
 use LaminasTest\Hydrator\TestAsset\AggregateObject;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use stdClass;
 
@@ -45,9 +46,8 @@ class AggregateHydratorFunctionalTest extends TestCase
 
     /**
      * Verifies that using a single hydrator will have the aggregate hydrator behave like that single hydrator
-     *
-     * @dataProvider getHydratorSet
      */
+    #[DataProvider('getHydratorSet')]
     public function testSingleHydratorExtraction(HydratorInterface $comparisonHydrator, object $object): void
     {
         $blueprint = clone $object;
@@ -59,9 +59,8 @@ class AggregateHydratorFunctionalTest extends TestCase
 
     /**
      * Verifies that using a single hydrator will have the aggregate hydrator behave like that single hydrator
-     *
-     * @dataProvider getHydratorSet
      */
+    #[DataProvider('getHydratorSet')]
     public function testSingleHydratorHydration(
         HydratorInterface $comparisonHydrator,
         object $object,
@@ -163,7 +162,7 @@ class AggregateHydratorFunctionalTest extends TestCase
      *
      * @return list<array{0: HydratorInterface, 1: object, 2: array}>
      */
-    public function getHydratorSet(): array
+    public static function getHydratorSet(): array
     {
         return [
             [new ArraySerializableHydrator(), new ArrayObject(['zaphod' => 'beeblebrox']), ['arthur' => 'dent']],

--- a/test/Aggregate/AggregateHydratorFunctionalTest.php
+++ b/test/Aggregate/AggregateHydratorFunctionalTest.php
@@ -12,13 +12,12 @@ use Laminas\Hydrator\ArraySerializableHydrator;
 use Laminas\Hydrator\ClassMethodsHydrator;
 use Laminas\Hydrator\HydratorInterface;
 use LaminasTest\Hydrator\TestAsset\AggregateObject;
+use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use stdClass;
 
-/**
- * Integration tests {@see AggregateHydrator}
- */
+#[CoversClass(AggregateHydrator::class)]
 class AggregateHydratorFunctionalTest extends TestCase
 {
     protected AggregateHydrator $hydrator;

--- a/test/Aggregate/AggregateHydratorTest.php
+++ b/test/Aggregate/AggregateHydratorTest.php
@@ -29,9 +29,6 @@ class AggregateHydratorTest extends TestCase
         $this->hydrator->setEventManager($this->eventManager);
     }
 
-    /**
-     * @covers \Laminas\Hydrator\Aggregate\AggregateHydrator::add
-     */
     public function testAdd(): void
     {
         $attached = $this->createMock(HydratorInterface::class);
@@ -64,9 +61,6 @@ class AggregateHydratorTest extends TestCase
         $this->hydrator->add($attached, 123);
     }
 
-    /**
-     * @covers \Laminas\Hydrator\Aggregate\AggregateHydrator::hydrate
-     */
     public function testHydrate(): void
     {
         $object = new stdClass();
@@ -79,9 +73,6 @@ class AggregateHydratorTest extends TestCase
         $this->assertSame($object, $this->hydrator->hydrate(['foo' => 'bar'], $object));
     }
 
-    /**
-     * @covers \Laminas\Hydrator\Aggregate\AggregateHydrator::extract
-     */
     public function testExtract(): void
     {
         $object = new stdClass();
@@ -94,10 +85,6 @@ class AggregateHydratorTest extends TestCase
         $this->assertSame([], $this->hydrator->extract($object));
     }
 
-    /**
-     * @covers \Laminas\Hydrator\Aggregate\AggregateHydrator::getEventManager
-     * @covers \Laminas\Hydrator\Aggregate\AggregateHydrator::setEventManager
-     */
     public function testGetSetManager(): void
     {
         $hydrator     = new AggregateHydrator();

--- a/test/Aggregate/AggregateHydratorTest.php
+++ b/test/Aggregate/AggregateHydratorTest.php
@@ -9,13 +9,12 @@ use Laminas\Hydrator\Aggregate\AggregateHydrator;
 use Laminas\Hydrator\Aggregate\ExtractEvent;
 use Laminas\Hydrator\Aggregate\HydrateEvent;
 use Laminas\Hydrator\HydratorInterface;
+use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use stdClass;
 
-/**
- * Unit tests for {@see AggregateHydrator}
- */
+#[CoversClass(AggregateHydrator::class)]
 class AggregateHydratorTest extends TestCase
 {
     protected AggregateHydrator $hydrator;

--- a/test/Aggregate/ExtractEventTest.php
+++ b/test/Aggregate/ExtractEventTest.php
@@ -5,9 +5,11 @@ declare(strict_types=1);
 namespace LaminasTest\Hydrator\Aggregate;
 
 use Laminas\Hydrator\Aggregate\ExtractEvent;
+use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 use stdClass;
 
+#[CoversClass(ExtractEvent::class)]
 class ExtractEventTest extends TestCase
 {
     public function testEvent(): void

--- a/test/Aggregate/ExtractEventTest.php
+++ b/test/Aggregate/ExtractEventTest.php
@@ -8,14 +8,8 @@ use Laminas\Hydrator\Aggregate\ExtractEvent;
 use PHPUnit\Framework\TestCase;
 use stdClass;
 
-/**
- * Unit tests for {@see ExtractEvent}
- */
 class ExtractEventTest extends TestCase
 {
-    /**
-     * @covers \Laminas\Hydrator\Aggregate\ExtractEvent
-     */
     public function testEvent(): void
     {
         $target  = new stdClass();

--- a/test/Aggregate/HydrateEventTest.php
+++ b/test/Aggregate/HydrateEventTest.php
@@ -8,14 +8,8 @@ use Laminas\Hydrator\Aggregate\HydrateEvent;
 use PHPUnit\Framework\TestCase;
 use stdClass;
 
-/**
- * Unit tests for {@see HydrateEvent}
- */
 class HydrateEventTest extends TestCase
 {
-    /**
-     * @covers \Laminas\Hydrator\Aggregate\HydrateEvent
-     */
     public function testEvent(): void
     {
         $target    = new stdClass();

--- a/test/Aggregate/HydrateEventTest.php
+++ b/test/Aggregate/HydrateEventTest.php
@@ -5,9 +5,11 @@ declare(strict_types=1);
 namespace LaminasTest\Hydrator\Aggregate;
 
 use Laminas\Hydrator\Aggregate\HydrateEvent;
+use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 use stdClass;
 
+#[CoversClass(HydrateEvent::class)]
 class HydrateEventTest extends TestCase
 {
     public function testEvent(): void

--- a/test/Aggregate/HydratorListenerTest.php
+++ b/test/Aggregate/HydratorListenerTest.php
@@ -9,10 +9,12 @@ use Laminas\Hydrator\Aggregate\ExtractEvent;
 use Laminas\Hydrator\Aggregate\HydrateEvent;
 use Laminas\Hydrator\Aggregate\HydratorListener;
 use Laminas\Hydrator\HydratorInterface;
+use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use stdClass;
 
+#[CoversClass(HydratorListener::class)]
 class HydratorListenerTest extends TestCase
 {
     private HydratorInterface&MockObject $hydrator;

--- a/test/Aggregate/HydratorListenerTest.php
+++ b/test/Aggregate/HydratorListenerTest.php
@@ -13,31 +13,17 @@ use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use stdClass;
 
-/**
- * Unit tests for {@see HydratorListener}
- */
 class HydratorListenerTest extends TestCase
 {
-    /** @var HydratorInterface&MockObject */
-    protected $hydrator;
+    private HydratorInterface&MockObject $hydrator;
+    private HydratorListener $listener;
 
-    /** @var HydratorListener */
-    protected $listener;
-
-    /**
-     * {@inheritDoc}
-     *
-     * @covers \Laminas\Hydrator\Aggregate\HydratorListener::__construct
-     */
     protected function setUp(): void
     {
         $this->hydrator = $this->createMock(HydratorInterface::class);
         $this->listener = new HydratorListener($this->hydrator);
     }
 
-    /**
-     * @covers \Laminas\Hydrator\Aggregate\HydratorListener::attach
-     */
     public function testAttach(): void
     {
         $eventManager = $this->createMock(EventManagerInterface::class);
@@ -56,9 +42,6 @@ class HydratorListenerTest extends TestCase
         $this->listener->attach($eventManager);
     }
 
-    /**
-     * @covers \Laminas\Hydrator\Aggregate\HydratorListener::onHydrate
-     */
     public function testOnHydrate(): void
     {
         $object   = new stdClass();
@@ -83,9 +66,6 @@ class HydratorListenerTest extends TestCase
         $this->assertSame($hydrated, $this->listener->onHydrate($event));
     }
 
-    /**
-     * @covers \Laminas\Hydrator\Aggregate\HydratorListener::onExtract
-     */
     public function testOnExtract(): void
     {
         $object = new stdClass();

--- a/test/ArraySerializableHydratorTest.php
+++ b/test/ArraySerializableHydratorTest.php
@@ -8,6 +8,7 @@ use ArrayObject;
 use Laminas\Hydrator\ArraySerializableHydrator;
 use LaminasTest\Hydrator\TestAsset\ArraySerializable as ArraySerializableAsset;
 use LaminasTest\Hydrator\TestAsset\ArraySerializableNoGetArrayCopy;
+use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\TestCase;
@@ -15,6 +16,7 @@ use TypeError;
 
 use function array_merge;
 
+#[CoversClass(ArraySerializableHydrator::class)]
 class ArraySerializableHydratorTest extends TestCase
 {
     use HydratorTestTrait;

--- a/test/ArraySerializableHydratorTest.php
+++ b/test/ArraySerializableHydratorTest.php
@@ -8,16 +8,13 @@ use ArrayObject;
 use Laminas\Hydrator\ArraySerializableHydrator;
 use LaminasTest\Hydrator\TestAsset\ArraySerializable as ArraySerializableAsset;
 use LaminasTest\Hydrator\TestAsset\ArraySerializableNoGetArrayCopy;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\TestCase;
 use TypeError;
 
 use function array_merge;
 
-/**
- * Unit tests for {@see ArraySerializableHydrator}
- *
- * @covers \Laminas\Hydrator\ArraySerializableHydrator
- */
 class ArraySerializableHydratorTest extends TestCase
 {
     use HydratorTestTrait;
@@ -89,9 +86,8 @@ class ArraySerializableHydratorTest extends TestCase
      * Verifies that when an object already has properties,
      * these properties are preserved when it's hydrated with new data
      * existing properties should get overwritten
-     *
-     * @group 65
      */
+    #[Group('65')]
     public function testWillPreserveOriginalPropsAtHydration(): void
     {
         $original = new ArraySerializableAsset();
@@ -110,9 +106,8 @@ class ArraySerializableHydratorTest extends TestCase
     /**
      * To preserve backwards compatibility, if getArrayCopy() is not implemented
      * by the to-be hydrated object, simply exchange the array
-     *
-     * @group 65
      */
+    #[Group('65')]
     public function testWillReplaceArrayIfNoGetArrayCopy(): void
     {
         $original = new ArraySerializableNoGetArrayCopy();
@@ -131,7 +126,7 @@ class ArraySerializableHydratorTest extends TestCase
      * @return string[][][]
      * @psalm-return array<string, array{0: string[], 1: string[], 2: string[]}>
      */
-    public function arrayDataProvider(): array
+    public static function arrayDataProvider(): array
     {
         // @codingStandardsIgnoreStart
         return [
@@ -150,12 +145,12 @@ class ArraySerializableHydratorTest extends TestCase
      * one _removes_ data, then no change occurs. Ideally, in these cases, the
      * submitted value should _replace_ the original.
      *
-     * @group 66
-     * @dataProvider arrayDataProvider
      * @param string[] $start
      * @param string[] $submit
      * @param string[] $expected
      */
+    #[DataProvider('arrayDataProvider')]
+    #[Group('66')]
     public function testHydrationWillReplaceNestedArrayData(
         array $start,
         array $submit,

--- a/test/ArraySerializableTest.php
+++ b/test/ArraySerializableTest.php
@@ -6,6 +6,7 @@ namespace LaminasTest\Hydrator;
 
 use Laminas\Hydrator\ArraySerializable;
 use Laminas\Hydrator\ArraySerializableHydrator;
+use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 
 use function restore_error_handler;
@@ -13,6 +14,7 @@ use function set_error_handler;
 
 use const E_USER_DEPRECATED;
 
+#[CoversClass(ArraySerializable::class)]
 class ArraySerializableTest extends TestCase
 {
     public function testTriggerUserDeprecatedError(): void

--- a/test/ArraySerializableTest.php
+++ b/test/ArraySerializableTest.php
@@ -22,7 +22,6 @@ class ArraySerializableTest extends TestCase
             public $message = false;
         };
 
-        /** @psalm-suppress UnusedClosureParam */
         set_error_handler(static function ($errno, $errstr) use ($test): bool {
             $test->message = $errstr;
             return true;

--- a/test/ClassMethodsHydratorTest.php
+++ b/test/ClassMethodsHydratorTest.php
@@ -10,9 +10,11 @@ use LaminasTest\Hydrator\TestAsset\ArraySerializable;
 use LaminasTest\Hydrator\TestAsset\ClassMethodsCamelCase;
 use LaminasTest\Hydrator\TestAsset\ClassMethodsCamelCaseMissing;
 use LaminasTest\Hydrator\TestAsset\ClassMethodsOptionalParameters;
+use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 use TypeError;
 
+#[CoversClass(ClassMethodsHydrator::class)]
 class ClassMethodsHydratorTest extends TestCase
 {
     use HydratorTestTrait;

--- a/test/ClassMethodsHydratorTest.php
+++ b/test/ClassMethodsHydratorTest.php
@@ -13,11 +13,6 @@ use LaminasTest\Hydrator\TestAsset\ClassMethodsOptionalParameters;
 use PHPUnit\Framework\TestCase;
 use TypeError;
 
-/**
- * Unit tests for {@see ClassMethodsHydrator}
- *
- * @covers \Laminas\Hydrator\ClassMethodsHydrator
- */
 class ClassMethodsHydratorTest extends TestCase
 {
     use HydratorTestTrait;

--- a/test/ClassMethodsTest.php
+++ b/test/ClassMethodsTest.php
@@ -6,6 +6,7 @@ namespace LaminasTest\Hydrator;
 
 use Laminas\Hydrator\ClassMethods;
 use Laminas\Hydrator\ClassMethodsHydrator;
+use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 
 use function restore_error_handler;
@@ -13,6 +14,7 @@ use function set_error_handler;
 
 use const E_USER_DEPRECATED;
 
+#[CoversClass(ClassMethods::class)]
 class ClassMethodsTest extends TestCase
 {
     public function testTriggerUserDeprecatedError(): void

--- a/test/ClassMethodsTest.php
+++ b/test/ClassMethodsTest.php
@@ -22,7 +22,6 @@ class ClassMethodsTest extends TestCase
             public $message = false;
         };
 
-        /** @psalm-suppress UnusedClosureParam */
         set_error_handler(static function ($errno, $errstr) use ($test): bool {
             $test->message = $errstr;
             return true;

--- a/test/DelegatingHydratorFactoryTest.php
+++ b/test/DelegatingHydratorFactoryTest.php
@@ -7,6 +7,7 @@ namespace LaminasTest\Hydrator;
 use Laminas\Hydrator\DelegatingHydrator;
 use Laminas\Hydrator\DelegatingHydratorFactory;
 use Laminas\Hydrator\HydratorPluginManager;
+use LaminasTest\Hydrator\TestAsset\InMemoryContainer;
 use PHPUnit\Framework\TestCase;
 use Psr\Container\ContainerInterface;
 use ReflectionProperty;
@@ -43,22 +44,8 @@ class DelegatingHydratorFactoryTest extends TestCase
     public function testFactoryUsesHydratorManagerServiceFromContainerToSeedDelegatingHydratorWhenAvailable(): void
     {
         $hydrators = $this->createMock(HydratorPluginManager::class);
-        $container = $this->createMock(ContainerInterface::class);
-        $container
-            ->expects($this->exactly(3))
-            ->method('has')
-            ->withConsecutive(
-                [HydratorPluginManager::class],
-                ['Zend\Hydrator\HydratorPluginManager'],
-                ['HydratorManager']
-            )
-            ->willReturnOnConsecutiveCalls(
-                false,
-                false,
-                true
-            );
-        $container->expects($this->once())->method('get')->with('HydratorManager')->willReturn($hydrators);
-
+        $container = new InMemoryContainer();
+        $container->set('HydratorManager', $hydrators);
         $factory = new DelegatingHydratorFactory();
 
         $hydrator = $factory($container);
@@ -67,23 +54,8 @@ class DelegatingHydratorFactoryTest extends TestCase
 
     public function testFactoryCreatesHydratorPluginManagerToSeedDelegatingHydratorAsFallback(): void
     {
-        $container = $this->createMock(ContainerInterface::class);
-        $container
-            ->expects($this->exactly(3))
-            ->method('has')
-            ->withConsecutive(
-                [HydratorPluginManager::class],
-                ['Zend\Hydrator\HydratorPluginManager'],
-                ['HydratorManager']
-            )
-            ->willReturnOnConsecutiveCalls(
-                false,
-                false,
-                false
-            );
-        $container->expects($this->never())->method('get');
-
-        $factory = new DelegatingHydratorFactory();
+        $container = new InMemoryContainer();
+        $factory   = new DelegatingHydratorFactory();
 
         $hydrator = $factory($container);
         $this->assertInstanceOf(DelegatingHydrator::class, $hydrator);

--- a/test/DelegatingHydratorFactoryTest.php
+++ b/test/DelegatingHydratorFactoryTest.php
@@ -8,10 +8,12 @@ use Laminas\Hydrator\DelegatingHydrator;
 use Laminas\Hydrator\DelegatingHydratorFactory;
 use Laminas\Hydrator\HydratorPluginManager;
 use LaminasTest\Hydrator\TestAsset\InMemoryContainer;
+use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 use Psr\Container\ContainerInterface;
 use ReflectionProperty;
 
+#[CoversClass(DelegatingHydratorFactory::class)]
 class DelegatingHydratorFactoryTest extends TestCase
 {
     public function testFactoryUsesContainerToSeedDelegatingHydratorWhenItIsAHydratorPluginManager(): void

--- a/test/DelegatingHydratorFactoryTest.php
+++ b/test/DelegatingHydratorFactoryTest.php
@@ -12,9 +12,6 @@ use PHPUnit\Framework\TestCase;
 use Psr\Container\ContainerInterface;
 use ReflectionProperty;
 
-/**
- * @covers Laminas\Hydrator\DelegatingHydratorFactory
- */
 class DelegatingHydratorFactoryTest extends TestCase
 {
     public function testFactoryUsesContainerToSeedDelegatingHydratorWhenItIsAHydratorPluginManager(): void
@@ -60,7 +57,7 @@ class DelegatingHydratorFactoryTest extends TestCase
         $hydrator = $factory($container);
         $this->assertInstanceOf(DelegatingHydrator::class, $hydrator);
 
-        $r = new ReflectionProperty($hydrator, 'hydrators');
+        $r         = new ReflectionProperty($hydrator, 'hydrators');
         $hydrators = $r->getValue($hydrator);
 
         $this->assertInstanceOf(HydratorPluginManager::class, $hydrators);

--- a/test/DelegatingHydratorFactoryTest.php
+++ b/test/DelegatingHydratorFactoryTest.php
@@ -61,7 +61,6 @@ class DelegatingHydratorFactoryTest extends TestCase
         $this->assertInstanceOf(DelegatingHydrator::class, $hydrator);
 
         $r = new ReflectionProperty($hydrator, 'hydrators');
-        $r->setAccessible(true);
         $hydrators = $r->getValue($hydrator);
 
         $this->assertInstanceOf(HydratorPluginManager::class, $hydrators);

--- a/test/DelegatingHydratorTest.php
+++ b/test/DelegatingHydratorTest.php
@@ -7,10 +7,12 @@ namespace LaminasTest\Hydrator;
 use ArrayObject;
 use Laminas\Hydrator\DelegatingHydrator;
 use Laminas\Hydrator\HydratorInterface;
+use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Psr\Container\ContainerInterface;
 
+#[CoversClass(DelegatingHydrator::class)]
 class DelegatingHydratorTest extends TestCase
 {
     /** @var DelegatingHydrator */

--- a/test/DelegatingHydratorTest.php
+++ b/test/DelegatingHydratorTest.php
@@ -11,11 +11,6 @@ use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Psr\Container\ContainerInterface;
 
-/**
- * Unit tests for {@see DelegatingHydrator}
- *
- * @covers \Laminas\Hydrator\DelegatingHydrator
- */
 class DelegatingHydratorTest extends TestCase
 {
     /** @var DelegatingHydrator */

--- a/test/Filter/FilterCompositeTest.php
+++ b/test/Filter/FilterCompositeTest.php
@@ -12,12 +12,14 @@ use Laminas\Hydrator\Filter\GetFilter;
 use Laminas\Hydrator\Filter\HasFilter;
 use Laminas\Hydrator\Filter\IsFilter;
 use Laminas\Hydrator\Filter\NumberOfParameterFilter;
+use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
 use function array_keys;
 use function sprintf;
 
+#[CoversClass(FilterComposite::class)]
 class FilterCompositeTest extends TestCase
 {
     #[DataProvider('validFiltersProvider')]

--- a/test/Filter/FilterCompositeTest.php
+++ b/test/Filter/FilterCompositeTest.php
@@ -12,21 +12,15 @@ use Laminas\Hydrator\Filter\GetFilter;
 use Laminas\Hydrator\Filter\HasFilter;
 use Laminas\Hydrator\Filter\IsFilter;
 use Laminas\Hydrator\Filter\NumberOfParameterFilter;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
 use function array_keys;
 use function sprintf;
 
-/**
- * Unit tests for {@see FilterComposite}
- *
- * @covers \Laminas\Hydrator\Filter\FilterComposite
- */
 class FilterCompositeTest extends TestCase
 {
-    /**
-     * @dataProvider validFiltersProvider
-     */
+    #[DataProvider('validFiltersProvider')]
     public function testFilters(array $orFilters, array $andFilters): void
     {
         $filter = new FilterComposite($orFilters, $andFilters);
@@ -37,7 +31,7 @@ class FilterCompositeTest extends TestCase
     }
 
     /** @return list<array{0: array, 1: array}> */
-    public function validFiltersProvider(): array
+    public static function validFiltersProvider(): array
     {
         return [
             [
@@ -58,7 +52,7 @@ class FilterCompositeTest extends TestCase
     }
 
     /** @return list<array{0: array, 1: array, 2: string}> */
-    public function invalidFiltersProvider(): array
+    public static function invalidFiltersProvider(): array
     {
         $callback = static fn(): bool => true;
 
@@ -91,9 +85,7 @@ class FilterCompositeTest extends TestCase
         ];
     }
 
-    /**
-     * @dataProvider invalidFiltersProvider
-     */
+    #[DataProvider('invalidFiltersProvider')]
     public function testConstructWithInvalidFilter(array $orFilters, array $andFilters, string $expectedKey): void
     {
         $this->expectException(InvalidArgumentException::class);
@@ -112,7 +104,11 @@ class FilterCompositeTest extends TestCase
         self::assertTrue($filter->filter('any_value'));
     }
 
-    private function buildFilters(array $values): array
+    /**
+     * @param array $values
+     * @return list<FilterInterface>
+     */
+    private static function buildFilters(array $values): array
     {
         $filters = [];
         foreach ($values as $value) {
@@ -132,9 +128,13 @@ class FilterCompositeTest extends TestCase
     }
 
     /**
-     * @psalm-return Generator<int, array{orFilters: array, andFilters: array, expected: bool}, mixed, void>
+     * @psalm-return Generator<int, array{
+     *     orFilters: list<FilterInterface>,
+     *     andFilters: list<FilterInterface>,
+     *     expected: bool,
+     * }, mixed, void>
      */
-    private function generateFilters(
+    private static function generateFilters(
         array $orCompositionFilters,
         array $andCompositionFilters,
         bool $expected
@@ -142,8 +142,8 @@ class FilterCompositeTest extends TestCase
         foreach ($orCompositionFilters as $orFilters) {
             foreach ($andCompositionFilters as $andFilters) {
                 yield [
-                    'orFilters'  => $this->buildFilters($orFilters), // boolean sum : true
-                    'andFilters' => $this->buildFilters($andFilters),
+                    'orFilters'  => self::buildFilters($orFilters), // boolean sum : true
+                    'andFilters' => self::buildFilters($andFilters),
                     'expected'   => $expected,
                 ];
             }
@@ -153,7 +153,7 @@ class FilterCompositeTest extends TestCase
     /**
      * @psalm-return Generator<int, array{orFilters: array, andFilters: array, expected: bool}, mixed, void>
      */
-    public function providerCompositionFiltering(): Generator
+    public static function providerCompositionFiltering(): Generator
     {
         $orCompositionFilters = [
             'truthy' => [
@@ -183,22 +183,22 @@ class FilterCompositeTest extends TestCase
             ],
         ];
 
-        yield from $this->generateFilters(
+        yield from self::generateFilters(
             $orCompositionFilters['truthy'],
             $andCompositionFilters['truthy'],
             true
         );
-        yield from $this->generateFilters(
+        yield from self::generateFilters(
             $orCompositionFilters['truthy'],
             $andCompositionFilters['falsy'],
             false
         );
-        yield from $this->generateFilters(
+        yield from self::generateFilters(
             $orCompositionFilters['falsy'],
             $andCompositionFilters['truthy'],
             false
         );
-        yield from $this->generateFilters(
+        yield from self::generateFilters(
             $orCompositionFilters['falsy'],
             $andCompositionFilters['falsy'],
             false
@@ -206,8 +206,10 @@ class FilterCompositeTest extends TestCase
     }
 
     /**
-     * @dataProvider providerCompositionFiltering
+     * @param list<FilterInterface> $orFilters
+     * @param list<FilterInterface> $andFilters
      */
+    #[DataProvider('providerCompositionFiltering')]
     public function testCompositionFiltering(array $orFilters, array $andFilters, bool $expected): void
     {
         $filter = new FilterComposite($orFilters, $andFilters);

--- a/test/Filter/MethodMatchFilterTest.php
+++ b/test/Filter/MethodMatchFilterTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace LaminasTest\Hydrator\Filter;
 
 use Laminas\Hydrator\Filter\MethodMatchFilter;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
 class MethodMatchFilterTest extends TestCase
@@ -13,7 +14,7 @@ class MethodMatchFilterTest extends TestCase
      * @return (bool|string)[][]
      * @psalm-return list<array{0: string, 1: bool}>
      */
-    public function providerFilter(): array
+    public static function providerFilter(): array
     {
         return [
             ['foo', true],
@@ -23,9 +24,7 @@ class MethodMatchFilterTest extends TestCase
         ];
     }
 
-    /**
-     * @dataProvider providerFilter
-     */
+    #[DataProvider('providerFilter')]
     public function testFilter(string $methodName, bool $expected): void
     {
         $testedInstance = new MethodMatchFilter('foo', false);

--- a/test/Filter/MethodMatchFilterTest.php
+++ b/test/Filter/MethodMatchFilterTest.php
@@ -5,9 +5,11 @@ declare(strict_types=1);
 namespace LaminasTest\Hydrator\Filter;
 
 use Laminas\Hydrator\Filter\MethodMatchFilter;
+use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
+#[CoversClass(MethodMatchFilter::class)]
 class MethodMatchFilterTest extends TestCase
 {
     /**

--- a/test/Filter/NumberOfParameterFilterTest.php
+++ b/test/Filter/NumberOfParameterFilterTest.php
@@ -6,18 +6,12 @@ namespace LaminasTest\Hydrator\Filter;
 
 use Laminas\Hydrator\Exception\InvalidArgumentException;
 use Laminas\Hydrator\Filter\NumberOfParameterFilter;
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\TestCase;
 
-/**
- * Unit tests for {@see NumberOfParameterFilter}
- *
- * @covers \Laminas\Hydrator\Filter\NumberOfParameterFilter
- */
 class NumberOfParameterFilterTest extends TestCase
 {
-    /**
-     * @group 6083
-     */
+    #[Group('6083')]
     public function testArityZero(): void
     {
         $filter = new NumberOfParameterFilter();
@@ -25,9 +19,7 @@ class NumberOfParameterFilterTest extends TestCase
         $this->assertFalse($filter->filter(self::class . '::methodWithOptionalParameters'));
     }
 
-    /**
-     * @group 6083
-     */
+    #[Group('6083')]
     public function testArityOne(): void
     {
         $filter = new NumberOfParameterFilter(1);

--- a/test/Filter/NumberOfParameterFilterTest.php
+++ b/test/Filter/NumberOfParameterFilterTest.php
@@ -6,9 +6,11 @@ namespace LaminasTest\Hydrator\Filter;
 
 use Laminas\Hydrator\Exception\InvalidArgumentException;
 use Laminas\Hydrator\Filter\NumberOfParameterFilter;
+use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\TestCase;
 
+#[CoversClass(NumberOfParameterFilter::class)]
 class NumberOfParameterFilterTest extends TestCase
 {
     #[Group('6083')]

--- a/test/Filter/OptionalParametersFilterTest.php
+++ b/test/Filter/OptionalParametersFilterTest.php
@@ -6,9 +6,11 @@ namespace LaminasTest\Hydrator\Filter;
 
 use InvalidArgumentException;
 use Laminas\Hydrator\Filter\OptionalParametersFilter;
+use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
+#[CoversClass(OptionalParametersFilter::class)]
 class OptionalParametersFilterTest extends TestCase
 {
     /** @var OptionalParametersFilter */

--- a/test/Filter/OptionalParametersFilterTest.php
+++ b/test/Filter/OptionalParametersFilterTest.php
@@ -6,13 +6,9 @@ namespace LaminasTest\Hydrator\Filter;
 
 use InvalidArgumentException;
 use Laminas\Hydrator\Filter\OptionalParametersFilter;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
-/**
- * Unit tests for {@see OptionalParametersFilter}
- *
- * @covers \Laminas\Hydrator\Filter\OptionalParametersFilter
- */
 class OptionalParametersFilterTest extends TestCase
 {
     /** @var OptionalParametersFilter */
@@ -28,9 +24,8 @@ class OptionalParametersFilterTest extends TestCase
 
     /**
      * Verifies a list of methods against expected results
-     *
-     * @dataProvider methodProvider
      */
+    #[DataProvider('methodProvider')]
     public function testMethods(string $method, bool $expectedResult): void
     {
         $this->assertSame($expectedResult, $this->filter->filter($method));
@@ -39,9 +34,8 @@ class OptionalParametersFilterTest extends TestCase
     /**
      * Verifies a list of methods against expected results over subsequent calls, checking
      * that the filter behaves consistently regardless of cache optimizations
-     *
-     * @dataProvider methodProvider
      */
+    #[DataProvider('methodProvider')]
     public function testMethodsOnSubsequentCalls(string $method, bool $expectedResult): void
     {
         for ($i = 0; $i < 5; $i += 1) {
@@ -63,7 +57,7 @@ class OptionalParametersFilterTest extends TestCase
      *     1: bool
      * }>
      */
-    public function methodProvider(): array
+    public static function methodProvider(): array
     {
         return [
             [self::class . '::methodWithoutParameters', true],

--- a/test/HydratorAwareTraitTest.php
+++ b/test/HydratorAwareTraitTest.php
@@ -4,38 +4,27 @@ declare(strict_types=1);
 
 namespace LaminasTest\Hydrator;
 
-use Laminas\Hydrator\AbstractHydrator;
-use Laminas\Hydrator\HydratorAwareTrait;
+use Laminas\Hydrator\HydratorInterface;
+use LaminasTest\Hydrator\TestAsset\HydratorAwareTraitImplementor;
 use PHPUnit\Framework\TestCase;
 
-/**
- * @covers Laminas\Hydrator\HydratorAwareTrait
- */
 class HydratorAwareTraitTest extends TestCase
 {
     public function testSetHydrator(): void
     {
-        $object = $this->getObjectForTrait(HydratorAwareTrait::class);
-
-        $this->assertSame(null, $object->getHydrator());
-
-        $hydrator = $this->getMockForAbstractClass(AbstractHydrator::class);
-
+        $object = new HydratorAwareTraitImplementor();
+        self::assertNull($object->getHydrator());
+        $hydrator = $this->createMock(HydratorInterface::class);
         $object->setHydrator($hydrator);
-
-        $this->assertSame($hydrator, $object->getHydrator());
+        self::assertSame($hydrator, $object->getHydrator());
     }
 
     public function testGetHydrator(): void
     {
-        $object = $this->getObjectForTrait(HydratorAwareTrait::class);
-
-        $this->assertNull($object->getHydrator());
-
-        $hydrator = $this->getMockForAbstractClass(AbstractHydrator::class);
-
+        $object = new HydratorAwareTraitImplementor();
+        self::assertNull($object->getHydrator());
+        $hydrator = $this->createMock(HydratorInterface::class);
         $object->setHydrator($hydrator);
-
-        $this->assertEquals($hydrator, $object->getHydrator());
+        self::assertSame($hydrator, $object->getHydrator());
     }
 }

--- a/test/HydratorClosureStrategyTest.php
+++ b/test/HydratorClosureStrategyTest.php
@@ -7,10 +7,12 @@ namespace LaminasTest\Hydrator;
 use Laminas\Hydrator\HydratorInterface;
 use Laminas\Hydrator\ObjectPropertyHydrator;
 use Laminas\Hydrator\Strategy\ClosureStrategy;
+use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 
 use function sprintf;
 
+#[CoversClass(ClosureStrategy::class)]
 class HydratorClosureStrategyTest extends TestCase
 {
     /**

--- a/test/HydratorObjectPropertyTest.php
+++ b/test/HydratorObjectPropertyTest.php
@@ -5,8 +5,10 @@ declare(strict_types=1);
 namespace LaminasTest\Hydrator;
 
 use Laminas\Hydrator\ObjectPropertyHydrator;
+use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 
+#[CoversClass(ObjectPropertyHydrator::class)]
 class HydratorObjectPropertyTest extends TestCase
 {
     private ObjectPropertyHydrator $hydrator;

--- a/test/HydratorPluginManagerCompatibilityTest.php
+++ b/test/HydratorPluginManagerCompatibilityTest.php
@@ -15,7 +15,7 @@ class HydratorPluginManagerCompatibilityTest extends TestCase
     use CommonPluginManagerTrait;
 
     /** @return HydratorPluginManager */
-    protected function getPluginManager()
+    protected static function getPluginManager()
     {
         return new HydratorPluginManager(new ServiceManager());
     }

--- a/test/HydratorPluginManagerCompatibilityTest.php
+++ b/test/HydratorPluginManagerCompatibilityTest.php
@@ -8,8 +8,10 @@ use Laminas\Hydrator\HydratorInterface;
 use Laminas\Hydrator\HydratorPluginManager;
 use Laminas\ServiceManager\ServiceManager;
 use Laminas\ServiceManager\Test\CommonPluginManagerTrait;
+use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 
+#[CoversClass(HydratorPluginManager::class)]
 class HydratorPluginManagerCompatibilityTest extends TestCase
 {
     use CommonPluginManagerTrait;

--- a/test/HydratorPluginManagerFactoryTest.php
+++ b/test/HydratorPluginManagerFactoryTest.php
@@ -9,6 +9,7 @@ use Laminas\Hydrator\HydratorPluginManager;
 use Laminas\Hydrator\HydratorPluginManagerFactory;
 use Laminas\Hydrator\ReflectionHydrator;
 use LaminasTest\Hydrator\TestAsset\InMemoryContainer;
+use PHPUnit\Framework\Attributes\Depends;
 use PHPUnit\Framework\TestCase;
 use Psr\Container\ContainerInterface;
 
@@ -23,9 +24,7 @@ class HydratorPluginManagerFactoryTest extends TestCase
         $this->assertInstanceOf(HydratorPluginManager::class, $hydrators);
     }
 
-    /**
-     * @depends testFactoryReturnsPluginManager
-     */
+    #[Depends('testFactoryReturnsPluginManager')]
     public function testFactoryConfiguresPluginManagerUnderContainerInterop(): void
     {
         $container = $this->createMock(ContainerInterface::class);

--- a/test/HydratorPluginManagerFactoryTest.php
+++ b/test/HydratorPluginManagerFactoryTest.php
@@ -9,10 +9,12 @@ use Laminas\Hydrator\HydratorPluginManager;
 use Laminas\Hydrator\HydratorPluginManagerFactory;
 use Laminas\Hydrator\ReflectionHydrator;
 use LaminasTest\Hydrator\TestAsset\InMemoryContainer;
+use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Depends;
 use PHPUnit\Framework\TestCase;
 use Psr\Container\ContainerInterface;
 
+#[CoversClass(HydratorPluginManagerFactory::class)]
 class HydratorPluginManagerFactoryTest extends TestCase
 {
     public function testFactoryReturnsPluginManager(): void

--- a/test/HydratorPluginManagerFactoryTest.php
+++ b/test/HydratorPluginManagerFactoryTest.php
@@ -8,7 +8,7 @@ use Laminas\Hydrator\HydratorInterface;
 use Laminas\Hydrator\HydratorPluginManager;
 use Laminas\Hydrator\HydratorPluginManagerFactory;
 use Laminas\Hydrator\ReflectionHydrator;
-use Laminas\ServiceManager\ServiceLocatorInterface;
+use LaminasTest\Hydrator\TestAsset\InMemoryContainer;
 use PHPUnit\Framework\TestCase;
 use Psr\Container\ContainerInterface;
 
@@ -42,8 +42,8 @@ class HydratorPluginManagerFactoryTest extends TestCase
 
     public function testConfiguresHydratorServicesWhenFound(): void
     {
-        $hydrator = $this->createMock(HydratorInterface::class);
-        $config   = [
+        $hydrator  = $this->createMock(HydratorInterface::class);
+        $config    = [
             'hydrators' => [
                 'aliases'   => [
                     'test' => ReflectionHydrator::class,
@@ -54,24 +54,8 @@ class HydratorPluginManagerFactoryTest extends TestCase
                 ],
             ],
         ];
-
-        $container = $this->createMock(ServiceLocatorInterface::class);
-        $container
-            ->expects($this->exactly(2))
-            ->method('has')
-            ->withConsecutive(
-                ['ServiceListener'],
-                ['config']
-            )
-            ->willReturnOnConsecutiveCalls(
-                false,
-                true
-            );
-        $container
-            ->expects($this->once())
-            ->method('get')
-            ->with('config')
-            ->willReturn($config);
+        $container = new InMemoryContainer();
+        $container->set('config', $config);
 
         $factory   = new HydratorPluginManagerFactory();
         $hydrators = $factory($container, 'HydratorManager');
@@ -85,22 +69,7 @@ class HydratorPluginManagerFactoryTest extends TestCase
 
     public function testDoesNotConfigureHydratorServicesWhenServiceListenerPresent(): void
     {
-        $container = $this->createMock(ServiceLocatorInterface::class);
-        $container
-            ->expects($this->exactly(2))
-            ->method('has')
-            ->withConsecutive(
-                ['ServiceListener'],
-                ['config']
-            )
-            ->willReturnOnConsecutiveCalls(
-                false,
-                false
-            );
-        $container
-            ->expects($this->never())
-            ->method('get');
-
+        $container = new InMemoryContainer();
         $factory   = new HydratorPluginManagerFactory();
         $hydrators = $factory($container, 'HydratorManager');
 
@@ -111,22 +80,7 @@ class HydratorPluginManagerFactoryTest extends TestCase
 
     public function testDoesNotConfigureHydratorServicesWhenConfigServiceNotPresent(): void
     {
-        $container = $this->createMock(ServiceLocatorInterface::class);
-        $container
-            ->expects($this->exactly(2))
-            ->method('has')
-            ->withConsecutive(
-                ['ServiceListener'],
-                ['config']
-            )
-            ->willReturnOnConsecutiveCalls(
-                false,
-                false
-            );
-        $container
-            ->expects($this->never())
-            ->method('get');
-
+        $container = new InMemoryContainer();
         $factory   = new HydratorPluginManagerFactory();
         $hydrators = $factory($container, 'HydratorManager');
 
@@ -135,23 +89,8 @@ class HydratorPluginManagerFactoryTest extends TestCase
 
     public function testDoesNotConfigureHydratorServicesWhenConfigServiceDoesNotContainHydratorsConfig(): void
     {
-        $container = $this->createMock(ServiceLocatorInterface::class);
-        $container
-            ->expects($this->exactly(2))
-            ->method('has')
-            ->withConsecutive(
-                ['ServiceListener'],
-                ['config']
-            )
-            ->willReturnOnConsecutiveCalls(
-                false,
-                true
-            );
-        $container
-            ->expects($this->once())
-            ->method('get')
-            ->with('config')
-            ->willReturn(['foo' => 'bar']);
+        $container = new InMemoryContainer();
+        $container->set('config', ['foo' => 'bar']);
 
         $factory   = new HydratorPluginManagerFactory();
         $hydrators = $factory($container, 'HydratorManager');

--- a/test/HydratorStrategyTest.php
+++ b/test/HydratorStrategyTest.php
@@ -7,6 +7,7 @@ namespace LaminasTest\Hydrator;
 use Laminas\Hydrator\ClassMethodsHydrator;
 use Laminas\Hydrator\HydratorInterface;
 use Laminas\Hydrator\Strategy\StrategyInterface;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
 class HydratorStrategyTest extends TestCase
@@ -92,9 +93,7 @@ class HydratorStrategyTest extends TestCase
         $this->assertCount(3, $entities);
     }
 
-    /**
-     * @dataProvider underscoreHandlingDataProvider
-     */
+    #[DataProvider('underscoreHandlingDataProvider')]
     public function testWhenUsingUnderscoreSeparatedKeysHydratorStrategyIsAlwaysConsideredUnderscoreSeparatedToo(
         bool $underscoreSeparatedKeys,
         string $formFieldKey
@@ -131,7 +130,7 @@ class HydratorStrategyTest extends TestCase
      *     1: string
      * }>
      */
-    public function underscoreHandlingDataProvider(): array
+    public static function underscoreHandlingDataProvider(): array
     {
         return [
             [true, 'foo_bar'],

--- a/test/HydratorTest.php
+++ b/test/HydratorTest.php
@@ -24,6 +24,7 @@ use LaminasTest\Hydrator\TestAsset\ClassMethodsUnderscore;
 use LaminasTest\Hydrator\TestAsset\ObjectProperty as ObjectPropertyAsset;
 use LaminasTest\Hydrator\TestAsset\Reflection as ReflectionAsset;
 use LaminasTest\Hydrator\TestAsset\ReflectionFilter;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
 use function explode;
@@ -371,9 +372,7 @@ class HydratorTest extends TestCase
         self::assertArrayNotHaskey('hasFoo', $datas);
     }
 
-    /**
-     * @dataProvider filterProvider
-     */
+    #[DataProvider('filterProvider')]
     public function testArraySerializableFilter(
         AbstractHydrator $hydrator,
         object $serializable
@@ -436,7 +435,7 @@ class HydratorTest extends TestCase
     /**
      * @psalm-return list<array{0: AbstractHydrator, 1: object}>
      */
-    public function filterProvider(): array
+    public static function filterProvider(): array
     {
         return [
             [new ObjectPropertyHydrator(), new ObjectPropertyAsset()],

--- a/test/Iterator/HydratingArrayIteratorTest.php
+++ b/test/Iterator/HydratingArrayIteratorTest.php
@@ -8,8 +8,10 @@ use ArrayObject;
 use Laminas\Hydrator\ArraySerializableHydrator;
 use Laminas\Hydrator\Exception\InvalidArgumentException;
 use Laminas\Hydrator\Iterator\HydratingArrayIterator;
+use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 
+#[CoversClass(HydratingArrayIterator::class)]
 class HydratingArrayIteratorTest extends TestCase
 {
     public function testHydratesObjectAndClonesOnCurrent(): void

--- a/test/Iterator/HydratingArrayIteratorTest.php
+++ b/test/Iterator/HydratingArrayIteratorTest.php
@@ -10,9 +10,6 @@ use Laminas\Hydrator\Exception\InvalidArgumentException;
 use Laminas\Hydrator\Iterator\HydratingArrayIterator;
 use PHPUnit\Framework\TestCase;
 
-/**
- * @covers Laminas\Hydrator\Iterator\HydratingArrayIterator
- */
 class HydratingArrayIteratorTest extends TestCase
 {
     public function testHydratesObjectAndClonesOnCurrent(): void

--- a/test/Iterator/HydratingIteratorIteratorTest.php
+++ b/test/Iterator/HydratingIteratorIteratorTest.php
@@ -9,8 +9,10 @@ use ArrayObject;
 use Laminas\Hydrator\ArraySerializableHydrator;
 use Laminas\Hydrator\Exception\InvalidArgumentException;
 use Laminas\Hydrator\Iterator\HydratingIteratorIterator;
+use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 
+#[CoversClass(HydratingIteratorIterator::class)]
 class HydratingIteratorIteratorTest extends TestCase
 {
     public function testHydratesObjectAndClonesOnCurrent(): void

--- a/test/Iterator/HydratingIteratorIteratorTest.php
+++ b/test/Iterator/HydratingIteratorIteratorTest.php
@@ -11,9 +11,6 @@ use Laminas\Hydrator\Exception\InvalidArgumentException;
 use Laminas\Hydrator\Iterator\HydratingIteratorIterator;
 use PHPUnit\Framework\TestCase;
 
-/**
- * @covers Laminas\Hydrator\Iterator\HydratingIteratorIterator
- */
 class HydratingIteratorIteratorTest extends TestCase
 {
     public function testHydratesObjectAndClonesOnCurrent(): void

--- a/test/NamingStrategy/CompositeNamingStrategyTest.php
+++ b/test/NamingStrategy/CompositeNamingStrategyTest.php
@@ -6,9 +6,11 @@ namespace LaminasTest\Hydrator\NamingStrategy;
 
 use Laminas\Hydrator\NamingStrategy\CompositeNamingStrategy;
 use Laminas\Hydrator\NamingStrategy\NamingStrategyInterface;
+use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
+#[CoversClass(CompositeNamingStrategy::class)]
 class CompositeNamingStrategyTest extends TestCase
 {
     public function testGetSameNameWhenNoNamingStrategyExistsForTheName(): void

--- a/test/NamingStrategy/CompositeNamingStrategyTest.php
+++ b/test/NamingStrategy/CompositeNamingStrategyTest.php
@@ -9,11 +9,6 @@ use Laminas\Hydrator\NamingStrategy\NamingStrategyInterface;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
-/**
- * Tests for {@see CompositeNamingStrategy}
- *
- * @covers \Laminas\Hydrator\NamingStrategy\CompositeNamingStrategy
- */
 class CompositeNamingStrategyTest extends TestCase
 {
     public function testGetSameNameWhenNoNamingStrategyExistsForTheName(): void

--- a/test/NamingStrategy/IdentityNamingStrategyTest.php
+++ b/test/NamingStrategy/IdentityNamingStrategyTest.php
@@ -5,19 +5,15 @@ declare(strict_types=1);
 namespace LaminasTest\Hydrator\NamingStrategy;
 
 use Laminas\Hydrator\NamingStrategy\IdentityNamingStrategy;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
-/**
- * Tests for {@see IdentityNamingStrategy}
- *
- * @covers \Laminas\Hydrator\NamingStrategy\IdentityNamingStrategy
- */
 class IdentityNamingStrategyTest extends TestCase
 {
     /**
-     * @dataProvider getTestedNames
      * @param string $name
      */
+    #[DataProvider('getTestedNames')]
     public function testHydrate($name): void
     {
         $namingStrategy = new IdentityNamingStrategy();
@@ -26,9 +22,9 @@ class IdentityNamingStrategyTest extends TestCase
     }
 
     /**
-     * @dataProvider getTestedNames
      * @param string $name
      */
+    #[DataProvider('getTestedNames')]
     public function testExtract($name): void
     {
         $namingStrategy = new IdentityNamingStrategy();
@@ -41,7 +37,7 @@ class IdentityNamingStrategyTest extends TestCase
      *
      * @return string[][]
      */
-    public function getTestedNames()
+    public static function getTestedNames()
     {
         return [
             'foo' => ['foo'],

--- a/test/NamingStrategy/IdentityNamingStrategyTest.php
+++ b/test/NamingStrategy/IdentityNamingStrategyTest.php
@@ -5,9 +5,11 @@ declare(strict_types=1);
 namespace LaminasTest\Hydrator\NamingStrategy;
 
 use Laminas\Hydrator\NamingStrategy\IdentityNamingStrategy;
+use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
+#[CoversClass(IdentityNamingStrategy::class)]
 class IdentityNamingStrategyTest extends TestCase
 {
     /**

--- a/test/NamingStrategy/MapNamingStrategyTest.php
+++ b/test/NamingStrategy/MapNamingStrategyTest.php
@@ -7,9 +7,11 @@ namespace LaminasTest\Hydrator\NamingStrategy;
 use Generator;
 use Laminas\Hydrator\Exception;
 use Laminas\Hydrator\NamingStrategy\MapNamingStrategy;
+use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
+#[CoversClass(MapNamingStrategy::class)]
 class MapNamingStrategyTest extends TestCase
 {
     /** @return Generator<string, list<mixed>> */

--- a/test/NamingStrategy/MapNamingStrategyTest.php
+++ b/test/NamingStrategy/MapNamingStrategyTest.php
@@ -7,17 +7,13 @@ namespace LaminasTest\Hydrator\NamingStrategy;
 use Generator;
 use Laminas\Hydrator\Exception;
 use Laminas\Hydrator\NamingStrategy\MapNamingStrategy;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
-/**
- * Tests for {@see MapNamingStrategy}
- *
- * @covers \Laminas\Hydrator\NamingStrategy\MapNamingStrategy
- */
 class MapNamingStrategyTest extends TestCase
 {
     /** @return Generator<string, list<mixed>> */
-    public function invalidMapValues(): Generator
+    public static function invalidMapValues(): Generator
     {
         yield 'null'       => [null];
         yield 'true'       => [true];
@@ -29,7 +25,7 @@ class MapNamingStrategyTest extends TestCase
     }
 
     /** @psalm-return Generator<string, array{invalidKeyArray: array<array-key, string>}> */
-    public function invalidKeyArrays(): Generator
+    public static function invalidKeyArrays(): Generator
     {
         yield 'int' => [
             'invalidKeyArray' => [1 => 'foo'],
@@ -39,9 +35,7 @@ class MapNamingStrategyTest extends TestCase
         ];
     }
 
-    /**
-     * @dataProvider invalidMapValues
-     */
+    #[DataProvider('invalidMapValues')]
     public function testExtractionMapConstructorRaisesExceptionWhenFlippingHydrationMapForInvalidValues(
         mixed $invalidValue
     ): void {
@@ -52,9 +46,7 @@ class MapNamingStrategyTest extends TestCase
         MapNamingStrategy::createFromExtractionMap(['foo' => $invalidValue]);
     }
 
-    /**
-     * @dataProvider invalidKeyArrays
-     */
+    #[DataProvider('invalidKeyArrays')]
     public function testExtractionMapConstructorRaisesExceptionWhenFlippingHydrationMapForInvalidKeys(
         array $invalidKeyArray
     ): void {
@@ -65,9 +57,7 @@ class MapNamingStrategyTest extends TestCase
         MapNamingStrategy::createFromExtractionMap($invalidKeyArray);
     }
 
-    /**
-     * @dataProvider invalidMapValues
-     */
+    #[DataProvider('invalidMapValues')]
     public function testHydrationMapConstructorRaisesExceptionWhenFlippingExtractionMapForInvalidValues(
         mixed $invalidValue
     ): void {
@@ -78,9 +68,7 @@ class MapNamingStrategyTest extends TestCase
         MapNamingStrategy::createFromHydrationMap(['foo' => $invalidValue]);
     }
 
-    /**
-     * @dataProvider invalidKeyArrays
-     */
+    #[DataProvider('invalidKeyArrays')]
     public function testHydrationMapConstructorRaisesExceptionWhenFlippingExtractionMapForInvalidKeys(
         array $invalidKeyArray
     ): void {

--- a/test/NamingStrategy/UnderscoreNamingStrategy/CamelCaseToUnderscoreFilterTest.php
+++ b/test/NamingStrategy/UnderscoreNamingStrategy/CamelCaseToUnderscoreFilterTest.php
@@ -5,12 +5,14 @@ declare(strict_types=1);
 namespace LaminasTest\Hydrator\NamingStrategy\UnderscoreNamingStrategy;
 
 use Laminas\Hydrator\NamingStrategy\UnderscoreNamingStrategy\CamelCaseToUnderscoreFilter;
+use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use ReflectionClass;
 
 use function extension_loaded;
 
+#[CoversClass(CamelCaseToUnderscoreFilter::class)]
 class CamelCaseToUnderscoreFilterTest extends TestCase
 {
     /**

--- a/test/NamingStrategy/UnderscoreNamingStrategy/CamelCaseToUnderscoreFilterTest.php
+++ b/test/NamingStrategy/UnderscoreNamingStrategy/CamelCaseToUnderscoreFilterTest.php
@@ -5,23 +5,19 @@ declare(strict_types=1);
 namespace LaminasTest\Hydrator\NamingStrategy\UnderscoreNamingStrategy;
 
 use Laminas\Hydrator\NamingStrategy\UnderscoreNamingStrategy\CamelCaseToUnderscoreFilter;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use ReflectionClass;
 
 use function extension_loaded;
 
-/**
- * Tests for {@see CamelCaseToUnderscoreFilter}
- *
- * @covers Laminas\Hydrator\NamingStrategy\UnderscoreNamingStrategy\CamelCaseToUnderscoreFilter
- */
 class CamelCaseToUnderscoreFilterTest extends TestCase
 {
     /**
-     * @dataProvider nonUnicodeProvider
      * @param string $string
      * @param string $expected
      */
+    #[DataProvider('nonUnicodeProvider')]
     public function testFilterUnderscoresNonUnicodeStrings($string, $expected): void
     {
         $filter = new CamelCaseToUnderscoreFilter();
@@ -37,10 +33,10 @@ class CamelCaseToUnderscoreFilterTest extends TestCase
     }
 
     /**
-     * @dataProvider unicodeProvider
      * @param string $string
      * @param string $expected
      */
+    #[DataProvider('unicodeProvider')]
     public function testFilterUnderscoresUnicodeStrings($string, $expected): void
     {
         if (! extension_loaded('mbstring')) {
@@ -56,10 +52,10 @@ class CamelCaseToUnderscoreFilterTest extends TestCase
     }
 
     /**
-     * @dataProvider unicodeProviderWithoutMbStrings
      * @param string $string
      * @param string $expected
      */
+    #[DataProvider('unicodeProviderWithoutMbStrings')]
     public function testFilterUnderscoresUnicodeStringsWithoutMbStrings($string, $expected): void
     {
         $filter = new CamelCaseToUnderscoreFilter();
@@ -78,7 +74,7 @@ class CamelCaseToUnderscoreFilterTest extends TestCase
      * @return string[][]
      * @psalm-return array<string, array{0: string, 1: string}>
      */
-    public function nonUnicodeProvider(): array
+    public static function nonUnicodeProvider(): array
     {
         return [
             'upcased first letter'                        => [
@@ -112,7 +108,7 @@ class CamelCaseToUnderscoreFilterTest extends TestCase
      * @return string[][]
      * @psalm-return array<string, array{0: string, 1: string}>
      */
-    public function unicodeProvider(): array
+    public static function unicodeProvider(): array
     {
         return [
             'upcased first letter'                        => [
@@ -146,7 +142,7 @@ class CamelCaseToUnderscoreFilterTest extends TestCase
      * @return string[][]
      * @psalm-return array<string, array{0: string, 1: string}>
      */
-    public function unicodeProviderWithoutMbStrings(): array
+    public static function unicodeProviderWithoutMbStrings(): array
     {
         return [
             'upcased first letter'                        => [

--- a/test/NamingStrategy/UnderscoreNamingStrategy/CamelCaseToUnderscoreFilterTest.php
+++ b/test/NamingStrategy/UnderscoreNamingStrategy/CamelCaseToUnderscoreFilterTest.php
@@ -28,7 +28,6 @@ class CamelCaseToUnderscoreFilterTest extends TestCase
 
         $reflectionClass = new ReflectionClass($filter);
         $property        = $reflectionClass->getProperty('pcreUnicodeSupport');
-        $property->setAccessible(true);
         $property->setValue($filter, false);
 
         $filtered = $filter->filter($string);
@@ -67,7 +66,6 @@ class CamelCaseToUnderscoreFilterTest extends TestCase
 
         $reflectionClass = new ReflectionClass($filter);
         $property        = $reflectionClass->getProperty('mbStringSupport');
-        $property->setAccessible(true);
         $property->setValue($filter, false);
 
         $filtered = $filter->filter($string);

--- a/test/NamingStrategy/UnderscoreNamingStrategy/UnderscoreToCamelCaseFilterTest.php
+++ b/test/NamingStrategy/UnderscoreNamingStrategy/UnderscoreToCamelCaseFilterTest.php
@@ -28,7 +28,6 @@ class UnderscoreToCamelCaseFilterTest extends TestCase
 
         $reflectionClass = new ReflectionClass($filter);
         $property        = $reflectionClass->getProperty('pcreUnicodeSupport');
-        $property->setAccessible(true);
         $property->setValue($filter, false);
 
         $filtered = $filter->filter($string);
@@ -128,7 +127,6 @@ class UnderscoreToCamelCaseFilterTest extends TestCase
 
         $reflectionClass = new ReflectionClass($filter);
         $property        = $reflectionClass->getProperty('mbStringSupport');
-        $property->setAccessible(true);
         $property->setValue($filter, false);
 
         $filtered = $filter->filter($string);

--- a/test/NamingStrategy/UnderscoreNamingStrategy/UnderscoreToCamelCaseFilterTest.php
+++ b/test/NamingStrategy/UnderscoreNamingStrategy/UnderscoreToCamelCaseFilterTest.php
@@ -5,12 +5,14 @@ declare(strict_types=1);
 namespace LaminasTest\Hydrator\NamingStrategy\UnderscoreNamingStrategy;
 
 use Laminas\Hydrator\NamingStrategy\UnderscoreNamingStrategy\UnderscoreToCamelCaseFilter;
+use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use ReflectionClass;
 
 use function extension_loaded;
 
+#[CoversClass(UnderscoreToCamelCaseFilter::class)]
 class UnderscoreToCamelCaseFilterTest extends TestCase
 {
     /**

--- a/test/NamingStrategy/UnderscoreNamingStrategy/UnderscoreToCamelCaseFilterTest.php
+++ b/test/NamingStrategy/UnderscoreNamingStrategy/UnderscoreToCamelCaseFilterTest.php
@@ -5,23 +5,19 @@ declare(strict_types=1);
 namespace LaminasTest\Hydrator\NamingStrategy\UnderscoreNamingStrategy;
 
 use Laminas\Hydrator\NamingStrategy\UnderscoreNamingStrategy\UnderscoreToCamelCaseFilter;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use ReflectionClass;
 
 use function extension_loaded;
 
-/**
- * Tests for {@see UnderscoreToCamelCaseFilter}
- *
- * @covers Laminas\Hydrator\NamingStrategy\UnderscoreNamingStrategy\UnderscoreToCamelCaseFilter
- */
 class UnderscoreToCamelCaseFilterTest extends TestCase
 {
     /**
-     * @dataProvider nonUnicodeProvider
      * @param string $string
      * @param string $expected
      */
+    #[DataProvider('nonUnicodeProvider')]
     public function testFilterCamelCasesNonUnicodeStrings($string, $expected): void
     {
         $filter = new UnderscoreToCamelCaseFilter();
@@ -40,7 +36,7 @@ class UnderscoreToCamelCaseFilterTest extends TestCase
      * @return string[][]
      * @psalm-return array<string, array{0: string, 1: string}>
      */
-    public function nonUnicodeProvider(): array
+    public static function nonUnicodeProvider(): array
     {
         return [
             'one word'                       => [
@@ -63,10 +59,10 @@ class UnderscoreToCamelCaseFilterTest extends TestCase
     }
 
     /**
-     * @dataProvider unicodeProvider
      * @param string $string
      * @param string $expected
      */
+    #[DataProvider('unicodeProvider')]
     public function testFilterCamelCasesUnicodeStrings($string, $expected): void
     {
         if (! extension_loaded('mbstring')) {
@@ -84,7 +80,7 @@ class UnderscoreToCamelCaseFilterTest extends TestCase
      * @return string[][]
      * @psalm-return array<string, array{0: string, 1: string}>
      */
-    public function unicodeProvider(): array
+    public static function unicodeProvider(): array
     {
         return [
             'uppercase first letter'            => [
@@ -115,10 +111,10 @@ class UnderscoreToCamelCaseFilterTest extends TestCase
     }
 
     /**
-     * @dataProvider unicodeWithoutMbStringsProvider
      * @param string $string
      * @param string $expected
      */
+    #[DataProvider('unicodeWithoutMbStringsProvider')]
     public function testFilterCamelCasesUnicodeStringsWithoutMbStrings(
         $string,
         $expected
@@ -137,7 +133,7 @@ class UnderscoreToCamelCaseFilterTest extends TestCase
      * @return string[][]
      * @psalm-return array<string, array{0: string, 1: string}>
      */
-    public function unicodeWithoutMbStringsProvider(): array
+    public static function unicodeWithoutMbStringsProvider(): array
     {
         return [
             'multiple words'                 => [

--- a/test/NamingStrategy/UnderscoreNamingStrategyTest.php
+++ b/test/NamingStrategy/UnderscoreNamingStrategyTest.php
@@ -5,13 +5,9 @@ declare(strict_types=1);
 namespace LaminasTest\Hydrator\NamingStrategy;
 
 use Laminas\Hydrator\NamingStrategy\UnderscoreNamingStrategy;
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\TestCase;
 
-/**
- * Unit tests for {@see UnderscoreNamingStrategy}
- *
- * @covers \Laminas\Hydrator\NamingStrategy\UnderscoreNamingStrategy
- */
 class UnderscoreNamingStrategyTest extends TestCase
 {
     public function testNameHydratesToCamelCase(): void
@@ -26,10 +22,8 @@ class UnderscoreNamingStrategyTest extends TestCase
         $this->assertEquals('foo_bar_baz', $strategy->extract('fooBarBaz'));
     }
 
-    /**
-     * @group 6422
-     * @group 6420
-     */
+    #[Group('6422')]
+    #[Group('6420')]
     public function testNameHydratesToStudlyCaps(): void
     {
         $strategy = new UnderscoreNamingStrategy();

--- a/test/NamingStrategy/UnderscoreNamingStrategyTest.php
+++ b/test/NamingStrategy/UnderscoreNamingStrategyTest.php
@@ -5,9 +5,11 @@ declare(strict_types=1);
 namespace LaminasTest\Hydrator\NamingStrategy;
 
 use Laminas\Hydrator\NamingStrategy\UnderscoreNamingStrategy;
+use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\TestCase;
 
+#[CoversClass(UnderscoreNamingStrategy::class)]
 class UnderscoreNamingStrategyTest extends TestCase
 {
     public function testNameHydratesToCamelCase(): void

--- a/test/ObjectPropertyHydratorTest.php
+++ b/test/ObjectPropertyHydratorTest.php
@@ -11,11 +11,6 @@ use PHPUnit\Framework\TestCase;
 use stdClass;
 use TypeError;
 
-/**
- * Unit tests for {@see ObjectPropertyHydrator}
- *
- * @covers \Laminas\Hydrator\ObjectPropertyHydrator
- */
 class ObjectPropertyHydratorTest extends TestCase
 {
     use HydratorTestTrait;
@@ -100,7 +95,7 @@ class ObjectPropertyHydratorTest extends TestCase
         $object = $this->hydrator->hydrate(['foo' => 'baz', 'bar' => 'baz'], $object);
 
         $this->assertEquals('baz', $object->foo);
-        $this->assertObjectHasAttribute('bar', $object);
+        $this->assertObjectHasProperty('bar', $object);
         $this->assertSame('baz', $object->bar);
     }
 

--- a/test/ObjectPropertyHydratorTest.php
+++ b/test/ObjectPropertyHydratorTest.php
@@ -7,10 +7,12 @@ namespace LaminasTest\Hydrator;
 use Laminas\Hydrator\ObjectPropertyHydrator;
 use LaminasTest\Hydrator\TestAsset\ClassWithPublicStaticProperties;
 use LaminasTest\Hydrator\TestAsset\ObjectProperty as ObjectPropertyTestAsset;
+use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 use stdClass;
 use TypeError;
 
+#[CoversClass(ObjectPropertyHydrator::class)]
 class ObjectPropertyHydratorTest extends TestCase
 {
     use HydratorTestTrait;

--- a/test/ObjectPropertyTest.php
+++ b/test/ObjectPropertyTest.php
@@ -6,6 +6,7 @@ namespace LaminasTest\Hydrator;
 
 use Laminas\Hydrator\ObjectProperty;
 use Laminas\Hydrator\ObjectPropertyHydrator;
+use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 
 use function restore_error_handler;
@@ -13,6 +14,7 @@ use function set_error_handler;
 
 use const E_USER_DEPRECATED;
 
+#[CoversClass(ObjectProperty::class)]
 class ObjectPropertyTest extends TestCase
 {
     public function testTriggerUserDeprecatedError(): void

--- a/test/ObjectPropertyTest.php
+++ b/test/ObjectPropertyTest.php
@@ -22,7 +22,6 @@ class ObjectPropertyTest extends TestCase
             public $message = false;
         };
 
-        /** @psalm-suppress UnusedClosureParam */
         set_error_handler(static function ($errno, $errstr) use ($test): bool {
             $test->message = $errstr;
             return true;

--- a/test/ReflectionHydratorTest.php
+++ b/test/ReflectionHydratorTest.php
@@ -10,11 +10,6 @@ use ReflectionProperty;
 use stdClass;
 use TypeError;
 
-/**
- * Unit tests for {@see ReflectionHydrator}
- *
- * @covers \Laminas\Hydrator\ReflectionHydrator
- */
 class ReflectionHydratorTest extends TestCase
 {
     use HydratorTestTrait;

--- a/test/ReflectionHydratorTest.php
+++ b/test/ReflectionHydratorTest.php
@@ -84,7 +84,6 @@ class ReflectionHydratorTest extends TestCase
 
         $this->assertSame($instance, $hydrated);
         $r = new ReflectionProperty($hydrated, 'foo');
-        $r->setAccessible(true);
         $this->assertSame('bar', $r->getValue($hydrated));
     }
 }

--- a/test/ReflectionHydratorTest.php
+++ b/test/ReflectionHydratorTest.php
@@ -5,11 +5,13 @@ declare(strict_types=1);
 namespace LaminasTest\Hydrator;
 
 use Laminas\Hydrator\ReflectionHydrator;
+use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 use ReflectionProperty;
 use stdClass;
 use TypeError;
 
+#[CoversClass(ReflectionHydrator::class)]
 class ReflectionHydratorTest extends TestCase
 {
     use HydratorTestTrait;

--- a/test/ReflectionTest.php
+++ b/test/ReflectionTest.php
@@ -22,7 +22,6 @@ class ReflectionTest extends TestCase
             public $message = false;
         };
 
-        /** @psalm-suppress UnusedClosureParam */
         set_error_handler(static function ($errno, $errstr) use ($test): bool {
             $test->message = $errstr;
             return true;

--- a/test/ReflectionTest.php
+++ b/test/ReflectionTest.php
@@ -6,6 +6,7 @@ namespace LaminasTest\Hydrator;
 
 use Laminas\Hydrator\Reflection;
 use Laminas\Hydrator\ReflectionHydrator;
+use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 
 use function restore_error_handler;
@@ -13,6 +14,7 @@ use function set_error_handler;
 
 use const E_USER_DEPRECATED;
 
+#[CoversClass(Reflection::class)]
 class ReflectionTest extends TestCase
 {
     public function testTriggerUserDeprecatedError(): void

--- a/test/StandaloneHydratorPluginManagerFactoryTest.php
+++ b/test/StandaloneHydratorPluginManagerFactoryTest.php
@@ -15,12 +15,14 @@ use Laminas\Hydrator\Reflection;
 use Laminas\Hydrator\ReflectionHydrator;
 use Laminas\Hydrator\StandaloneHydratorPluginManager;
 use Laminas\Hydrator\StandaloneHydratorPluginManagerFactory;
+use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Psr\Container\ContainerInterface;
 
 use function sprintf;
 
+#[CoversClass(StandaloneHydratorPluginManagerFactory::class)]
 class StandaloneHydratorPluginManagerFactoryTest extends TestCase
 {
     private const MESSAGE_DEFAULT_SERVICES = 'Missing the service %s';

--- a/test/StandaloneHydratorPluginManagerTest.php
+++ b/test/StandaloneHydratorPluginManagerTest.php
@@ -8,6 +8,7 @@ use Closure;
 use Generator;
 use Laminas\Hydrator;
 use Laminas\Hydrator\StandaloneHydratorPluginManager;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use ReflectionProperty;
 
@@ -23,10 +24,7 @@ class StandaloneHydratorPluginManagerTest extends TestCase
         $this->manager = new StandaloneHydratorPluginManager();
     }
 
-    /**
-     * @return mixed
-     */
-    public function reflectProperty(object $class, string $property)
+    public function reflectProperty(object $class, string $property): mixed
     {
         $r = new ReflectionProperty($class, $property);
         return $r->getValue($class);
@@ -35,7 +33,7 @@ class StandaloneHydratorPluginManagerTest extends TestCase
     /**
      * @psalm-return Generator<string, array{0: class-string}>
      */
-    public function hydratorsWithoutConstructors(): Generator
+    public static function hydratorsWithoutConstructors(): Generator
     {
         yield 'ArraySerializable'               => [Hydrator\ArraySerializableHydrator::class];
         yield 'ArraySerializableHydrator'       => [Hydrator\ArraySerializableHydrator::class];
@@ -51,9 +49,7 @@ class StandaloneHydratorPluginManagerTest extends TestCase
         yield 'Reflection'                      => [Hydrator\ReflectionHydrator::class];
     }
 
-    /**
-     * @dataProvider hydratorsWithoutConstructors
-     */
+    #[DataProvider('hydratorsWithoutConstructors')]
     public function testInstantiationInitializesFactoriesForHydratorsWithoutConstructorArguments(string $class): void
     {
         $factories = $this->reflectProperty($this->manager, 'factories');
@@ -77,9 +73,9 @@ class StandaloneHydratorPluginManagerTest extends TestCase
     }
 
     /** @return Generator<string, array{0: string, 1: class-string}> */
-    public function knownServices(): Generator
+    public static function knownServices(): Generator
     {
-        foreach ($this->hydratorsWithoutConstructors() as $key => $data) {
+        foreach (self::hydratorsWithoutConstructors() as $key => $data) {
             $class = array_pop($data);
             $alias = sprintf('%s alias', $key);
             $fqcn  = sprintf('%s class', $key);
@@ -92,9 +88,7 @@ class StandaloneHydratorPluginManagerTest extends TestCase
         yield 'DelegatingHydrator class' => [Hydrator\DelegatingHydrator::class, Hydrator\DelegatingHydrator::class];
     }
 
-    /**
-     * @dataProvider knownServices
-     */
+    #[DataProvider('knownServices')]
     public function testHasReturnsTrueForKnownServices(string $service): void
     {
         self::assertTrue($this->manager->has($service));
@@ -107,10 +101,10 @@ class StandaloneHydratorPluginManagerTest extends TestCase
     }
 
     /**
-     * @dataProvider knownServices
      * @param string|class-string $service
      * @param class-string $expectedType
      */
+    #[DataProvider('knownServices')]
     public function testGetReturnsExpectedTypesForKnownServices(string $service, string $expectedType): void
     {
         $instance = $this->manager->get($service);

--- a/test/StandaloneHydratorPluginManagerTest.php
+++ b/test/StandaloneHydratorPluginManagerTest.php
@@ -29,7 +29,6 @@ class StandaloneHydratorPluginManagerTest extends TestCase
     public function reflectProperty(object $class, string $property)
     {
         $r = new ReflectionProperty($class, $property);
-        $r->setAccessible(true);
         return $r->getValue($class);
     }
 

--- a/test/StandaloneHydratorPluginManagerTest.php
+++ b/test/StandaloneHydratorPluginManagerTest.php
@@ -8,6 +8,7 @@ use Closure;
 use Generator;
 use Laminas\Hydrator;
 use Laminas\Hydrator\StandaloneHydratorPluginManager;
+use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use ReflectionProperty;
@@ -15,6 +16,7 @@ use ReflectionProperty;
 use function array_pop;
 use function sprintf;
 
+#[CoversClass(StandaloneHydratorPluginManager::class)]
 class StandaloneHydratorPluginManagerTest extends TestCase
 {
     private StandaloneHydratorPluginManager $manager;

--- a/test/Strategy/BackedEnumStrategyTest.php
+++ b/test/Strategy/BackedEnumStrategyTest.php
@@ -8,11 +8,13 @@ use Laminas\Hydrator\Strategy\BackedEnumStrategy;
 use Laminas\Hydrator\Strategy\Exception\InvalidArgumentException;
 use LaminasTest\Hydrator\Strategy\TestAsset\TestBackedEnum;
 use LaminasTest\Hydrator\Strategy\TestAsset\TestUnitEnum;
+use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 
 use const PHP_VERSION_ID;
 
-final class BackedEnumStrategyTest extends TestCase
+#[CoversClass(BackedEnumStrategy::class)]
+class BackedEnumStrategyTest extends TestCase
 {
     protected function setUp(): void
     {

--- a/test/Strategy/BackedEnumStrategyTest.php
+++ b/test/Strategy/BackedEnumStrategyTest.php
@@ -12,12 +12,6 @@ use PHPUnit\Framework\TestCase;
 
 use const PHP_VERSION_ID;
 
-/**
- * @uses \Laminas\Hydrator\Exception\DomainException
- * @uses \Laminas\Hydrator\Strategy\Exception\InvalidArgumentException
- *
- * @covers \Laminas\Hydrator\Strategy\BackedEnumStrategy
- */
 final class BackedEnumStrategyTest extends TestCase
 {
     protected function setUp(): void

--- a/test/Strategy/BooleanStrategyTest.php
+++ b/test/Strategy/BooleanStrategyTest.php
@@ -9,11 +9,6 @@ use Laminas\Hydrator\Strategy\BooleanStrategy;
 use PHPUnit\Framework\TestCase;
 use stdClass;
 
-/**
- * Tests for {@see BooleanStrategy}
- *
- * @covers \Laminas\Hydrator\Strategy\BooleanStrategy
- */
 class BooleanStrategyTest extends TestCase
 {
     public function testConstructorWithValidInteger(): void

--- a/test/Strategy/BooleanStrategyTest.php
+++ b/test/Strategy/BooleanStrategyTest.php
@@ -6,9 +6,11 @@ namespace LaminasTest\Hydrator\Strategy;
 
 use Laminas\Hydrator\Exception\InvalidArgumentException;
 use Laminas\Hydrator\Strategy\BooleanStrategy;
+use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 use stdClass;
 
+#[CoversClass(BooleanStrategy::class)]
 class BooleanStrategyTest extends TestCase
 {
     public function testConstructorWithValidInteger(): void

--- a/test/Strategy/CollectionStrategyTest.php
+++ b/test/Strategy/CollectionStrategyTest.php
@@ -10,6 +10,7 @@ use Laminas\Hydrator\HydratorInterface;
 use Laminas\Hydrator\ReflectionHydrator;
 use Laminas\Hydrator\Strategy\CollectionStrategy;
 use LaminasTest\Hydrator\TestAsset;
+use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
@@ -27,6 +28,7 @@ use function mt_rand;
 use function spl_object_hash;
 use function sprintf;
 
+#[CoversClass(CollectionStrategy::class)]
 class CollectionStrategyTest extends TestCase
 {
     /**

--- a/test/Strategy/CollectionStrategyTest.php
+++ b/test/Strategy/CollectionStrategyTest.php
@@ -10,6 +10,7 @@ use Laminas\Hydrator\HydratorInterface;
 use Laminas\Hydrator\ReflectionHydrator;
 use Laminas\Hydrator\Strategy\CollectionStrategy;
 use LaminasTest\Hydrator\TestAsset;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use stdClass;
@@ -26,17 +27,12 @@ use function mt_rand;
 use function spl_object_hash;
 use function sprintf;
 
-/**
- * Tests for {@see CollectionStrategy}
- *
- * @covers \Laminas\Hydrator\Strategy\CollectionStrategy
- */
 class CollectionStrategyTest extends TestCase
 {
     /**
-     * @dataProvider providerInvalidObjectClassName
      * @param class-string<Throwable> $expectedExceptionType
      */
+    #[DataProvider('providerInvalidObjectClassName')]
     public function testConstructorRejectsInvalidObjectClassName(
         mixed $objectClassName,
         string $expectedExceptionType,
@@ -53,7 +49,7 @@ class CollectionStrategyTest extends TestCase
     }
 
     /** @return array<string, array{0:mixed, 1: class-string<Throwable>, 2: string}> */
-    public function providerInvalidObjectClassName(): array
+    public static function providerInvalidObjectClassName(): array
     {
         // @codingStandardsIgnoreStart
         return [
@@ -70,9 +66,7 @@ class CollectionStrategyTest extends TestCase
         // @codingStandardsIgnoreEnd
     }
 
-    /**
-     * @dataProvider providerInvalidValueForExtraction
-     */
+    #[DataProvider('providerInvalidValueForExtraction')]
     public function testExtractRejectsInvalidValue(mixed $value): void
     {
         $strategy = new CollectionStrategy(
@@ -93,7 +87,7 @@ class CollectionStrategyTest extends TestCase
     /**
      * @return Generator<string, list<mixed>>
      */
-    public function providerInvalidValueForExtraction(): Generator
+    public static function providerInvalidValueForExtraction(): Generator
     {
         $values = [
             'boolean-false'             => false,
@@ -111,9 +105,7 @@ class CollectionStrategyTest extends TestCase
         }
     }
 
-    /**
-     * @dataProvider providerInvalidObjectForExtraction
-     */
+    #[DataProvider('providerInvalidObjectForExtraction')]
     public function testExtractRejectsInvalidObject(mixed $object): void
     {
         $value = [$object];
@@ -136,7 +128,7 @@ class CollectionStrategyTest extends TestCase
     /**
      * @return Generator<string, list<mixed>>
      */
-    public function providerInvalidObjectForExtraction(): Generator
+    public static function providerInvalidObjectForExtraction(): Generator
     {
         $values = [
             'boolean-false'                           => false,
@@ -187,9 +179,7 @@ class CollectionStrategyTest extends TestCase
         self::assertSame($expected, $strategy->extract($value));
     }
 
-    /**
-     * @dataProvider providerInvalidValueForHydration
-     */
+    #[DataProvider('providerInvalidValueForHydration')]
     public function testHydrateRejectsInvalidValue(mixed $value): void
     {
         $strategy = new CollectionStrategy(
@@ -210,7 +200,7 @@ class CollectionStrategyTest extends TestCase
     /**
      * @return Generator<string, list<mixed>>
      */
-    public function providerInvalidValueForHydration(): Generator
+    public static function providerInvalidValueForHydration(): Generator
     {
         $values = [
             'boolean-false'             => false,

--- a/test/Strategy/DateTimeFormatterStrategyTest.php
+++ b/test/Strategy/DateTimeFormatterStrategyTest.php
@@ -10,10 +10,12 @@ use DateTimeInterface;
 use DateTimeZone;
 use Laminas\Hydrator\Strategy\DateTimeFormatterStrategy;
 use Laminas\Hydrator\Strategy\Exception\InvalidArgumentException;
+use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use stdClass;
 
+#[CoversClass(DateTimeFormatterStrategy::class)]
 class DateTimeFormatterStrategyTest extends TestCase
 {
     public function testHydrate(): void

--- a/test/Strategy/DateTimeFormatterStrategyTest.php
+++ b/test/Strategy/DateTimeFormatterStrategyTest.php
@@ -10,14 +10,10 @@ use DateTimeInterface;
 use DateTimeZone;
 use Laminas\Hydrator\Strategy\DateTimeFormatterStrategy;
 use Laminas\Hydrator\Strategy\Exception\InvalidArgumentException;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use stdClass;
 
-/**
- * Tests for {@see DateTimeFormatterStrategy}
- *
- * @covers \Laminas\Hydrator\Strategy\DateTimeFormatterStrategy
- */
 class DateTimeFormatterStrategyTest extends TestCase
 {
     public function testHydrate(): void
@@ -86,10 +82,10 @@ class DateTimeFormatterStrategyTest extends TestCase
     }
 
     /**
-     * @dataProvider formatsWithSpecialCharactersProvider
      * @param string $format
      * @param string $expectedValue
      */
+    #[DataProvider('formatsWithSpecialCharactersProvider')]
     public function testAcceptsCreateFromFormatSpecialCharacters($format, $expectedValue): void
     {
         $strategy = new DateTimeFormatterStrategy($format);
@@ -99,9 +95,7 @@ class DateTimeFormatterStrategyTest extends TestCase
         self::assertEquals($expectedValue, $hydrated->format('Y-m-d'));
     }
 
-    /**
-     * @dataProvider formatsWithSpecialCharactersProvider
-     */
+    #[DataProvider('formatsWithSpecialCharactersProvider')]
     public function testCanExtractWithCreateFromFormatSpecialCharacters(string $format, string $expectedValue): void
     {
         $date      = DateTime::createFromFormat($format, $expectedValue);
@@ -123,7 +117,7 @@ class DateTimeFormatterStrategyTest extends TestCase
      * @return string[][]
      * @psalm-return array<string, array{0: string, 1: string}>
      */
-    public function formatsWithSpecialCharactersProvider(): array
+    public static function formatsWithSpecialCharactersProvider(): array
     {
         return [
             '!-prepended' => ['!Y-m-d', '2018-02-05'],
@@ -148,7 +142,7 @@ class DateTimeFormatterStrategyTest extends TestCase
     }
 
     /** @return array<string, list<mixed>> */
-    public function invalidValuesForHydration(): array
+    public static function invalidValuesForHydration(): array
     {
         return [
             'zero'       => [0],
@@ -160,9 +154,7 @@ class DateTimeFormatterStrategyTest extends TestCase
         ];
     }
 
-    /**
-     * @dataProvider invalidValuesForHydration
-     */
+    #[DataProvider('invalidValuesForHydration')]
     public function testHydrateRaisesExceptionIfValueIsInvalid(mixed $value): void
     {
         $strategy = new DateTimeFormatterStrategy('Y-m-d');
@@ -173,7 +165,7 @@ class DateTimeFormatterStrategyTest extends TestCase
     }
 
     /** @return array<string, list<mixed>> */
-    public function validUnHydratableValues(): array
+    public static function validUnHydratableValues(): array
     {
         return [
             'empty string' => [''],
@@ -182,9 +174,7 @@ class DateTimeFormatterStrategyTest extends TestCase
         ];
     }
 
-    /**
-     * @dataProvider validUnHydratableValues
-     */
+    #[DataProvider('validUnHydratableValues')]
     public function testReturnsValueVerbatimUnderSpecificConditions(mixed $value): void
     {
         $strategy = new DateTimeFormatterStrategy('Y-m-d');

--- a/test/Strategy/DateTimeImmutableFormatterStrategyTest.php
+++ b/test/Strategy/DateTimeImmutableFormatterStrategyTest.php
@@ -7,9 +7,11 @@ namespace LaminasTest\Hydrator\Strategy;
 use DateTimeImmutable;
 use Laminas\Hydrator\Strategy\DateTimeFormatterStrategy;
 use Laminas\Hydrator\Strategy\DateTimeImmutableFormatterStrategy;
+use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
+#[CoversClass(DateTimeImmutableFormatterStrategy::class)]
 class DateTimeImmutableFormatterStrategyTest extends TestCase
 {
     private DateTimeImmutableFormatterStrategy $strategy;

--- a/test/Strategy/DateTimeImmutableFormatterStrategyTest.php
+++ b/test/Strategy/DateTimeImmutableFormatterStrategyTest.php
@@ -7,6 +7,7 @@ namespace LaminasTest\Hydrator\Strategy;
 use DateTimeImmutable;
 use Laminas\Hydrator\Strategy\DateTimeFormatterStrategy;
 use Laminas\Hydrator\Strategy\DateTimeImmutableFormatterStrategy;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
 class DateTimeImmutableFormatterStrategyTest extends TestCase
@@ -50,16 +51,14 @@ class DateTimeImmutableFormatterStrategyTest extends TestCase
         );
     }
 
-    /**
-     * @dataProvider dataProviderForInvalidDateValues
-     */
+    #[DataProvider('dataProviderForInvalidDateValues')]
     public function testHydrationShouldReturnInvalidDateValuesAsIs(string|null $value): void
     {
         self::assertSame($value, $this->strategy->hydrate($value));
     }
 
     /** @return array<string, array{0: null|string}> */
-    public function dataProviderForInvalidDateValues(): array
+    public static function dataProviderForInvalidDateValues(): array
     {
         return [
             'null'         => [null],

--- a/test/Strategy/ExplodeStrategyTest.php
+++ b/test/Strategy/ExplodeStrategyTest.php
@@ -6,23 +6,19 @@ namespace LaminasTest\Hydrator\Strategy;
 
 use Laminas\Hydrator\Strategy\Exception\InvalidArgumentException;
 use Laminas\Hydrator\Strategy\ExplodeStrategy;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use stdClass;
 
 use function is_numeric;
 
-/**
- * Tests for {@see ExplodeStrategy}
- *
- * @covers \Laminas\Hydrator\Strategy\ExplodeStrategy
- */
 class ExplodeStrategyTest extends TestCase
 {
     /**
-     * @dataProvider getValidHydratedValues
      * @param non-empty-string $delimiter
      * @param string[] $extractValue
      */
+    #[DataProvider('getValidHydratedValues')]
     public function testExtract(mixed $expected, string $delimiter, array $extractValue): void
     {
         $strategy = new ExplodeStrategy($delimiter);
@@ -111,9 +107,9 @@ class ExplodeStrategyTest extends TestCase
     }
 
     /**
-     * @dataProvider getValidHydratedValues
      * @param non-empty-string $delimiter
      */
+    #[DataProvider('getValidHydratedValues')]
     public function testHydration(mixed $value, string $delimiter, array $expected): void
     {
         $strategy = new ExplodeStrategy($delimiter);
@@ -125,7 +121,7 @@ class ExplodeStrategyTest extends TestCase
     /**
      * @return array<string, array{0: mixed, 1: non-empty-string, 2: list<string>}>
      */
-    public function getValidHydratedValues(): array
+    public static function getValidHydratedValues(): array
     {
         // @codingStandardsIgnoreStart
         return [

--- a/test/Strategy/ExplodeStrategyTest.php
+++ b/test/Strategy/ExplodeStrategyTest.php
@@ -6,12 +6,14 @@ namespace LaminasTest\Hydrator\Strategy;
 
 use Laminas\Hydrator\Strategy\Exception\InvalidArgumentException;
 use Laminas\Hydrator\Strategy\ExplodeStrategy;
+use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use stdClass;
 
 use function is_numeric;
 
+#[CoversClass(ExplodeStrategy::class)]
 class ExplodeStrategyTest extends TestCase
 {
     /**

--- a/test/Strategy/HydratorStrategyTest.php
+++ b/test/Strategy/HydratorStrategyTest.php
@@ -10,6 +10,7 @@ use Laminas\Hydrator\ReflectionHydrator;
 use Laminas\Hydrator\Strategy\Exception\InvalidArgumentException;
 use Laminas\Hydrator\Strategy\HydratorStrategy;
 use LaminasTest\Hydrator\TestAsset;
+use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
@@ -26,6 +27,7 @@ use function mt_rand;
 use function spl_object_hash;
 use function sprintf;
 
+#[CoversClass(HydratorStrategy::class)]
 class HydratorStrategyTest extends TestCase
 {
     /**

--- a/test/Strategy/HydratorStrategyTest.php
+++ b/test/Strategy/HydratorStrategyTest.php
@@ -10,6 +10,7 @@ use Laminas\Hydrator\ReflectionHydrator;
 use Laminas\Hydrator\Strategy\Exception\InvalidArgumentException;
 use Laminas\Hydrator\Strategy\HydratorStrategy;
 use LaminasTest\Hydrator\TestAsset;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use stdClass;
@@ -28,9 +29,9 @@ use function sprintf;
 class HydratorStrategyTest extends TestCase
 {
     /**
-     * @dataProvider providerInvalidObjectClassName
      * @param class-string<Throwable> $expectedExceptionType
      */
+    #[DataProvider('providerInvalidObjectClassName')]
     public function testConstructorRejectsInvalidObjectClassName(
         mixed $objectClassName,
         string $expectedExceptionType,
@@ -46,7 +47,7 @@ class HydratorStrategyTest extends TestCase
     }
 
     /** @return non-empty-array<non-empty-string, array{mixed, class-string<Throwable>, string}> */
-    public function providerInvalidObjectClassName(): array
+    public static function providerInvalidObjectClassName(): array
     {
         return [
             'array'                     => [[], TypeError::class, 'type string'],
@@ -65,9 +66,7 @@ class HydratorStrategyTest extends TestCase
         ];
     }
 
-    /**
-     * @dataProvider providerInvalidValueForExtraction
-     */
+    #[DataProvider('providerInvalidValueForExtraction')]
     public function testExtractRejectsInvalidValue(mixed $value): void
     {
         $strategy = new HydratorStrategy(
@@ -88,7 +87,7 @@ class HydratorStrategyTest extends TestCase
     }
 
     /** @return Generator<string, array{0: mixed}> */
-    public function providerInvalidValueForExtraction(): Generator
+    public static function providerInvalidValueForExtraction(): Generator
     {
         $values = [
             'boolean-false'             => false,
@@ -106,9 +105,7 @@ class HydratorStrategyTest extends TestCase
         }
     }
 
-    /**
-     * @dataProvider providerInvalidObjectForExtraction
-     */
+    #[DataProvider('providerInvalidObjectForExtraction')]
     public function testExtractRejectsInvalidObject(mixed $object): void
     {
         $strategy = new HydratorStrategy(
@@ -129,7 +126,7 @@ class HydratorStrategyTest extends TestCase
     }
 
     /** @return Generator<string, array{0: mixed}> */
-    public function providerInvalidObjectForExtraction(): Generator
+    public static function providerInvalidObjectForExtraction(): Generator
     {
         $values = [
             'boolean-false'                           => false,
@@ -173,9 +170,7 @@ class HydratorStrategyTest extends TestCase
         self::assertSame($extraction($value), $strategy->extract($value));
     }
 
-    /**
-     * @dataProvider providerInvalidValueForHydration
-     */
+    #[DataProvider('providerInvalidValueForHydration')]
     public function testHydrateRejectsInvalidValue(mixed $value): void
     {
         $strategy = new HydratorStrategy(
@@ -195,7 +190,7 @@ class HydratorStrategyTest extends TestCase
     }
 
     /** @return Generator<string, array{0: mixed}> */
-    public function providerInvalidValueForHydration(): Generator
+    public static function providerInvalidValueForHydration(): Generator
     {
         $values = [
             'boolean-false'             => false,
@@ -212,9 +207,7 @@ class HydratorStrategyTest extends TestCase
         }
     }
 
-    /**
-     * @dataProvider providerEmptyOrSameObjects
-     */
+    #[DataProvider('providerEmptyOrSameObjects')]
     public function testHydrateShouldReturnEmptyOrSameObjects(mixed $value): void
     {
         $strategy = new HydratorStrategy(
@@ -226,7 +219,7 @@ class HydratorStrategyTest extends TestCase
     }
 
     /** @return Generator<string, array{0: mixed}> */
-    public function providerEmptyOrSameObjects(): Generator
+    public static function providerEmptyOrSameObjects(): Generator
     {
         $values = [
             'null'                => null,

--- a/test/Strategy/NullableStrategyTest.php
+++ b/test/Strategy/NullableStrategyTest.php
@@ -6,8 +6,10 @@ namespace LaminasTest\Hydrator\Strategy;
 
 use Laminas\Hydrator\Strategy\NullableStrategy;
 use Laminas\Hydrator\Strategy\StrategyInterface;
+use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 
+#[CoversClass(NullableStrategy::class)]
 class NullableStrategyTest extends TestCase
 {
     public function testExtractNonNullAndNonEmptyValue(): void

--- a/test/Strategy/ScalarTypeStrategyTest.php
+++ b/test/Strategy/ScalarTypeStrategyTest.php
@@ -7,9 +7,6 @@ namespace LaminasTest\Hydrator\Strategy;
 use Laminas\Hydrator\Strategy\ScalarTypeStrategy;
 use PHPUnit\Framework\TestCase;
 
-/**
- * @covers \Laminas\Hydrator\Strategy\ScalarTypeStrategy
- */
 final class ScalarTypeStrategyTest extends TestCase
 {
     public function testHydrate(): void

--- a/test/Strategy/ScalarTypeStrategyTest.php
+++ b/test/Strategy/ScalarTypeStrategyTest.php
@@ -5,9 +5,11 @@ declare(strict_types=1);
 namespace LaminasTest\Hydrator\Strategy;
 
 use Laminas\Hydrator\Strategy\ScalarTypeStrategy;
+use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 
-final class ScalarTypeStrategyTest extends TestCase
+#[CoversClass(ScalarTypeStrategy::class)]
+class ScalarTypeStrategyTest extends TestCase
 {
     public function testHydrate(): void
     {

--- a/test/Strategy/SerializableStrategyTest.php
+++ b/test/Strategy/SerializableStrategyTest.php
@@ -8,8 +8,10 @@ use Laminas\Hydrator\Exception\InvalidArgumentException;
 use Laminas\Hydrator\Strategy\SerializableStrategy;
 use Laminas\Serializer\Adapter\PhpSerialize;
 use Laminas\Serializer\Serializer;
+use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 
+#[CoversClass(SerializableStrategy::class)]
 class SerializableStrategyTest extends TestCase
 {
     public function testCannotUseBadArgumentSerializer(): void

--- a/test/Strategy/SerializableStrategyTest.php
+++ b/test/Strategy/SerializableStrategyTest.php
@@ -10,9 +10,6 @@ use Laminas\Serializer\Adapter\PhpSerialize;
 use Laminas\Serializer\Serializer;
 use PHPUnit\Framework\TestCase;
 
-/**
- * @covers Laminas\Hydrator\Strategy\SerializableStrategy
- */
 class SerializableStrategyTest extends TestCase
 {
     public function testCannotUseBadArgumentSerializer(): void

--- a/test/Strategy/StrategyChainTest.php
+++ b/test/Strategy/StrategyChainTest.php
@@ -6,8 +6,10 @@ namespace LaminasTest\Hydrator\Strategy;
 
 use Laminas\Hydrator\Strategy\ClosureStrategy;
 use Laminas\Hydrator\Strategy\StrategyChain;
+use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 
+#[CoversClass(StrategyChain::class)]
 class StrategyChainTest extends TestCase
 {
     public function testEmptyStrategyChainReturnsOriginalValue(): void

--- a/test/Strategy/StrategyChainTest.php
+++ b/test/Strategy/StrategyChainTest.php
@@ -8,9 +8,6 @@ use Laminas\Hydrator\Strategy\ClosureStrategy;
 use Laminas\Hydrator\Strategy\StrategyChain;
 use PHPUnit\Framework\TestCase;
 
-/**
- * @covers \Laminas\Hydrator\Strategy\StrategyChain
- */
 class StrategyChainTest extends TestCase
 {
     public function testEmptyStrategyChainReturnsOriginalValue(): void

--- a/test/TestAsset/HydratorAwareTraitImplementor.php
+++ b/test/TestAsset/HydratorAwareTraitImplementor.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LaminasTest\Hydrator\TestAsset;
+
+use Laminas\Hydrator\HydratorAwareInterface;
+use Laminas\Hydrator\HydratorAwareTrait;
+
+final class HydratorAwareTraitImplementor implements HydratorAwareInterface
+{
+    use HydratorAwareTrait;
+}

--- a/test/TestAsset/InMemoryContainer.php
+++ b/test/TestAsset/InMemoryContainer.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LaminasTest\Hydrator\TestAsset;
+
+use Psr\Container\ContainerInterface;
+use Psr\Container\NotFoundExceptionInterface;
+use RuntimeException;
+
+use function array_key_exists;
+
+final class InMemoryContainer implements ContainerInterface
+{
+    /** @var array<string, mixed> */
+    private array $services = [];
+
+    /** @inheritDoc */
+    public function get($id): mixed
+    {
+        if (! array_key_exists($id, $this->services)) {
+            throw new class ($id . ' was not found') extends RuntimeException implements NotFoundExceptionInterface {
+            };
+        }
+
+        return $this->services[$id];
+    }
+
+    /** @inheritDoc */
+    public function has($id): bool
+    {
+        return array_key_exists($id, $this->services);
+    }
+
+    public function set(string $id, mixed $item): void
+    {
+        $this->services[$id] = $item;
+    }
+}


### PR DESCRIPTION
This patch also deprecates some unused Exception types for removal in 5.0

Closes #104