### PR TITLE
Deprecate `HydratorProviderInterface`

### DIFF
--- a/src/HydratorProviderInterface.php
+++ b/src/HydratorProviderInterface.php
@@ -4,6 +4,9 @@ declare(strict_types=1);
 
 namespace Laminas\Hydrator;
 
+/**
+ * @deprecated This interface will be removed in version 5.0 without replacement
+ */
 interface HydratorProviderInterface
 {
     /**

--- a/src/HydratorProviderInterface.php
+++ b/src/HydratorProviderInterface.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Laminas\Hydrator;
 
 /**
- * @deprecated This interface will be removed in version 5.0 without replacement
+ * @deprecated Since 4.17.0 This interface will be removed in version 5.0 without replacement.
  */
 interface HydratorProviderInterface
 {

--- a/src/Module.php
+++ b/src/Module.php
@@ -25,7 +25,7 @@ class Module
     /**
      * Register a specification for the HydratorManager with the ServiceListener.
      *
-     * @deprecated ModuleManager support will be removed in version 5.0 of this component
+     * @deprecated Since 4.17.0 This method is not necessary for module manager and will be removed in 5.0
      */
     public function init(ModuleManager $moduleManager): void
     {

--- a/src/Module.php
+++ b/src/Module.php
@@ -24,6 +24,8 @@ class Module
 
     /**
      * Register a specification for the HydratorManager with the ServiceListener.
+     *
+     * @deprecated ModuleManager support will be removed in version 5.0 of this component
      */
     public function init(ModuleManager $moduleManager): void
     {


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | no
| BC Break      | no
| New Feature   | no
| RFC           | yes
| QA            | no

### Description

This PR deprecates support for [`laminas/laminas-modulemanager`](https://github.com/laminas/laminas-modulemanager), completing [laminas/laminas-hydrator#138](https://github.com/laminas/laminas-hydrator/issues/138).

**What was done**
- Marked `laminas-modulemanager` support as **deprecated**.
- Added notices in code/docs indicating it will be removed in a future major release.
- No functionality has been removed yet — existing usage continues to work.
