### PR TITLE
refactor: update psr/container dependency to support version 2.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -36,7 +36,7 @@
         "laminas/laminas-serializer": "^3.0",
         "laminas/laminas-servicemanager": "^4.4.0",
         "laminas/laminas-stdlib": "^3.20",
-        "psr/container": "^1.1",
+        "psr/container": "^1.1 || ^2.0",
         "webmozart/assert": "^1.11"
     },
     "require-dev": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "82b0c77d44fc2126a396e6348358e62d",
+    "content-hash": "e2447a613b08a2204d71c6f571e44f88",
     "packages": [
         {
             "name": "brick/varexporter",
@@ -455,22 +455,27 @@
         },
         {
             "name": "psr/container",
-            "version": "1.1.2",
+            "version": "2.0.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/php-fig/container.git",
-                "reference": "513e0666f7216c7459170d56df27dfcefe1689ea"
+                "reference": "c71ecc56dfe541dbd90c5360474fbc405f8d5963"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/php-fig/container/zipball/513e0666f7216c7459170d56df27dfcefe1689ea",
-                "reference": "513e0666f7216c7459170d56df27dfcefe1689ea",
+                "url": "https://api.github.com/repos/php-fig/container/zipball/c71ecc56dfe541dbd90c5360474fbc405f8d5963",
+                "reference": "c71ecc56dfe541dbd90c5360474fbc405f8d5963",
                 "shasum": ""
             },
             "require": {
                 "php": ">=7.4.0"
             },
             "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0.x-dev"
+                }
+            },
             "autoload": {
                 "psr-4": {
                     "Psr\\Container\\": "src/"
@@ -497,9 +502,9 @@
             ],
             "support": {
                 "issues": "https://github.com/php-fig/container/issues",
-                "source": "https://github.com/php-fig/container/tree/1.1.2"
+                "source": "https://github.com/php-fig/container/tree/2.0.2"
             },
-            "time": "2021-11-05T16:50:12+00:00"
+            "time": "2021-11-05T16:47:00+00:00"
         },
         {
             "name": "webmozart/assert",


### PR DESCRIPTION

|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | no
| BC Break      | no
| New Feature   | no
| RFC           | no
| QA            | yes

### Description

This patch updates the `psr/container` dependency from a fixed `1.1` version to a flexible constraint: `^1.1 || ^2.0`.

This ensures compatibility with both v1 and v2 of the `psr/container` package, improving forward-compatibility without introducing breaking changes.