### PR TITLE
Bug fix for issue #113 - Use static instead of self.

### DIFF
--- a/src/ReflectionHydrator.php
+++ b/src/ReflectionHydrator.php
@@ -24,7 +24,7 @@ class ReflectionHydrator extends AbstractHydrator
     public function extract(object $object): array
     {
         $result = [];
-        foreach (self::getReflProperties($object) as $property) {
+        foreach (static::getReflProperties($object) as $property) {
             $propertyName = $this->extractName($property->getName(), $object);
             if (! $this->getCompositeFilter()->filter($propertyName)) {
                 continue;
@@ -44,7 +44,7 @@ class ReflectionHydrator extends AbstractHydrator
      */
     public function hydrate(array $data, object $object)
     {
-        $reflProperties = self::getReflProperties($object);
+        $reflProperties = static::getReflProperties($object);
         foreach ($data as $key => $value) {
             $name = $this->hydrateName($key, $data);
             if (isset($reflProperties[$name])) {


### PR DESCRIPTION
PR to fix bug #113.

|    Q          |   A
|-------------- | ------
| Bugfix        | yes
| BC Break      | no
### Description

This is a fix for issue #113 so that the ReflectionHydrator can be extended and overloaded versions of getReflProperties will be called.
