### PR TITLE
docs: add migration guide for v4 to v5

### DIFF
--- a/docs/book/v5/migration/v4-to-v5.md
+++ b/docs/book/v5/migration/v4-to-v5.md
@@ -10,7 +10,7 @@ Use **decorators** to extend behavior without modifying original classes or crea
 
 ### Hydrator Plugin Manager
 
-#### Removal of legacy Zend aliases
+#### Removal of Legacy Zend Aliases
 
 All aliases that referenced the equivalent, legacy "Zend" hydrators have been removed. This means that an exception will be thrown if you attempt to retrieve a hydrator using one of these aliases such as `Zend\Hydrator\ArraySerializableHydrator::class`.
 
@@ -30,12 +30,12 @@ The following exceptions have been removed:
 - Internal getter and setter methods have been removed.
 - If you're relying on these, update your code to use serialization logic externally or via injected services.
 
-### Changes to Individual Hydrators
+## Removed Classes
 
 The following deprecated classes (since version 3.0.0) have been removed in version 5.  
 Please update your codebase to use the corresponding `*Hydrator` classes:
 
-| Removed Class                              | Replacement Class                                  |
+| Removed Class                             | Replacement Class                                  |
 |-------------------------------------------|----------------------------------------------------|
 | `Laminas\Hydrator\ArraySerializable`      | `Laminas\Hydrator\ArraySerializableHydrator`       |
 | `Laminas\Hydrator\ClassMethods`           | `Laminas\Hydrator\ClassMethodsHydrator`            |

--- a/docs/book/v5/migration/v4-to-v5.md
+++ b/docs/book/v5/migration/v4-to-v5.md
@@ -41,3 +41,9 @@ Please update your codebase to use the corresponding `*Hydrator` classes:
 | `Laminas\Hydrator\ClassMethods`           | `Laminas\Hydrator\ClassMethodsHydrator`            |
 | `Laminas\Hydrator\ObjectProperty`         | `Laminas\Hydrator\ObjectPropertyHydrator`          |
 | `Laminas\Hydrator\Reflection`             | `Laminas\Hydrator\ReflectionHydrator`              |
+
+## Removed Features
+
+### Removal of Module Manager Support
+
+[Module Manager](https://docs.laminas.dev/laminas-modulemanager/) support has been removed along with the interface `Laminas\Hydrator\HydratorProviderInterface`

--- a/docs/book/v5/migration/v4-to-v5.md
+++ b/docs/book/v5/migration/v4-to-v5.md
@@ -2,21 +2,21 @@
 
 ## Changed Behavior & Signature Changes
 
-### 🔒 Final Classes and Inheritance
+### Final Classes and Inheritance
 
 As a best practice, even if a hydrator (or other classes) is not marked as `final` in this library, extending it is discouraged — future major releases may prohibit inheritance altogether.
 Prefer **composition over inheritance** by combining small, focused objects.
 Use **decorators** to extend behavior without modifying original classes or creating deep inheritance chains.
 
-### 🧩 Hydrator Plugin Manager
+### Hydrator Plugin Manager
 
-#### ❌ Removal of legacy Zend aliases
+#### Removal of legacy Zend aliases
 
 All aliases that referenced the equivalent, legacy "Zend" hydrators have been removed. This means that an exception will be thrown if you attempt to retrieve a hydrator using one of these aliases such as `Zend\Hydrator\ArraySerializableHydrator::class`.
 
 You will need to either update your codebase to use known aliases such as `Laminas\Hydrator\ArraySerializableHydrator::class`, or re-implement the aliases in your configuration.
 
-### ❌ Removed Exceptions
+### Removed Exceptions
 
 The following exceptions have been removed:
 
@@ -24,13 +24,13 @@ The following exceptions have been removed:
 - `Laminas\Hydrator\Exception\InvalidCallbackException`
 - `Laminas\Hydrator\Exception\LogicException`
 
-### 🔄 Changes of `Laminas\Hydrator\Strategy\SerializableStrategy`
+### Changes of `Laminas\Hydrator\Strategy\SerializableStrategy`
 
 - Simplified implementation.
 - Internal getter and setter methods have been removed.
 - If you're relying on these, update your code to use serialization logic externally or via injected services.
 
-### 🔄 Changes to Individual Hydrators
+### Changes to Individual Hydrators
 
 The following deprecated classes (since version 3.0.0) have been removed in version 5.  
 Please update your codebase to use the corresponding `*Hydrator` classes:

--- a/docs/book/v5/migration/v4-to-v5.md
+++ b/docs/book/v5/migration/v4-to-v5.md
@@ -1,0 +1,43 @@
+# Migration from Version 4 to 5
+
+## Changed Behavior & Signature Changes
+
+### 🔒 Final Classes and Inheritance
+
+As a best practice, even if a hydrator (or other classes) is not marked as `final` in this library, extending it is discouraged — future major releases may prohibit inheritance altogether.
+Prefer **composition over inheritance** by combining small, focused objects.
+Use **decorators** to extend behavior without modifying original classes or creating deep inheritance chains.
+
+### 🧩 Hydrator Plugin Manager
+
+#### ❌ Removal of legacy Zend aliases
+
+All aliases that referenced the equivalent, legacy "Zend" hydrators have been removed. This means that an exception will be thrown if you attempt to retrieve a hydrator using one of these aliases such as `Zend\Hydrator\ArraySerializableHydrator::class`.
+
+You will need to either update your codebase to use known aliases such as `Laminas\Hydrator\ArraySerializableHydrator::class`, or re-implement the aliases in your configuration.
+
+### ❌ Removed Exceptions
+
+The following exceptions have been removed:
+
+- `Laminas\Hydrator\Exception\ExtensionNotLoadedException`
+- `Laminas\Hydrator\Exception\InvalidCallbackException`
+- `Laminas\Hydrator\Exception\LogicException`
+
+### 🔄 Changes of `Laminas\Hydrator\Strategy\SerializableStrategy`
+
+- Simplified implementation.
+- Internal getter and setter methods have been removed.
+- If you're relying on these, update your code to use serialization logic externally or via injected services.
+
+### 🔄 Changes to Individual Hydrators
+
+The following deprecated classes (since version 3.0.0) have been removed in version 5.  
+Please update your codebase to use the corresponding `*Hydrator` classes:
+
+| Removed Class                              | Replacement Class                                  |
+|-------------------------------------------|----------------------------------------------------|
+| `Laminas\Hydrator\ArraySerializable`      | `Laminas\Hydrator\ArraySerializableHydrator`       |
+| `Laminas\Hydrator\ClassMethods`           | `Laminas\Hydrator\ClassMethodsHydrator`            |
+| `Laminas\Hydrator\ObjectProperty`         | `Laminas\Hydrator\ObjectPropertyHydrator`          |
+| `Laminas\Hydrator\Reflection`             | `Laminas\Hydrator\ReflectionHydrator`              |


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | yes
| Bugfix        | no
| BC Break      | no
| New Feature   | no
| RFC           | no
| QA            | no

### Description

This pull request adds a migration guide for users upgrading from version 4 to version 5 of the `laminas-hydrator` package.

The new guide includes:
- Clear explanation of removed and replaced hydrator classes.
- Notes on removed legacy Zend aliases and how to update plugin manager usage.
- Clarification on removed exceptions and updated `SerializableStrategy` behavior.
- Recommendations to avoid inheritance and prefer composition or decorators going forward.
