### PR TITLE
Standardise Test Code Style + Additional QA with Rector

### DIFF
--- a/rector.php
+++ b/rector.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 use Rector\Config\RectorConfig;
 use Rector\PHPUnit\CodeQuality\Rector\Class_\YieldDataProviderRector;
+use Rector\PHPUnit\CodeQuality\Rector\MethodCall\AssertEqualsOrAssertSameFloatParameterToSpecificMethodsTypeRector;
 
 return RectorConfig::configure()
     ->withPhpSets(php81: true)
@@ -21,4 +22,5 @@ return RectorConfig::configure()
     ->withSkipPath(__DIR__ . '/test/TestAsset')
     ->withSkip([
         YieldDataProviderRector::class,
+        AssertEqualsOrAssertSameFloatParameterToSpecificMethodsTypeRector::class,
     ]);

--- a/rector.php
+++ b/rector.php
@@ -7,6 +7,7 @@ use Rector\PHPUnit\CodeQuality\Rector\Class_\YieldDataProviderRector;
 
 return RectorConfig::configure()
     ->withPhpSets(php81: true)
+    ->withAttributesSets()
     ->withPaths([
         __DIR__ . '/src',
         __DIR__ . '/test',

--- a/rector.php
+++ b/rector.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 use Rector\Config\RectorConfig;
+use Rector\PHPUnit\CodeQuality\Rector\Class_\YieldDataProviderRector;
 
 return RectorConfig::configure()
     ->withPhpSets(php81: true)
@@ -14,5 +15,9 @@ return RectorConfig::configure()
         codeQuality: true,
         typeDeclarations: true,
         privatization: true,
+        phpunitCodeQuality: true,
     )
-    ->withSkip([__DIR__ . '/test/TestAsset']);
+    ->withSkipPath(__DIR__ . '/test/TestAsset')
+    ->withSkip([
+        YieldDataProviderRector::class,
+    ]);

--- a/test/Aggregate/AggregateHydratorFunctionalTest.php
+++ b/test/Aggregate/AggregateHydratorFunctionalTest.php
@@ -37,10 +37,10 @@ final class AggregateHydratorFunctionalTest extends TestCase
     {
         $object = new ArrayObject(['zaphod' => 'beeblebrox']);
 
-        self::assertSame([], $this->hydrator->extract($object));
-        self::assertSame($object, $this->hydrator->hydrate(['arthur' => 'dent'], $object));
+        $this->assertSame([], $this->hydrator->extract($object));
+        $this->assertSame($object, $this->hydrator->hydrate(['arthur' => 'dent'], $object));
 
-        self::assertSame(['zaphod' => 'beeblebrox'], $object->getArrayCopy());
+        $this->assertSame(['zaphod' => 'beeblebrox'], $object->getArrayCopy());
     }
 
     /**
@@ -53,7 +53,7 @@ final class AggregateHydratorFunctionalTest extends TestCase
 
         $this->hydrator->add($comparisonHydrator);
 
-        self::assertSame($comparisonHydrator->extract($blueprint), $this->hydrator->extract($object));
+        $this->assertSame($comparisonHydrator->extract($blueprint), $this->hydrator->extract($object));
     }
 
     /**
@@ -72,10 +72,10 @@ final class AggregateHydratorFunctionalTest extends TestCase
         $hydratedBlueprint = $comparisonHydrator->hydrate($data, $blueprint);
         $hydrated          = $this->hydrator->hydrate($data, $object);
 
-        self::assertEquals($hydratedBlueprint, $hydrated);
+        $this->assertEquals($hydratedBlueprint, $hydrated);
 
         if ($hydratedBlueprint === $blueprint) {
-            self::assertSame($hydrated, $object);
+            $this->assertSame($hydrated, $object);
         }
     }
 
@@ -91,10 +91,10 @@ final class AggregateHydratorFunctionalTest extends TestCase
 
         $extracted = $this->hydrator->extract($object);
 
-        self::assertArrayHasKey('maintainer', $extracted);
-        self::assertArrayHasKey('president', $extracted);
-        self::assertSame('Marvin', $extracted['maintainer']);
-        self::assertSame('Zaphod', $extracted['president']);
+        $this->assertArrayHasKey('maintainer', $extracted);
+        $this->assertArrayHasKey('president', $extracted);
+        $this->assertSame('Marvin', $extracted['maintainer']);
+        $this->assertSame('Zaphod', $extracted['president']);
     }
 
     /**
@@ -107,16 +107,16 @@ final class AggregateHydratorFunctionalTest extends TestCase
 
         $object = new AggregateObject();
 
-        self::assertSame(
+        $this->assertSame(
             $object,
             $this->hydrator->hydrate(['maintainer' => 'Trillian', 'president' => '???'], $object)
         );
 
-        self::assertArrayHasKey('maintainer', $object->arrayData);
-        self::assertArrayHasKey('president', $object->arrayData);
-        self::assertSame('Trillian', $object->arrayData['maintainer']);
-        self::assertSame('???', $object->arrayData['president']);
-        self::assertSame('Trillian', $object->maintainer);
+        $this->assertArrayHasKey('maintainer', $object->arrayData);
+        $this->assertArrayHasKey('president', $object->arrayData);
+        $this->assertSame('Trillian', $object->arrayData['maintainer']);
+        $this->assertSame('???', $object->arrayData['president']);
+        $this->assertSame('Trillian', $object->maintainer);
     }
 
     /**
@@ -134,7 +134,7 @@ final class AggregateHydratorFunctionalTest extends TestCase
         $this->hydrator->add(new ArraySerializableHydrator());
         $this->hydrator->getEventManager()->attach(ExtractEvent::EVENT_EXTRACT, $callback, 1000);
 
-        self::assertSame(['Ravenous Bugblatter Beast of Traal'], $this->hydrator->extract($object));
+        $this->assertSame(['Ravenous Bugblatter Beast of Traal'], $this->hydrator->extract($object));
     }
 
     /**
@@ -153,7 +153,7 @@ final class AggregateHydratorFunctionalTest extends TestCase
         $this->hydrator->add(new ArraySerializableHydrator());
         $this->hydrator->getEventManager()->attach(HydrateEvent::EVENT_HYDRATE, $callback, 1000);
 
-        self::assertSame($swappedObject, $this->hydrator->hydrate(['president' => 'Zaphod'], $object));
+        $this->assertSame($swappedObject, $this->hydrator->hydrate(['president' => 'Zaphod'], $object));
     }
 
     /**

--- a/test/Aggregate/AggregateHydratorTest.php
+++ b/test/Aggregate/AggregateHydratorTest.php
@@ -33,12 +33,12 @@ final class AggregateHydratorTest extends TestCase
         $attached = $this->createMock(HydratorInterface::class);
 
         $this->eventManager
-            ->expects(self::exactly(2))
+            ->expects($this->exactly(2))
             ->method('attach')
             ->with(
                 self::callback(function (mixed $event): bool {
-                    self::assertIsString($event);
-                    self::assertContains($event, [
+                    $this->assertIsString($event);
+                    $this->assertContains($event, [
                         HydrateEvent::EVENT_HYDRATE,
                         ExtractEvent::EVENT_EXTRACT,
                     ]);
@@ -46,12 +46,12 @@ final class AggregateHydratorTest extends TestCase
                     return true;
                 }),
                 self::callback(function (mixed $listener): bool {
-                    self::assertIsCallable($listener);
+                    $this->assertIsCallable($listener);
 
                     return true;
                 }),
                 self::callback(function (mixed $priority): bool {
-                    self::assertSame(123, $priority);
+                    $this->assertSame(123, $priority);
 
                     return true;
                 }),

--- a/test/ClassMethodsHydratorTest.php
+++ b/test/ClassMethodsHydratorTest.php
@@ -87,7 +87,7 @@ final class ClassMethodsHydratorTest extends TestCase
         ]);
         $this->hydrator->setOptions($options);
 
-        $this->assertSame(false, $this->hydrator->getUnderscoreSeparatedKeys());
+        $this->assertFalse($this->hydrator->getUnderscoreSeparatedKeys());
     }
 
     /**
@@ -115,7 +115,7 @@ final class ClassMethodsHydratorTest extends TestCase
         $data = $this->hydrator->extract(
             new TestAsset\ClassWithoutAnyMethod()
         );
-        self::assertSame([], $data);
+        $this->assertSame([], $data);
     }
 
     public function testCanExtractFromAnonymousClassMethods(): void

--- a/test/DelegatingHydratorTest.php
+++ b/test/DelegatingHydratorTest.php
@@ -42,7 +42,7 @@ final class DelegatingHydratorTest extends TestCase
             ->with(ArrayObject::class)
             ->willReturn($hydrator);
 
-        $this->assertEquals(['foo' => 'bar'], $this->hydrator->extract($this->object));
+        $this->assertSame(['foo' => 'bar'], $this->hydrator->extract($this->object));
     }
 
     public function testHydrate(): void

--- a/test/Filter/FilterCompositeTest.php
+++ b/test/Filter/FilterCompositeTest.php
@@ -103,7 +103,7 @@ final class FilterCompositeTest extends TestCase
     public function testNoFilters(): void
     {
         $filter = new FilterComposite();
-        self::assertTrue($filter->filter('any_value'));
+        $this->assertTrue($filter->filter('any_value'));
     }
 
     /**
@@ -220,6 +220,6 @@ final class FilterCompositeTest extends TestCase
     public function testCompositionFiltering(array $orFilters, array $andFilters, bool $expected): void
     {
         $filter = new FilterComposite($orFilters, $andFilters);
-        self::assertSame($expected, $filter->filter('any_value'));
+        $this->assertSame($expected, $filter->filter('any_value'));
     }
 }

--- a/test/Filter/MethodMatchFilterTest.php
+++ b/test/Filter/MethodMatchFilterTest.php
@@ -30,9 +30,9 @@ final class MethodMatchFilterTest extends TestCase
     public function testFilter(string $methodName, bool $expected): void
     {
         $testedInstance = new MethodMatchFilter('foo', false);
-        self::assertEquals($expected, $testedInstance->filter($methodName));
+        $this->assertSame($expected, $testedInstance->filter($methodName));
 
         $testedInstance = new MethodMatchFilter('foo', true);
-        self::assertEquals(! $expected, $testedInstance->filter($methodName));
+        $this->assertSame(! $expected, $testedInstance->filter($methodName));
     }
 }

--- a/test/HydratorAwareTraitTest.php
+++ b/test/HydratorAwareTraitTest.php
@@ -13,18 +13,18 @@ final class HydratorAwareTraitTest extends TestCase
     public function testSetHydrator(): void
     {
         $object = new HydratorAwareTraitImplementor();
-        self::assertNull($object->getHydrator());
+        $this->assertNotInstanceOf(HydratorInterface::class, $object->getHydrator());
         $hydrator = $this->createMock(HydratorInterface::class);
         $object->setHydrator($hydrator);
-        self::assertSame($hydrator, $object->getHydrator());
+        $this->assertSame($hydrator, $object->getHydrator());
     }
 
     public function testGetHydrator(): void
     {
         $object = new HydratorAwareTraitImplementor();
-        self::assertNull($object->getHydrator());
+        $this->assertNotInstanceOf(HydratorInterface::class, $object->getHydrator());
         $hydrator = $this->createMock(HydratorInterface::class);
         $object->setHydrator($hydrator);
-        self::assertSame($hydrator, $object->getHydrator());
+        $this->assertSame($hydrator, $object->getHydrator());
     }
 }

--- a/test/HydratorTest.php
+++ b/test/HydratorTest.php
@@ -58,61 +58,61 @@ final class HydratorTest extends TestCase
 
     public function testInitiateValues(): void
     {
-        self::assertSame('1', $this->classMethodsCamelCase->getFooBar());
-        self::assertSame('2', $this->classMethodsCamelCase->getFooBarBaz());
-        self::assertSame(true, $this->classMethodsCamelCase->getIsFoo());
-        self::assertSame(true, $this->classMethodsCamelCase->isBar());
-        self::assertSame(true, $this->classMethodsCamelCase->getHasFoo());
-        self::assertSame(true, $this->classMethodsCamelCase->hasBar());
+        $this->assertSame('1', $this->classMethodsCamelCase->getFooBar());
+        $this->assertSame('2', $this->classMethodsCamelCase->getFooBarBaz());
+        $this->assertTrue($this->classMethodsCamelCase->getIsFoo());
+        $this->assertTrue($this->classMethodsCamelCase->isBar());
+        $this->assertTrue($this->classMethodsCamelCase->getHasFoo());
+        $this->assertTrue($this->classMethodsCamelCase->hasBar());
 
-        self::assertSame('1', $this->classMethodsTitleCase->getFooBar());
-        self::assertSame('2', $this->classMethodsTitleCase->getFooBarBaz());
-        self::assertSame(true, $this->classMethodsTitleCase->getIsFoo());
-        self::assertSame(true, $this->classMethodsTitleCase->getIsBar());
-        self::assertSame(true, $this->classMethodsTitleCase->getHasFoo());
-        self::assertSame(true, $this->classMethodsTitleCase->getHasBar());
+        $this->assertSame('1', $this->classMethodsTitleCase->getFooBar());
+        $this->assertSame('2', $this->classMethodsTitleCase->getFooBarBaz());
+        $this->assertTrue($this->classMethodsTitleCase->getIsFoo());
+        $this->assertTrue($this->classMethodsTitleCase->getIsBar());
+        $this->assertTrue($this->classMethodsTitleCase->getHasFoo());
+        $this->assertTrue($this->classMethodsTitleCase->getHasBar());
 
-        self::assertSame('1', $this->classMethodsUnderscore->getFooBar());
-        self::assertSame('2', $this->classMethodsUnderscore->getFooBarBaz());
-        self::assertSame(true, $this->classMethodsUnderscore->getIsFoo());
-        self::assertSame(true, $this->classMethodsUnderscore->isBar());
-        self::assertSame(true, $this->classMethodsUnderscore->getHasFoo());
-        self::assertSame(true, $this->classMethodsUnderscore->hasBar());
+        $this->assertSame('1', $this->classMethodsUnderscore->getFooBar());
+        $this->assertSame('2', $this->classMethodsUnderscore->getFooBarBaz());
+        $this->assertTrue($this->classMethodsUnderscore->getIsFoo());
+        $this->assertTrue($this->classMethodsUnderscore->isBar());
+        $this->assertTrue($this->classMethodsUnderscore->getHasFoo());
+        $this->assertTrue($this->classMethodsUnderscore->hasBar());
     }
 
     public function testHydratorReflection(): void
     {
         $hydrator = new ReflectionHydrator();
         $datas    = $hydrator->extract($this->reflection);
-        self::assertArrayHaskey('foo', $datas);
-        self::assertSame('1', $datas['foo']);
-        self::assertArrayHaskey('fooBar', $datas);
-        self::assertSame('2', $datas['fooBar']);
-        self::assertArrayHaskey('fooBarBaz', $datas);
-        self::assertSame('3', $datas['fooBarBaz']);
+        $this->assertArrayHaskey('foo', $datas);
+        $this->assertSame('1', $datas['foo']);
+        $this->assertArrayHaskey('fooBar', $datas);
+        $this->assertSame('2', $datas['fooBar']);
+        $this->assertArrayHaskey('fooBarBaz', $datas);
+        $this->assertSame('3', $datas['fooBarBaz']);
 
         $test = $hydrator->hydrate(['foo' => 'foo', 'fooBar' => 'bar', 'fooBarBaz' => 'baz'], $this->reflection);
-        self::assertSame('foo', $test->foo);
-        self::assertSame('bar', $test->getFooBar());
-        self::assertSame('baz', $test->getFooBarBaz());
+        $this->assertSame('foo', $test->foo);
+        $this->assertSame('bar', $test->getFooBar());
+        $this->assertSame('baz', $test->getFooBarBaz());
     }
 
     public function testHydratorClassMethodsCamelCase(): void
     {
         $hydrator = new ClassMethodsHydrator(false);
         $datas    = $hydrator->extract($this->classMethodsCamelCase);
-        self::assertArrayHaskey('fooBar', $datas);
-        self::assertSame('1', $datas['fooBar']);
-        self::assertArrayHaskey('fooBarBaz', $datas);
-        self::assertArrayNotHasKey('foo_bar', $datas);
-        self::assertArrayHaskey('isFoo', $datas);
-        self::assertSame(true, $datas['isFoo']);
-        self::assertArrayHaskey('isBar', $datas);
-        self::assertSame(true, $datas['isBar']);
-        self::assertArrayHaskey('hasFoo', $datas);
-        self::assertSame(true, $datas['hasFoo']);
-        self::assertArrayHaskey('hasBar', $datas);
-        self::assertSame(true, $datas['hasBar']);
+        $this->assertArrayHaskey('fooBar', $datas);
+        $this->assertSame('1', $datas['fooBar']);
+        $this->assertArrayHaskey('fooBarBaz', $datas);
+        $this->assertArrayNotHasKey('foo_bar', $datas);
+        $this->assertArrayHaskey('isFoo', $datas);
+        $this->assertTrue($datas['isFoo']);
+        $this->assertArrayHaskey('isBar', $datas);
+        $this->assertTrue($datas['isBar']);
+        $this->assertArrayHaskey('hasFoo', $datas);
+        $this->assertTrue($datas['hasFoo']);
+        $this->assertArrayHaskey('hasBar', $datas);
+        $this->assertTrue($datas['hasBar']);
         $test = $hydrator->hydrate(
             [
                 'fooBar'    => 'foo',
@@ -124,31 +124,31 @@ final class HydratorTest extends TestCase
             ],
             $this->classMethodsCamelCase
         );
-        self::assertSame($this->classMethodsCamelCase, $test);
-        self::assertSame('foo', $test->getFooBar());
-        self::assertSame('bar', $test->getFooBarBaz());
-        self::assertSame(false, $test->getIsFoo());
-        self::assertSame(false, $test->isBar());
-        self::assertSame(false, $test->getHasFoo());
-        self::assertSame(false, $test->hasBar());
+        $this->assertSame($this->classMethodsCamelCase, $test);
+        $this->assertSame('foo', $test->getFooBar());
+        $this->assertSame('bar', $test->getFooBarBaz());
+        $this->assertFalse($test->getIsFoo());
+        $this->assertFalse($test->isBar());
+        $this->assertFalse($test->getHasFoo());
+        $this->assertFalse($test->hasBar());
     }
 
     public function testHydratorClassMethodsTitleCase(): void
     {
         $hydrator = new ClassMethodsHydrator(false);
         $datas    = $hydrator->extract($this->classMethodsTitleCase);
-        self::assertArrayHaskey('FooBar', $datas);
-        self::assertSame('1', $datas['FooBar']);
-        self::assertArrayHaskey('FooBarBaz', $datas);
-        self::assertArrayNotHasKey('foo_bar', $datas);
-        self::assertArrayHaskey('IsFoo', $datas);
-        self::assertSame(true, $datas['IsFoo']);
-        self::assertArrayHaskey('IsBar', $datas);
-        self::assertSame(true, $datas['IsBar']);
-        self::assertArrayHaskey('HasFoo', $datas);
-        self::assertSame(true, $datas['HasFoo']);
-        self::assertArrayHaskey('HasBar', $datas);
-        self::assertSame(true, $datas['HasBar']);
+        $this->assertArrayHaskey('FooBar', $datas);
+        $this->assertSame('1', $datas['FooBar']);
+        $this->assertArrayHaskey('FooBarBaz', $datas);
+        $this->assertArrayNotHasKey('foo_bar', $datas);
+        $this->assertArrayHaskey('IsFoo', $datas);
+        $this->assertTrue($datas['IsFoo']);
+        $this->assertArrayHaskey('IsBar', $datas);
+        $this->assertTrue($datas['IsBar']);
+        $this->assertArrayHaskey('HasFoo', $datas);
+        $this->assertTrue($datas['HasFoo']);
+        $this->assertArrayHaskey('HasBar', $datas);
+        $this->assertTrue($datas['HasBar']);
         $test = $hydrator->hydrate(
             [
                 'FooBar'    => 'foo',
@@ -160,35 +160,35 @@ final class HydratorTest extends TestCase
             ],
             $this->classMethodsTitleCase
         );
-        self::assertSame($this->classMethodsTitleCase, $test);
-        self::assertSame('foo', $test->getFooBar());
-        self::assertSame('bar', $test->getFooBarBaz());
-        self::assertSame(false, $test->getIsFoo());
-        self::assertSame(false, $test->getIsBar());
-        self::assertSame(false, $test->getHasFoo());
-        self::assertSame(false, $test->getHasBar());
+        $this->assertSame($this->classMethodsTitleCase, $test);
+        $this->assertSame('foo', $test->getFooBar());
+        $this->assertSame('bar', $test->getFooBarBaz());
+        $this->assertFalse($test->getIsFoo());
+        $this->assertFalse($test->getIsBar());
+        $this->assertFalse($test->getHasFoo());
+        $this->assertFalse($test->getHasBar());
     }
 
     public function testHydratorClassMethodsUnderscore(): void
     {
         $hydrator = new ClassMethodsHydrator(true);
         $datas    = $hydrator->extract($this->classMethodsUnderscore);
-        self::assertArrayHaskey('foo_bar', $datas);
-        self::assertSame('1', $datas['foo_bar']);
-        self::assertArrayHaskey('foo_bar_baz', $datas);
-        self::assertArrayNotHasKey('fooBar', $datas);
-        self::assertArrayHaskey('is_foo', $datas);
-        self::assertArrayNotHasKey('isFoo', $datas);
-        self::assertSame(true, $datas['is_foo']);
-        self::assertArrayHaskey('is_bar', $datas);
-        self::assertArrayNotHasKey('isBar', $datas);
-        self::assertSame(true, $datas['is_bar']);
-        self::assertArrayHaskey('has_foo', $datas);
-        self::assertArrayNotHasKey('hasFoo', $datas);
-        self::assertSame(true, $datas['has_foo']);
-        self::assertArrayHaskey('has_bar', $datas);
-        self::assertArrayNotHasKey('hasBar', $datas);
-        self::assertSame(true, $datas['has_bar']);
+        $this->assertArrayHaskey('foo_bar', $datas);
+        $this->assertSame('1', $datas['foo_bar']);
+        $this->assertArrayHaskey('foo_bar_baz', $datas);
+        $this->assertArrayNotHasKey('fooBar', $datas);
+        $this->assertArrayHaskey('is_foo', $datas);
+        $this->assertArrayNotHasKey('isFoo', $datas);
+        $this->assertTrue($datas['is_foo']);
+        $this->assertArrayHaskey('is_bar', $datas);
+        $this->assertArrayNotHasKey('isBar', $datas);
+        $this->assertTrue($datas['is_bar']);
+        $this->assertArrayHaskey('has_foo', $datas);
+        $this->assertArrayNotHasKey('hasFoo', $datas);
+        $this->assertTrue($datas['has_foo']);
+        $this->assertArrayHaskey('has_bar', $datas);
+        $this->assertArrayNotHasKey('hasBar', $datas);
+        $this->assertTrue($datas['has_bar']);
         $test = $hydrator->hydrate(
             [
                 'foo_bar'     => 'foo',
@@ -200,13 +200,13 @@ final class HydratorTest extends TestCase
             ],
             $this->classMethodsUnderscore
         );
-        self::assertSame($this->classMethodsUnderscore, $test);
-        self::assertSame('foo', $test->getFooBar());
-        self::assertSame('bar', $test->getFooBarBaz());
-        self::assertSame(false, $test->getIsFoo());
-        self::assertSame(false, $test->isBar());
-        self::assertSame(false, $test->getHasFoo());
-        self::assertSame(false, $test->hasBar());
+        $this->assertSame($this->classMethodsUnderscore, $test);
+        $this->assertSame('foo', $test->getFooBar());
+        $this->assertSame('bar', $test->getFooBarBaz());
+        $this->assertFalse($test->getIsFoo());
+        $this->assertFalse($test->isBar());
+        $this->assertFalse($test->getHasFoo());
+        $this->assertFalse($test->hasBar());
     }
 
     public function testHydratorClassMethodsUnderscoreWithUnderscoreUpperCasedHydrateDataKeys(): void
@@ -224,23 +224,23 @@ final class HydratorTest extends TestCase
             ],
             $this->classMethodsUnderscore
         );
-        self::assertSame($this->classMethodsUnderscore, $test);
-        self::assertSame('foo', $test->getFooBar());
-        self::assertSame('bar', $test->getFooBarBaz());
-        self::assertSame(false, $test->getIsFoo());
-        self::assertSame(false, $test->isBar());
-        self::assertSame(false, $test->getHasFoo());
-        self::assertSame(false, $test->hasBar());
+        $this->assertSame($this->classMethodsUnderscore, $test);
+        $this->assertSame('foo', $test->getFooBar());
+        $this->assertSame('bar', $test->getFooBarBaz());
+        $this->assertFalse($test->getIsFoo());
+        $this->assertFalse($test->isBar());
+        $this->assertFalse($test->getHasFoo());
+        $this->assertFalse($test->hasBar());
     }
 
     public function testHydratorClassMethodsOptions(): void
     {
         $hydrator = new ClassMethodsHydrator();
-        self::assertTrue($hydrator->getUnderscoreSeparatedKeys());
+        $this->assertTrue($hydrator->getUnderscoreSeparatedKeys());
         $hydrator->setOptions(['underscoreSeparatedKeys' => false]);
-        self::assertFalse($hydrator->getUnderscoreSeparatedKeys());
+        $this->assertFalse($hydrator->getUnderscoreSeparatedKeys());
         $hydrator->setUnderscoreSeparatedKeys(true);
-        self::assertTrue($hydrator->getUnderscoreSeparatedKeys());
+        $this->assertTrue($hydrator->getUnderscoreSeparatedKeys());
     }
 
     public function testHydratorClassMethodsIgnoresInvalidValues(): void
@@ -252,21 +252,21 @@ final class HydratorTest extends TestCase
             'invalid'     => 'value',
         ];
         $test     = $hydrator->hydrate($data, $this->classMethodsUnderscore);
-        self::assertSame($this->classMethodsUnderscore, $test);
+        $this->assertSame($this->classMethodsUnderscore, $test);
     }
 
     public function testHydratorClassMethodsDefaultBehaviorIsConvertUnderscoreToCamelCase(): void
     {
         $hydrator = new ClassMethodsHydrator();
         $datas    = $hydrator->extract($this->classMethodsUnderscore);
-        self::assertArrayHaskey('foo_bar', $datas);
-        self::assertSame('1', $datas['foo_bar']);
-        self::assertArrayHaskey('foo_bar_baz', $datas);
-        self::assertArrayNotHaskey('fooBar', $datas);
+        $this->assertArrayHaskey('foo_bar', $datas);
+        $this->assertSame('1', $datas['foo_bar']);
+        $this->assertArrayHaskey('foo_bar_baz', $datas);
+        $this->assertArrayNotHaskey('fooBar', $datas);
         $test = $hydrator->hydrate(['foo_bar' => 'foo', 'foo_bar_baz' => 'bar'], $this->classMethodsUnderscore);
-        self::assertSame($this->classMethodsUnderscore, $test);
-        self::assertSame('foo', $test->getFooBar());
-        self::assertSame('bar', $test->getFooBarBaz());
+        $this->assertSame($this->classMethodsUnderscore, $test);
+        $this->assertSame('foo', $test->getFooBar());
+        $this->assertSame('bar', $test->getFooBarBaz());
     }
 
     public function testRetrieveWildStrategyAndOther(): void
@@ -275,9 +275,9 @@ final class HydratorTest extends TestCase
         $hydrator->addStrategy('default', new DefaultStrategy());
         $hydrator->addStrategy('*', new SerializableStrategy(new PhpSerialize()));
         $default = $hydrator->getStrategy('default');
-        self::assertInstanceOf(DefaultStrategy::class, $default);
+        $this->assertInstanceOf(DefaultStrategy::class, $default);
         $serializable = $hydrator->getStrategy('*');
-        self::assertInstanceOf(SerializableStrategy::class, $serializable);
+        $this->assertInstanceOf(SerializableStrategy::class, $serializable);
     }
 
     public function testUseWildStrategyByDefault(): void
@@ -285,25 +285,25 @@ final class HydratorTest extends TestCase
         $hydrator = new ClassMethodsHydrator();
         $datas    = $hydrator->extract($this->classMethodsUnderscore);
 
-        self::assertSame('1', $datas['foo_bar']);
+        $this->assertSame('1', $datas['foo_bar']);
 
         $hydrator->addStrategy('*', new SerializableStrategy(new PhpSerialize()));
         $datas = $hydrator->extract($this->classMethodsUnderscore);
 
-        self::assertSame('s:1:"1";', $datas['foo_bar']);
+        $this->assertSame('s:1:"1";', $datas['foo_bar']);
     }
 
     public function testUseWildStrategyAndOther(): void
     {
         $hydrator = new ClassMethodsHydrator();
         $datas    = $hydrator->extract($this->classMethodsUnderscore);
-        self::assertSame('1', $datas['foo_bar']);
+        $this->assertSame('1', $datas['foo_bar']);
 
         $hydrator->addStrategy('foo_bar', new DefaultStrategy());
         $hydrator->addStrategy('*', new SerializableStrategy(new PhpSerialize()));
         $datas = $hydrator->extract($this->classMethodsUnderscore);
-        self::assertSame('1', $datas['foo_bar']);
-        self::assertSame('s:1:"2";', $datas['foo_bar_baz']);
+        $this->assertSame('1', $datas['foo_bar']);
+        $this->assertSame('s:1:"2";', $datas['foo_bar_baz']);
     }
 
     public function testHydratorClassMethodsCamelCaseWithSetterMissing(): void
@@ -311,14 +311,14 @@ final class HydratorTest extends TestCase
         $hydrator = new ClassMethodsHydrator(false);
 
         $datas = $hydrator->extract($this->classMethodsCamelCaseMissing);
-        self::assertArrayHaskey('fooBar', $datas);
-        self::assertSame('1', $datas['fooBar']);
-        self::assertArrayHaskey('fooBarBaz', $datas);
-        self::assertArrayNotHaskey('foo_bar', $datas);
+        $this->assertArrayHaskey('fooBar', $datas);
+        $this->assertSame('1', $datas['fooBar']);
+        $this->assertArrayHaskey('fooBarBaz', $datas);
+        $this->assertArrayNotHaskey('foo_bar', $datas);
         $test = $hydrator->hydrate(['fooBar' => 'foo', 'fooBarBaz' => 1], $this->classMethodsCamelCaseMissing);
-        self::assertSame($this->classMethodsCamelCaseMissing, $test);
-        self::assertSame('foo', $test->getFooBar());
-        self::assertSame('2', $test->getFooBarBaz());
+        $this->assertSame($this->classMethodsCamelCaseMissing, $test);
+        $this->assertSame('foo', $test->getFooBar());
+        $this->assertSame('2', $test->getFooBarBaz());
     }
 
     public function testHydratorClassMethodsManipulateFilter(): void
@@ -326,23 +326,23 @@ final class HydratorTest extends TestCase
         $hydrator = new ClassMethodsHydrator(false);
         $datas    = $hydrator->extract($this->classMethodsCamelCase);
 
-        self::assertArrayHaskey('fooBar', $datas);
-        self::assertSame('1', $datas['fooBar']);
-        self::assertArrayHaskey('fooBarBaz', $datas);
-        self::assertArrayNotHasKey('foo_bar', $datas);
-        self::assertArrayHaskey('isFoo', $datas);
-        self::assertSame(true, $datas['isFoo']);
-        self::assertArrayHaskey('isBar', $datas);
-        self::assertSame(true, $datas['isBar']);
-        self::assertArrayHaskey('hasFoo', $datas);
-        self::assertSame(true, $datas['hasFoo']);
-        self::assertArrayHaskey('hasBar', $datas);
-        self::assertSame(true, $datas['hasBar']);
+        $this->assertArrayHaskey('fooBar', $datas);
+        $this->assertSame('1', $datas['fooBar']);
+        $this->assertArrayHaskey('fooBarBaz', $datas);
+        $this->assertArrayNotHasKey('foo_bar', $datas);
+        $this->assertArrayHaskey('isFoo', $datas);
+        $this->assertTrue($datas['isFoo']);
+        $this->assertArrayHaskey('isBar', $datas);
+        $this->assertTrue($datas['isBar']);
+        $this->assertArrayHaskey('hasFoo', $datas);
+        $this->assertTrue($datas['hasFoo']);
+        $this->assertArrayHaskey('hasBar', $datas);
+        $this->assertTrue($datas['hasBar']);
 
         $hydrator->removeFilter('has');
         $datas = $hydrator->extract($this->classMethodsCamelCase);
-        self::assertArrayHaskey('hasFoo', $datas); //method is getHasFoo
-        self::assertArrayNotHaskey('hasBar', $datas); //method is hasBar
+        $this->assertArrayHaskey('hasFoo', $datas); //method is getHasFoo
+        $this->assertArrayNotHaskey('hasBar', $datas); //method is hasBar
     }
 
     public function testHydratorClassMethodsWithCustomFilter(): void
@@ -359,7 +359,7 @@ final class HydratorTest extends TestCase
         );
 
         $datas = $hydrator->extract($this->classMethodsCamelCase);
-        self::assertArrayNotHaskey('hasFoo', $datas);
+        $this->assertArrayNotHaskey('hasFoo', $datas);
     }
 
     #[DataProvider('filterProvider')]
@@ -367,26 +367,20 @@ final class HydratorTest extends TestCase
         AbstractHydrator $hydrator,
         object $serializable
     ): void {
-        self::assertSame(
-            [
-                'foo'   => 'bar',
-                'bar'   => 'foo',
-                'blubb' => 'baz',
-                'quo'   => 'blubb',
-            ],
-            $hydrator->extract($serializable)
-        );
+        $this->assertSame([
+            'foo'   => 'bar',
+            'bar'   => 'foo',
+            'blubb' => 'baz',
+            'quo'   => 'blubb',
+        ], $hydrator->extract($serializable));
 
         $hydrator->addFilter('foo', static fn($property): bool => $property !== 'foo');
 
-        self::assertSame(
-            [
-                'bar'   => 'foo',
-                'blubb' => 'baz',
-                'quo'   => 'blubb',
-            ],
-            $hydrator->extract($serializable)
-        );
+        $this->assertSame([
+            'bar'   => 'foo',
+            'blubb' => 'baz',
+            'quo'   => 'blubb',
+        ], $hydrator->extract($serializable));
 
         $hydrator->addFilter(
             'len',
@@ -394,26 +388,20 @@ final class HydratorTest extends TestCase
             FilterComposite::CONDITION_AND
         );
 
-        self::assertSame(
-            [
-                'bar' => 'foo',
-                'quo' => 'blubb',
-            ],
-            $hydrator->extract($serializable)
-        );
+        $this->assertSame([
+            'bar' => 'foo',
+            'quo' => 'blubb',
+        ], $hydrator->extract($serializable));
 
         $hydrator->removeFilter('len');
         $hydrator->removeFilter('foo');
 
-        self::assertSame(
-            [
-                'foo'   => 'bar',
-                'bar'   => 'foo',
-                'blubb' => 'baz',
-                'quo'   => 'blubb',
-            ],
-            $hydrator->extract($serializable)
-        );
+        $this->assertSame([
+            'foo'   => 'bar',
+            'bar'   => 'foo',
+            'blubb' => 'baz',
+            'quo'   => 'blubb',
+        ], $hydrator->extract($serializable));
     }
 
     /**
@@ -433,9 +421,9 @@ final class HydratorTest extends TestCase
         $hydrator = new ClassMethodsHydrator(false);
         $datas    = $hydrator->extract($this->classMethodsInvalidParameter);
 
-        self::assertTrue($datas['hasBar']);
-        self::assertSame('Bar', $datas['foo']);
-        self::assertFalse($datas['isBla']);
+        $this->assertTrue($datas['hasBar']);
+        $this->assertSame('Bar', $datas['foo']);
+        $this->assertFalse($datas['isBla']);
     }
 
     public function testObjectBasedFilters(): void
@@ -443,9 +431,9 @@ final class HydratorTest extends TestCase
         $hydrator = new ClassMethodsHydrator(false);
         $foo      = new ClassMethodsFilterProviderInterface();
         $data     = $hydrator->extract($foo);
-        self::assertArrayNotHasKey('filter', $data);
-        self::assertSame('bar', $data['foo']);
-        self::assertSame('foo', $data['bar']);
+        $this->assertArrayNotHasKey('filter', $data);
+        $this->assertSame('bar', $data['foo']);
+        $this->assertSame('foo', $data['bar']);
     }
 
     public function testHydratorClassMethodsWithProtectedSetter(): void
@@ -455,7 +443,7 @@ final class HydratorTest extends TestCase
         $hydrator->hydrate(['foo' => 'bar', 'bar' => 'BAR'], $object);
         $data = $hydrator->extract($object);
 
-        self::assertSame('BAR', $data['bar']);
+        $this->assertSame('BAR', $data['bar']);
     }
 
     public function testHydratorClassMethodsWithMagicMethodSetter(): void
@@ -465,7 +453,7 @@ final class HydratorTest extends TestCase
         $hydrator->hydrate(['foo' => 'bar'], $object);
         $data = $hydrator->extract($object);
 
-        self::assertSame('bar', $data['foo']);
+        $this->assertSame('bar', $data['foo']);
     }
 
     public function testHydratorClassMethodsWithMagicMethodSetterAndMethodExistsCheck(): void
@@ -475,6 +463,6 @@ final class HydratorTest extends TestCase
         $hydrator->hydrate(['foo' => 'bar'], $object);
         $data = $hydrator->extract($object);
 
-        self::assertNull($data['foo']);
+        $this->assertNull($data['foo']);
     }
 }

--- a/test/Iterator/HydratingIteratorIteratorTest.php
+++ b/test/Iterator/HydratingIteratorIteratorTest.php
@@ -53,7 +53,7 @@ final class HydratingIteratorIteratorTest extends TestCase
 
         $hydratingIterator->rewind();
 
-        $this->assertNull($hydratingIterator->current());
+        $this->assertNotInstanceOf(ArrayObject::class, $hydratingIterator->current());
     }
 
     public function testUsingStringForObjectName(): void

--- a/test/NamingStrategy/CompositeNamingStrategyTest.php
+++ b/test/NamingStrategy/CompositeNamingStrategyTest.php
@@ -19,8 +19,8 @@ final class CompositeNamingStrategyTest extends TestCase
             'foo' => $this->createMock(NamingStrategyInterface::class),
         ]);
 
-        $this->assertEquals('bar', $compositeNamingStrategy->hydrate('bar'));
-        $this->assertEquals('bar', $compositeNamingStrategy->extract('bar'));
+        $this->assertSame('bar', $compositeNamingStrategy->hydrate('bar'));
+        $this->assertSame('bar', $compositeNamingStrategy->extract('bar'));
     }
 
     public function testUseDefaultNamingStrategy(): void
@@ -40,8 +40,8 @@ final class CompositeNamingStrategyTest extends TestCase
             ['bar' => $this->createMock(NamingStrategyInterface::class)],
             $defaultNamingStrategy
         );
-        $this->assertEquals('Foo', $compositeNamingStrategy->hydrate('foo'));
-        $this->assertEquals('foo', $compositeNamingStrategy->extract('Foo'));
+        $this->assertSame('Foo', $compositeNamingStrategy->hydrate('foo'));
+        $this->assertSame('foo', $compositeNamingStrategy->extract('Foo'));
     }
 
     public function testHydrate(): void
@@ -52,7 +52,7 @@ final class CompositeNamingStrategyTest extends TestCase
             ->with('foo')
             ->willReturn('FOO');
         $compositeNamingStrategy = new CompositeNamingStrategy(['foo' => $fooNamingStrategy]);
-        $this->assertEquals('FOO', $compositeNamingStrategy->hydrate('foo'));
+        $this->assertSame('FOO', $compositeNamingStrategy->hydrate('foo'));
     }
 
     public function testExtract(): void
@@ -63,6 +63,6 @@ final class CompositeNamingStrategyTest extends TestCase
             ->with('FOO')
             ->willReturn('foo');
         $compositeNamingStrategy = new CompositeNamingStrategy(['FOO' => $fooNamingStrategy]);
-        $this->assertEquals('foo', $compositeNamingStrategy->extract('FOO'));
+        $this->assertSame('foo', $compositeNamingStrategy->extract('FOO'));
     }
 }

--- a/test/NamingStrategy/MapNamingStrategyTest.php
+++ b/test/NamingStrategy/MapNamingStrategyTest.php
@@ -26,14 +26,14 @@ final class MapNamingStrategyTest extends TestCase
         yield 'object'     => [(object) ['foo' => 'bar']];
     }
 
-    /** @psalm-return Generator<string, array{invalidKeyArray: array<array-key, string>}> */
+    /** @psalm-return Generator<string, array{array<array-key, string>}> */
     public static function invalidKeyArrays(): Generator
     {
         yield 'int' => [
-            'invalidKeyArray' => [1 => 'foo'],
+            [1 => 'foo'],
         ];
         yield 'emtpy-string' => [
-            'invalidKeyArray' => ['' => 'foo'],
+            ['' => 'foo'],
         ];
     }
 
@@ -84,43 +84,43 @@ final class MapNamingStrategyTest extends TestCase
     public function testExtractReturnsVerbatimWhenEmptyExtractionMapProvided(): void
     {
         $strategy = MapNamingStrategy::createFromExtractionMap([]);
-        self::assertEquals('some_stuff', $strategy->extract('some_stuff'));
+        $this->assertSame('some_stuff', $strategy->extract('some_stuff'));
     }
 
     public function testHydrateReturnsVerbatimWhenEmptyHydrationMapProvided(): void
     {
         $strategy = MapNamingStrategy::createFromHydrationMap([]);
-        self::assertEquals('some_stuff', $strategy->hydrate('some_stuff'));
+        $this->assertSame('some_stuff', $strategy->hydrate('some_stuff'));
     }
 
     public function testExtractUsesProvidedExtractionMap(): void
     {
         $strategy = MapNamingStrategy::createFromExtractionMap(['stuff3' => 'stuff4']);
-        self::assertEquals('stuff4', $strategy->extract('stuff3'));
+        $this->assertSame('stuff4', $strategy->extract('stuff3'));
     }
 
     public function testExtractUsesFlippedHydrationMapWhenOnlyHydrationMapProvided(): void
     {
         $strategy = MapNamingStrategy::createFromHydrationMap(['stuff3' => 'stuff4']);
-        self::assertEquals('stuff3', $strategy->extract('stuff4'));
+        $this->assertSame('stuff3', $strategy->extract('stuff4'));
     }
 
     public function testHydrateUsesProvidedHydrationMap(): void
     {
         $strategy = MapNamingStrategy::createFromHydrationMap(['stuff3' => 'stuff4']);
-        self::assertEquals('stuff4', $strategy->hydrate('stuff3'));
+        $this->assertSame('stuff4', $strategy->hydrate('stuff3'));
     }
 
     public function testHydrateUsesFlippedExtractionMapOnlyExtractionMapProvided(): void
     {
         $strategy = MapNamingStrategy::createFromExtractionMap(['foo' => 'bar']);
-        self::assertEquals('foo', $strategy->hydrate('bar'));
+        $this->assertSame('foo', $strategy->hydrate('bar'));
     }
 
     public function testHydrateAndExtractUseAsymmetricMapProvided(): void
     {
         $strategy = MapNamingStrategy::createFromAsymmetricMap(['foo' => 'bar'], ['bat' => 'baz']);
-        self::assertEquals('bar', $strategy->extract('foo'));
-        self::assertEquals('baz', $strategy->hydrate('bat'));
+        $this->assertSame('bar', $strategy->extract('foo'));
+        $this->assertSame('baz', $strategy->hydrate('bat'));
     }
 }

--- a/test/NamingStrategy/UnderscoreNamingStrategy/CamelCaseToUnderscoreFilterTest.php
+++ b/test/NamingStrategy/UnderscoreNamingStrategy/CamelCaseToUnderscoreFilterTest.php
@@ -26,8 +26,8 @@ final class CamelCaseToUnderscoreFilterTest extends TestCase
 
         $filtered = $filter->filter($string);
 
-        $this->assertNotEquals($string, $filtered);
-        $this->assertEquals($expected, $filtered);
+        $this->assertNotSame($string, $filtered);
+        $this->assertSame($expected, $filtered);
     }
 
     #[DataProvider('unicodeProvider')]
@@ -41,8 +41,8 @@ final class CamelCaseToUnderscoreFilterTest extends TestCase
 
         $filtered = $filter->filter($string);
 
-        $this->assertNotEquals($string, $filtered);
-        $this->assertEquals($expected, $filtered);
+        $this->assertNotSame($string, $filtered);
+        $this->assertSame($expected, $filtered);
     }
 
     #[DataProvider('unicodeProviderWithoutMbStrings')]
@@ -56,8 +56,8 @@ final class CamelCaseToUnderscoreFilterTest extends TestCase
 
         $filtered = $filter->filter($string);
 
-        $this->assertNotEquals($string, $filtered);
-        $this->assertEquals($expected, $filtered);
+        $this->assertNotSame($string, $filtered);
+        $this->assertSame($expected, $filtered);
     }
 
     /**

--- a/test/NamingStrategy/UnderscoreNamingStrategy/UnderscoreToCamelCaseFilterTest.php
+++ b/test/NamingStrategy/UnderscoreNamingStrategy/UnderscoreToCamelCaseFilterTest.php
@@ -26,8 +26,8 @@ final class UnderscoreToCamelCaseFilterTest extends TestCase
 
         $filtered = $filter->filter($string);
 
-        $this->assertNotEquals($string, $filtered);
-        $this->assertEquals($expected, $filtered);
+        $this->assertNotSame($string, $filtered);
+        $this->assertSame($expected, $filtered);
     }
 
     /**
@@ -66,8 +66,8 @@ final class UnderscoreToCamelCaseFilterTest extends TestCase
         $filter   = new UnderscoreToCamelCaseFilter();
         $filtered = $filter->filter($string);
 
-        $this->assertNotEquals($string, $filtered);
-        $this->assertEquals($expected, $filtered);
+        $this->assertNotSame($string, $filtered);
+        $this->assertSame($expected, $filtered);
     }
 
     /**
@@ -116,7 +116,7 @@ final class UnderscoreToCamelCaseFilterTest extends TestCase
         $property->setValue($filter, false);
 
         $filtered = $filter->filter($string);
-        $this->assertEquals($expected, $filtered);
+        $this->assertSame($expected, $filtered);
     }
 
     /**

--- a/test/NamingStrategy/UnderscoreNamingStrategyTest.php
+++ b/test/NamingStrategy/UnderscoreNamingStrategyTest.php
@@ -15,13 +15,13 @@ final class UnderscoreNamingStrategyTest extends TestCase
     public function testNameHydratesToCamelCase(): void
     {
         $strategy = new UnderscoreNamingStrategy();
-        $this->assertEquals('fooBarBaz', $strategy->hydrate('foo_bar_baz'));
+        $this->assertSame('fooBarBaz', $strategy->hydrate('foo_bar_baz'));
     }
 
     public function testNameExtractsToUnderscore(): void
     {
         $strategy = new UnderscoreNamingStrategy();
-        $this->assertEquals('foo_bar_baz', $strategy->extract('fooBarBaz'));
+        $this->assertSame('foo_bar_baz', $strategy->extract('fooBarBaz'));
     }
 
     #[Group('6422')]
@@ -30,6 +30,6 @@ final class UnderscoreNamingStrategyTest extends TestCase
     {
         $strategy = new UnderscoreNamingStrategy();
 
-        $this->assertEquals('fooBarBaz', $strategy->hydrate('Foo_Bar_Baz'));
+        $this->assertSame('fooBarBaz', $strategy->hydrate('Foo_Bar_Baz'));
     }
 }

--- a/test/StandaloneHydratorPluginManagerTest.php
+++ b/test/StandaloneHydratorPluginManagerTest.php
@@ -52,14 +52,14 @@ final class StandaloneHydratorPluginManagerTest extends TestCase
     {
         $factories = $this->reflectProperty($this->manager, 'factories');
 
-        self::assertArrayHasKey($class, $factories);
-        self::assertInstanceOf(Closure::class, $factories[$class]);
+        $this->assertArrayHasKey($class, $factories);
+        $this->assertInstanceOf(Closure::class, $factories[$class]);
     }
 
     public function testDelegatingHydratorFactoryIsInitialized(): void
     {
         $factories = $this->reflectProperty($this->manager, 'factories');
-        self::assertInstanceOf(
+        $this->assertInstanceOf(
             Hydrator\DelegatingHydratorFactory::class,
             $factories[Hydrator\DelegatingHydrator::class]
         );
@@ -67,7 +67,7 @@ final class StandaloneHydratorPluginManagerTest extends TestCase
 
     public function testHasReturnsFalseForUnknownNames(): void
     {
-        self::assertFalse($this->manager->has('unknown-service-name'));
+        $this->assertFalse($this->manager->has('unknown-service-name'));
     }
 
     /** @return Generator<string, array{0: string, 1: class-string}> */
@@ -89,7 +89,7 @@ final class StandaloneHydratorPluginManagerTest extends TestCase
     #[DataProvider('knownServices')]
     public function testHasReturnsTrueForKnownServices(string $service): void
     {
-        self::assertTrue($this->manager->has($service));
+        $this->assertTrue($this->manager->has($service));
     }
 
     public function testGetRaisesExceptionForUnknownService(): void
@@ -106,6 +106,6 @@ final class StandaloneHydratorPluginManagerTest extends TestCase
     public function testGetReturnsExpectedTypesForKnownServices(string $service, string $expectedType): void
     {
         $instance = $this->manager->get($service);
-        self::assertInstanceOf($expectedType, $instance);
+        $this->assertInstanceOf($expectedType, $instance);
     }
 }

--- a/test/Strategy/BackedEnumStrategyTest.php
+++ b/test/Strategy/BackedEnumStrategyTest.php
@@ -17,7 +17,7 @@ final class BackedEnumStrategyTest extends TestCase
     public function testExtractInvalidValueThrowsException(): void
     {
         $strategy = new BackedEnumStrategy(TestBackedEnum::class);
-        self::expectException(InvalidArgumentException::class);
+        $this->expectException(InvalidArgumentException::class);
         $strategy->extract(TestUnitEnum::One);
     }
 
@@ -25,7 +25,7 @@ final class BackedEnumStrategyTest extends TestCase
     {
         $strategy = new BackedEnumStrategy(TestBackedEnum::class);
         $actual   = $strategy->extract(TestBackedEnum::One);
-        self::assertSame('one', $actual);
+        $this->assertSame('one', $actual);
     }
 
     public function testHydrateEnumReturnsEnum(): void
@@ -33,22 +33,22 @@ final class BackedEnumStrategyTest extends TestCase
         $expected = TestBackedEnum::Two;
         $strategy = new BackedEnumStrategy(TestBackedEnum::class);
         $actual   = $strategy->hydrate($expected, null);
-        self::assertSame(TestBackedEnum::Two, $actual);
+        $this->assertSame(TestBackedEnum::Two, $actual);
     }
 
     public function testHydrateNonScalarThrowsException(): void
     {
         $strategy = new BackedEnumStrategy(TestBackedEnum::class);
-        self::expectException(InvalidArgumentException::class);
-        self::expectExceptionMessage("Value must be string or int; array provided");
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage("Value must be string or int; array provided");
         $strategy->hydrate([], null);
     }
 
     public function testHydrateNonCaseThrowsException(): void
     {
         $strategy = new BackedEnumStrategy(TestBackedEnum::class);
-        self::expectException(InvalidArgumentException::class);
-        self::expectExceptionMessage("Value 'three' is not a valid scalar value for " . TestBackedEnum::class);
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage("Value 'three' is not a valid scalar value for " . TestBackedEnum::class);
         $strategy->hydrate('three', null);
     }
 
@@ -56,6 +56,6 @@ final class BackedEnumStrategyTest extends TestCase
     {
         $strategy = new BackedEnumStrategy(TestBackedEnum::class);
         $actual   = $strategy->hydrate('two', null);
-        self::assertSame(TestBackedEnum::Two, $actual);
+        $this->assertSame(TestBackedEnum::Two, $actual);
     }
 }

--- a/test/Strategy/BooleanStrategyTest.php
+++ b/test/Strategy/BooleanStrategyTest.php
@@ -26,16 +26,16 @@ final class BooleanStrategyTest extends TestCase
     public function testExtractString(): void
     {
         $hydrator = new BooleanStrategy('true', 'false');
-        $this->assertEquals('true', $hydrator->extract(true));
-        $this->assertEquals('false', $hydrator->extract(false));
+        $this->assertSame('true', $hydrator->extract(true));
+        $this->assertSame('false', $hydrator->extract(false));
     }
 
     public function testExtractInteger(): void
     {
         $hydrator = new BooleanStrategy(1, 0);
 
-        $this->assertEquals(1, $hydrator->extract(true));
-        $this->assertEquals(0, $hydrator->extract(false));
+        $this->assertSame(1, $hydrator->extract(true));
+        $this->assertSame(0, $hydrator->extract(false));
     }
 
     public function testExtractThrowsExceptionOnUnknownValue(): void

--- a/test/Strategy/CollectionStrategyTest.php
+++ b/test/Strategy/CollectionStrategyTest.php
@@ -125,7 +125,7 @@ final class CollectionStrategyTest extends TestCase
         $hydrator = $this->createHydratorMock();
 
         $hydrator
-            ->expects(self::exactly(count($value)))
+            ->expects($this->exactly(count($value)))
             ->method('extract')
             ->willReturnCallback($extraction);
 
@@ -136,7 +136,7 @@ final class CollectionStrategyTest extends TestCase
 
         $expected = array_map($extraction, $value);
 
-        self::assertSame($expected, $strategy->extract($value));
+        $this->assertSame($expected, $strategy->extract($value));
     }
 
     #[DataProvider('providerInvalidValueForHydration')]
@@ -201,7 +201,7 @@ final class CollectionStrategyTest extends TestCase
         $hydrator = $this->createHydratorMock();
 
         $hydrator
-            ->expects(self::exactly(count($value)))
+            ->expects($this->exactly(count($value)))
             ->method('hydrate')
             ->willReturnCallback($hydration);
 
@@ -212,7 +212,7 @@ final class CollectionStrategyTest extends TestCase
 
         $expected = array_map($hydration, $value);
 
-        self::assertEquals($expected, $strategy->hydrate($value));
+        $this->assertEquals($expected, $strategy->hydrate($value));
     }
 
     private function createHydratorMock(): HydratorInterface&MockObject

--- a/test/Strategy/DateTimeFormatterStrategyTest.php
+++ b/test/Strategy/DateTimeFormatterStrategyTest.php
@@ -21,25 +21,25 @@ final class DateTimeFormatterStrategyTest extends TestCase
     public function testHydrate(): void
     {
         $strategy = new DateTimeFormatterStrategy('Y-m-d');
-        self::assertEquals('2014-04-26', $strategy->hydrate('2014-04-26')->format('Y-m-d'));
+        $this->assertEquals('2014-04-26', $strategy->hydrate('2014-04-26')->format('Y-m-d'));
 
         $strategy = new DateTimeFormatterStrategy('Y-m-d', new DateTimeZone('Asia/Kathmandu'));
 
         $date = $strategy->hydrate('2014-04-26');
-        self::assertEquals('Asia/Kathmandu', $date->getTimezone()->getName());
+        $this->assertEquals('Asia/Kathmandu', $date->getTimezone()->getName());
     }
 
     public function testExtract(): void
     {
         $strategy = new DateTimeFormatterStrategy('d/m/Y');
-        self::assertEquals('26/04/2014', $strategy->extract(new DateTime('2014-04-26')));
+        $this->assertEquals('26/04/2014', $strategy->extract(new DateTime('2014-04-26')));
     }
 
     public function testGetNullWithInvalidDateOnHydration(): void
     {
         $strategy = new DateTimeFormatterStrategy('Y-m-d');
-        self::assertEquals(null, $strategy->hydrate(null));
-        self::assertEquals(null, $strategy->hydrate(''));
+        $this->assertEquals(null, $strategy->hydrate(null));
+        $this->assertEquals(null, $strategy->hydrate(''));
     }
 
     public function testCanExtractIfNotDateTime(): void
@@ -47,13 +47,13 @@ final class DateTimeFormatterStrategyTest extends TestCase
         $strategy = new DateTimeFormatterStrategy();
         $date     = $strategy->extract(new stdClass());
 
-        self::assertInstanceOf(stdClass::class, $date);
+        $this->assertInstanceOf(stdClass::class, $date);
     }
 
     public function testCanHydrateWithInvalidDateTime(): void
     {
         $strategy = new DateTimeFormatterStrategy('d/m/Y');
-        self::assertSame('foo bar baz', $strategy->hydrate('foo bar baz'));
+        $this->assertSame('foo bar baz', $strategy->hydrate('foo bar baz'));
     }
 
     public function testCanExtractAnyDateTimeInterface(): void
@@ -64,7 +64,7 @@ final class DateTimeFormatterStrategyTest extends TestCase
 
         $format = 'Y-m-d';
         $dateMock
-            ->expects(self::once())
+            ->expects($this->once())
             ->method('format')
             ->with($format);
 
@@ -73,7 +73,7 @@ final class DateTimeFormatterStrategyTest extends TestCase
             ->getMock();
 
         $dateImmutableMock
-            ->expects(self::once())
+            ->expects($this->once())
             ->method('format')
             ->with($format);
 
@@ -89,8 +89,8 @@ final class DateTimeFormatterStrategyTest extends TestCase
         $strategy = new DateTimeFormatterStrategy($format);
         $hydrated = $strategy->hydrate($expectedValue);
 
-        self::assertInstanceOf(DateTime::class, $hydrated);
-        self::assertEquals($expectedValue, $hydrated->format('Y-m-d'));
+        $this->assertInstanceOf(DateTime::class, $hydrated);
+        $this->assertSame($expectedValue, $hydrated->format('Y-m-d'));
     }
 
     #[DataProvider('formatsWithSpecialCharactersProvider')]
@@ -100,7 +100,7 @@ final class DateTimeFormatterStrategyTest extends TestCase
         $strategy  = new DateTimeFormatterStrategy($format);
         $extracted = $strategy->extract($date);
 
-        self::assertEquals($expectedValue, $extracted);
+        $this->assertEquals($expectedValue, $extracted);
     }
 
     public function testCanExtractWithCreateFromFormatEscapedSpecialCharacters(): void
@@ -108,7 +108,7 @@ final class DateTimeFormatterStrategyTest extends TestCase
         $date      = DateTime::createFromFormat('Y-m-d', '2018-02-05');
         $strategy  = new DateTimeFormatterStrategy('Y-m-d\\+');
         $extracted = $strategy->extract($date);
-        self::assertEquals('2018-02-05+', $extracted);
+        $this->assertEquals('2018-02-05+', $extracted);
     }
 
     /**
@@ -129,14 +129,14 @@ final class DateTimeFormatterStrategyTest extends TestCase
         $strategy = new DateTimeFormatterStrategy('Y-m-d', null, true);
         $date     = $strategy->hydrate('2018-09-06T12:10:30');
 
-        self::assertInstanceOf(DateTimeInterface::class, $date);
-        self::assertSame('2018-09-06', $date->format('Y-m-d'));
+        $this->assertInstanceOf(DateTimeInterface::class, $date);
+        $this->assertSame('2018-09-06', $date->format('Y-m-d'));
 
         $strategy = new DateTimeFormatterStrategy('Y-m-d', new DateTimeZone('Europe/Prague'), true);
         $date     = $strategy->hydrate('2018-09-06T12:10:30');
 
-        self::assertInstanceOf(DateTimeInterface::class, $date);
-        self::assertSame('Europe/Prague', $date->getTimezone()->getName());
+        $this->assertInstanceOf(DateTimeInterface::class, $date);
+        $this->assertSame('Europe/Prague', $date->getTimezone()->getName());
     }
 
     /** @return array<string, list<mixed>> */
@@ -177,6 +177,6 @@ final class DateTimeFormatterStrategyTest extends TestCase
     {
         $strategy = new DateTimeFormatterStrategy('Y-m-d');
         $hydrated = $strategy->hydrate($value);
-        self::assertSame($value, $hydrated);
+        $this->assertSame($value, $hydrated);
     }
 }

--- a/test/Strategy/DateTimeImmutableFormatterStrategyTest.php
+++ b/test/Strategy/DateTimeImmutableFormatterStrategyTest.php
@@ -25,38 +25,29 @@ final class DateTimeImmutableFormatterStrategyTest extends TestCase
 
     public function testExtraction(): void
     {
-        self::assertEquals(
-            '2020-05-25',
-            $this->strategy->extract(new DateTimeImmutable('2020-05-25'))
-        );
+        $this->assertEquals('2020-05-25', $this->strategy->extract(new DateTimeImmutable('2020-05-25')));
     }
 
     public function testHydrationWithDateTimeImmutableObjectShouldReturnSame(): void
     {
         $dateTime = new DateTimeImmutable('2020-05-25');
-        self::assertEquals($dateTime, $this->strategy->hydrate($dateTime));
+        $this->assertEquals($dateTime, $this->strategy->hydrate($dateTime));
     }
 
     public function testHydrationShouldReturnImmutableDateTimeObject(): void
     {
-        self::assertInstanceOf(
-            DateTimeImmutable::class,
-            $this->strategy->hydrate('2020-05-25')
-        );
+        $this->assertInstanceOf(DateTimeImmutable::class, $this->strategy->hydrate('2020-05-25'));
     }
 
     public function testHydrationShouldReturnDateTimeObjectWithSameValue(): void
     {
-        self::assertSame(
-            '2020-05-25',
-            $this->strategy->hydrate('2020-05-25')->format('Y-m-d')
-        );
+        $this->assertSame('2020-05-25', $this->strategy->hydrate('2020-05-25')->format('Y-m-d'));
     }
 
     #[DataProvider('dataProviderForInvalidDateValues')]
     public function testHydrationShouldReturnInvalidDateValuesAsIs(string|null $value): void
     {
-        self::assertSame($value, $this->strategy->hydrate($value));
+        $this->assertSame($value, $this->strategy->hydrate($value));
     }
 
     /** @return array<string, array{0: null|string}> */

--- a/test/Strategy/ExplodeStrategyTest.php
+++ b/test/Strategy/ExplodeStrategyTest.php
@@ -26,9 +26,9 @@ final class ExplodeStrategyTest extends TestCase
         $strategy = new ExplodeStrategy($delimiter);
 
         if (is_numeric($expected)) {
-            self::assertEquals($expected, $strategy->extract($extractValue));
+            $this->assertEquals($expected, $strategy->extract($extractValue));
         } else {
-            self::assertSame($expected, $strategy->extract($extractValue));
+            $this->assertSame($expected, $strategy->extract($extractValue));
         }
     }
 
@@ -46,7 +46,7 @@ final class ExplodeStrategyTest extends TestCase
     {
         $strategy = new ExplodeStrategy();
 
-        self::assertSame([], $strategy->hydrate(null));
+        $this->assertSame([], $strategy->hydrate(null));
     }
 
     public function testGetExceptionWithEmptyDelimiter(): void
@@ -60,10 +60,10 @@ final class ExplodeStrategyTest extends TestCase
     public function testHydrateWithExplodeLimit(): void
     {
         $strategy = new ExplodeStrategy('-', 2);
-        self::assertSame(['foo', 'bar-baz-bat'], $strategy->hydrate('foo-bar-baz-bat'));
+        $this->assertSame(['foo', 'bar-baz-bat'], $strategy->hydrate('foo-bar-baz-bat'));
 
         $strategy = new ExplodeStrategy('-', 3);
-        self::assertSame(['foo', 'bar', 'baz-bat'], $strategy->hydrate('foo-bar-baz-bat'));
+        $this->assertSame(['foo', 'bar', 'baz-bat'], $strategy->hydrate('foo-bar-baz-bat'));
     }
 
     public function testHydrateWithInvalidScalarType(): void
@@ -114,7 +114,7 @@ final class ExplodeStrategyTest extends TestCase
     {
         $strategy = new ExplodeStrategy($delimiter);
 
-        self::assertSame($expected, $strategy->hydrate($value));
+        $this->assertSame($expected, $strategy->hydrate($value));
     }
 
     /**

--- a/test/Strategy/HydratorStrategyTest.php
+++ b/test/Strategy/HydratorStrategyTest.php
@@ -159,7 +159,7 @@ final class HydratorStrategyTest extends TestCase
 
         $hydrator = $this->createHydratorMock();
 
-        $hydrator->expects(self::once())
+        $hydrator->expects($this->once())
             ->method('extract')
             ->willReturnCallback($extraction);
 
@@ -168,7 +168,7 @@ final class HydratorStrategyTest extends TestCase
             TestAsset\User::class
         );
 
-        self::assertSame($extraction($value), $strategy->extract($value));
+        $this->assertSame($extraction($value), $strategy->extract($value));
     }
 
     #[DataProvider('providerInvalidValueForHydration')]
@@ -216,7 +216,7 @@ final class HydratorStrategyTest extends TestCase
             TestAsset\User::class
         );
 
-        self::assertSame($value, $strategy->hydrate($value));
+        $this->assertSame($value, $strategy->hydrate($value));
     }
 
     /** @return Generator<string, array{0: mixed}> */
@@ -252,7 +252,7 @@ final class HydratorStrategyTest extends TestCase
 
         $hydrator = $this->createHydratorMock();
 
-        $hydrator->expects(self::exactly(count($value)))
+        $hydrator->expects($this->exactly(count($value)))
             ->method('hydrate')
             ->willReturnCallback($hydration);
 
@@ -261,7 +261,7 @@ final class HydratorStrategyTest extends TestCase
             TestAsset\User::class
         );
 
-        self::assertEquals($hydration($value), $strategy->hydrate($value));
+        $this->assertEquals($hydration($value), $strategy->hydrate($value));
     }
 
     private function createHydratorMock(): MockObject&HydratorInterface

--- a/test/Strategy/NullableStrategyTest.php
+++ b/test/Strategy/NullableStrategyTest.php
@@ -15,89 +15,89 @@ final class NullableStrategyTest extends TestCase
     public function testExtractNonNullAndNonEmptyValue(): void
     {
         $strategy = $this->createMock(StrategyInterface::class);
-        $strategy->expects(self::once())
+        $strategy->expects($this->once())
             ->method('extract')
             ->with('original value')
             ->willReturn('extracted value');
         $nullableStrategy = new NullableStrategy($strategy, false);
 
-        self::assertEquals('extracted value', $nullableStrategy->extract('original value'));
+        $this->assertEquals('extracted value', $nullableStrategy->extract('original value'));
     }
 
     public function testExtractNullValue(): void
     {
         $strategy = $this->createMock(StrategyInterface::class);
-        $strategy->expects(self::never())
+        $strategy->expects($this->never())
             ->method('extract');
         $nullableStrategy = new NullableStrategy($strategy, false);
 
-        self::assertNull($nullableStrategy->extract(null));
+        $this->assertNull($nullableStrategy->extract(null));
     }
 
     public function testExtractEmptyValueAsNull(): void
     {
         $strategy = $this->createMock(StrategyInterface::class);
-        $strategy->expects(self::never())
+        $strategy->expects($this->never())
             ->method('extract');
         $nullableStrategy = new NullableStrategy($strategy, true);
 
-        self::assertNull($nullableStrategy->extract(''));
+        $this->assertNull($nullableStrategy->extract(''));
     }
 
     public function testExtractEmptyValueByHydrator(): void
     {
         $strategy = $this->createMock(StrategyInterface::class);
-        $strategy->expects(self::once())
+        $strategy->expects($this->once())
             ->method('extract')
             ->with('')
             ->willReturn('extracted empty value');
 
         $nullableStrategy = new NullableStrategy($strategy, false);
 
-        self::assertEquals('extracted empty value', $nullableStrategy->extract(''));
+        $this->assertEquals('extracted empty value', $nullableStrategy->extract(''));
     }
 
     public function testHydrateNonNullValue(): void
     {
         $strategy = $this->createMock(StrategyInterface::class);
-        $strategy->expects(self::once())
+        $strategy->expects($this->once())
             ->method('hydrate')
             ->with('original value')
             ->willReturn('hydrated value');
         $nullableStrategy = new NullableStrategy($strategy, false);
 
-        self::assertEquals('hydrated value', $nullableStrategy->hydrate('original value'));
+        $this->assertEquals('hydrated value', $nullableStrategy->hydrate('original value'));
     }
 
     public function testHydrateNullValue(): void
     {
         $strategy = $this->createMock(StrategyInterface::class);
-        $strategy->expects(self::never())
+        $strategy->expects($this->never())
             ->method('hydrate');
         $nullableStrategy = new NullableStrategy($strategy, false);
 
-        self::assertNull($nullableStrategy->hydrate(null));
+        $this->assertNull($nullableStrategy->hydrate(null));
     }
 
     public function testHydrateEmptyValueAsNull(): void
     {
         $strategy = $this->createMock(StrategyInterface::class);
-        $strategy->expects(self::never())
+        $strategy->expects($this->never())
             ->method('hydrate');
         $nullableStrategy = new NullableStrategy($strategy, true);
 
-        self::assertNull($nullableStrategy->hydrate(''));
+        $this->assertNull($nullableStrategy->hydrate(''));
     }
 
     public function testHydrateEmptyValueByHydrator(): void
     {
         $strategy = $this->createMock(StrategyInterface::class);
-        $strategy->expects(self::once())
+        $strategy->expects($this->once())
             ->method('hydrate')
             ->with('')
             ->willReturn('hydrated empty value');
         $nullableStrategy = new NullableStrategy($strategy, false);
 
-        self::assertEquals('hydrated empty value', $nullableStrategy->hydrate(''));
+        $this->assertEquals('hydrated empty value', $nullableStrategy->hydrate(''));
     }
 }

--- a/test/Strategy/ScalarTypeStrategyTest.php
+++ b/test/Strategy/ScalarTypeStrategyTest.php
@@ -8,8 +8,6 @@ use Laminas\Hydrator\Strategy\ScalarTypeStrategy;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 
-use const PHP_FLOAT_EPSILON;
-
 #[CoversClass(ScalarTypeStrategy::class)]
 final class ScalarTypeStrategyTest extends TestCase
 {
@@ -17,10 +15,9 @@ final class ScalarTypeStrategyTest extends TestCase
     {
         $this->assertSame(123, ScalarTypeStrategy::createToInt()->hydrate('123', null));
         $this->assertNull(ScalarTypeStrategy::createToInt()->hydrate(null, null));
-        $this->assertEqualsWithDelta(
+        $this->assertSame(
             123.99,
             ScalarTypeStrategy::createToFloat()->hydrate('123.99', null),
-            PHP_FLOAT_EPSILON
         );
         $this->assertTrue(ScalarTypeStrategy::createToBoolean()->hydrate(1, null));
         $this->assertFalse(ScalarTypeStrategy::createToBoolean()->hydrate(0, null));
@@ -37,7 +34,7 @@ final class ScalarTypeStrategyTest extends TestCase
     public function testExtract(): void
     {
         $this->assertSame(123, ScalarTypeStrategy::createToInt()->extract(123));
-        $this->assertEqualsWithDelta(123.99, ScalarTypeStrategy::createToFloat()->extract(123.99), PHP_FLOAT_EPSILON);
+        $this->assertSame(123.99, ScalarTypeStrategy::createToFloat()->extract(123.99));
         $this->assertSame('foo', ScalarTypeStrategy::createToString()->extract('foo'));
         $this->assertTrue(ScalarTypeStrategy::createToBoolean()->extract(true));
         $this->assertFalse(ScalarTypeStrategy::createToBoolean()->extract(false));

--- a/test/Strategy/ScalarTypeStrategyTest.php
+++ b/test/Strategy/ScalarTypeStrategyTest.php
@@ -8,6 +8,8 @@ use Laminas\Hydrator\Strategy\ScalarTypeStrategy;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 
+use const PHP_FLOAT_EPSILON;
+
 #[CoversClass(ScalarTypeStrategy::class)]
 final class ScalarTypeStrategyTest extends TestCase
 {
@@ -15,7 +17,11 @@ final class ScalarTypeStrategyTest extends TestCase
     {
         $this->assertSame(123, ScalarTypeStrategy::createToInt()->hydrate('123', null));
         $this->assertNull(ScalarTypeStrategy::createToInt()->hydrate(null, null));
-        $this->assertSame(123.99, ScalarTypeStrategy::createToFloat()->hydrate('123.99', null));
+        $this->assertEqualsWithDelta(
+            123.99,
+            ScalarTypeStrategy::createToFloat()->hydrate('123.99', null),
+            PHP_FLOAT_EPSILON
+        );
         $this->assertTrue(ScalarTypeStrategy::createToBoolean()->hydrate(1, null));
         $this->assertFalse(ScalarTypeStrategy::createToBoolean()->hydrate(0, null));
 
@@ -31,9 +37,9 @@ final class ScalarTypeStrategyTest extends TestCase
     public function testExtract(): void
     {
         $this->assertSame(123, ScalarTypeStrategy::createToInt()->extract(123));
-        $this->assertSame(123.99, ScalarTypeStrategy::createToFloat()->extract(123.99));
+        $this->assertEqualsWithDelta(123.99, ScalarTypeStrategy::createToFloat()->extract(123.99), PHP_FLOAT_EPSILON);
         $this->assertSame('foo', ScalarTypeStrategy::createToString()->extract('foo'));
-        $this->assertSame(true, ScalarTypeStrategy::createToBoolean()->extract(true));
-        $this->assertSame(false, ScalarTypeStrategy::createToBoolean()->extract(false));
+        $this->assertTrue(ScalarTypeStrategy::createToBoolean()->extract(true));
+        $this->assertFalse(ScalarTypeStrategy::createToBoolean()->extract(false));
     }
 }

--- a/test/Strategy/SerializableStrategyTest.php
+++ b/test/Strategy/SerializableStrategyTest.php
@@ -17,7 +17,7 @@ final class SerializableStrategyTest extends TestCase
         $serializer         = new PhpSerialize();
         $serializerStrategy = new SerializableStrategy($serializer);
         $serialized         = $serializerStrategy->extract('foo');
-        $this->assertEquals($serialized, 's:3:"foo";');
+        $this->assertSame('s:3:"foo";', $serialized);
     }
 
     public function testCanUnserialize(): void
@@ -25,6 +25,6 @@ final class SerializableStrategyTest extends TestCase
         $serializer         = new PhpSerialize();
         $serializerStrategy = new SerializableStrategy($serializer);
         $serialized         = $serializerStrategy->hydrate('s:3:"foo";');
-        $this->assertEquals($serialized, 'foo');
+        $this->assertEquals('foo', $serialized);
     }
 }


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | no
| BC Break      | no
| New Feature   | no
| RFC           | no
| QA            | yes

### Description

Refactored PHPUnit tests by applying Rector's PHPUnit code quality rules, except for the `yield` data provider changes.  

**Why**
- To improve test code readability, maintainability, and compliance with modern PHPUnit best practices.
- This is a QA improvement only — no production code or behavior has been changed.

**What was done**
- Applied Rector rules targeting PHPUnit code quality improvements.
- Left data providers using `yield` unchanged to avoid unnecessary alterations.