### PR TITLE
Use strpos for consistency with other filters

### DIFF
--- a/src/Filter/GetFilter.php
+++ b/src/Filter/GetFilter.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Laminas\Hydrator\Filter;
 
 use function strpos;
-use function substr;
 
 final class GetFilter implements FilterInterface
 {
@@ -18,6 +17,6 @@ final class GetFilter implements FilterInterface
             $pos = 0;
         }
 
-        return substr($property, $pos, 3) === 'get';
+        return strpos($property, 'get', $pos) === $pos;
     }
 }


### PR DESCRIPTION
- `IsFilter` and `HasFilter` are already using `strpos`.
- `strpos` matching technique appears to be about 20% faster in my tests
