### PR TITLE
Mark classes as soft `@final` for future introduction of the `final` keyword in v5

### DIFF
--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<files psalm-version="5.25.0@01a8eb06b9e9cc6cfb6a320bf9fb14331919d505">
+<files psalm-version="5.26.1@d747f6500b38ac4f7dfc5edbcae6e4b637d7add0">
   <file src="src/Aggregate/AggregateHydrator.php">
     <DocblockTypeContradiction>
       <code><![CDATA[null === $this->eventManager]]></code>
@@ -12,6 +12,9 @@
     <DeprecatedClass>
       <code><![CDATA[ArraySerializable::class]]></code>
     </DeprecatedClass>
+    <InvalidExtendClass>
+      <code><![CDATA[ArraySerializableHydrator]]></code>
+    </InvalidExtendClass>
   </file>
   <file src="src/ArraySerializableHydrator.php">
     <MixedArgument>
@@ -48,6 +51,9 @@
     <DeprecatedClass>
       <code><![CDATA[ClassMethods::class]]></code>
     </DeprecatedClass>
+    <InvalidExtendClass>
+      <code><![CDATA[ClassMethodsHydrator]]></code>
+    </InvalidExtendClass>
   </file>
   <file src="src/ClassMethodsHydrator.php">
     <DocblockTypeContradiction>
@@ -233,6 +239,9 @@
     <DeprecatedClass>
       <code><![CDATA[ObjectProperty::class]]></code>
     </DeprecatedClass>
+    <InvalidExtendClass>
+      <code><![CDATA[ObjectPropertyHydrator]]></code>
+    </InvalidExtendClass>
   </file>
   <file src="src/ObjectPropertyHydrator.php">
     <MixedArgumentTypeCoercion>
@@ -251,6 +260,9 @@
     <DeprecatedClass>
       <code><![CDATA[Reflection::class]]></code>
     </DeprecatedClass>
+    <InvalidExtendClass>
+      <code><![CDATA[ReflectionHydrator]]></code>
+    </InvalidExtendClass>
   </file>
   <file src="src/ReflectionHydrator.php">
     <MixedArgumentTypeCoercion>

--- a/src/Aggregate/AggregateHydrator.php
+++ b/src/Aggregate/AggregateHydrator.php
@@ -11,6 +11,8 @@ use Laminas\Hydrator\HydratorInterface;
 
 /**
  * Aggregate hydrator that composes multiple hydrators via events
+ *
+ * @final
  */
 class AggregateHydrator implements HydratorInterface, EventManagerAwareInterface
 {

--- a/src/Aggregate/HydratorListener.php
+++ b/src/Aggregate/HydratorListener.php
@@ -12,6 +12,8 @@ use Laminas\Hydrator\HydratorInterface;
  * Aggregate listener wrapping around a hydrator.
  *
  * Listens to {@see HydrateEvent::EVENT_HYDRATE} and {@see ExtractEvent::EVENT_EXTRACT}
+ *
+ * @final
  */
 class HydratorListener extends AbstractListenerAggregate
 {

--- a/src/ArraySerializableHydrator.php
+++ b/src/ArraySerializableHydrator.php
@@ -11,6 +11,9 @@ use function is_callable;
 use function method_exists;
 use function sprintf;
 
+/**
+ * @final
+ */
 class ArraySerializableHydrator extends AbstractHydrator
 {
     /**

--- a/src/ClassMethodsHydrator.php
+++ b/src/ClassMethodsHydrator.php
@@ -21,6 +21,9 @@ use function str_starts_with;
 use function substr;
 use function ucfirst;
 
+/**
+ * @final
+ */
 class ClassMethodsHydrator extends AbstractHydrator implements HydratorOptionsInterface
 {
     /**

--- a/src/ConfigProvider.php
+++ b/src/ConfigProvider.php
@@ -8,6 +8,9 @@ use Laminas\ServiceManager\ServiceManager;
 
 use function class_exists;
 
+/**
+ * @final
+ */
 class ConfigProvider
 {
     /**

--- a/src/DelegatingHydrator.php
+++ b/src/DelegatingHydrator.php
@@ -6,6 +6,9 @@ namespace Laminas\Hydrator;
 
 use Psr\Container\ContainerInterface;
 
+/**
+ * @final
+ */
 class DelegatingHydrator implements HydratorInterface
 {
     public function __construct(protected ContainerInterface $hydrators)

--- a/src/DelegatingHydratorFactory.php
+++ b/src/DelegatingHydratorFactory.php
@@ -6,6 +6,9 @@ namespace Laminas\Hydrator;
 
 use Psr\Container\ContainerInterface;
 
+/**
+ * @final
+ */
 class DelegatingHydratorFactory
 {
     /**

--- a/src/HydratorPluginManager.php
+++ b/src/HydratorPluginManager.php
@@ -18,6 +18,7 @@ use function sprintf;
  * Enforces that adapters retrieved are instances of HydratorInterface
  *
  * @extends AbstractPluginManager<HydratorInterface>
+ * @final
  */
 class HydratorPluginManager extends AbstractPluginManager implements HydratorPluginManagerInterface
 {

--- a/src/Iterator/HydratingArrayIterator.php
+++ b/src/Iterator/HydratingArrayIterator.php
@@ -13,6 +13,7 @@ use Laminas\Hydrator\HydratorInterface;
  * @template TInputData of array
  * @template TIterator of ArrayIterator<TKey, TInputData>
  * @template-extends HydratingIteratorIterator<TKey, TPrototype, TInputData, TIterator>
+ * @final
  */
 class HydratingArrayIterator extends HydratingIteratorIterator
 {

--- a/src/NamingStrategy/UnderscoreNamingStrategy.php
+++ b/src/NamingStrategy/UnderscoreNamingStrategy.php
@@ -7,6 +7,9 @@ namespace Laminas\Hydrator\NamingStrategy;
 use Laminas\Hydrator\NamingStrategy\UnderscoreNamingStrategy\CamelCaseToUnderscoreFilter;
 use Laminas\Hydrator\NamingStrategy\UnderscoreNamingStrategy\UnderscoreToCamelCaseFilter;
 
+/**
+ * @final
+ */
 class UnderscoreNamingStrategy implements NamingStrategyInterface
 {
     private static ?CamelCaseToUnderscoreFilter $camelCaseToUnderscoreFilter = null;

--- a/src/ObjectPropertyHydrator.php
+++ b/src/ObjectPropertyHydrator.php
@@ -11,6 +11,9 @@ use function array_fill_keys;
 use function array_map;
 use function get_object_vars;
 
+/**
+ * @final
+ */
 class ObjectPropertyHydrator extends AbstractHydrator
 {
     /** @var (null|array)[] indexed by class name and then property name */

--- a/src/ReflectionHydrator.php
+++ b/src/ReflectionHydrator.php
@@ -7,6 +7,9 @@ namespace Laminas\Hydrator;
 use ReflectionClass;
 use ReflectionProperty;
 
+/**
+ * @final
+ */
 class ReflectionHydrator extends AbstractHydrator
 {
     /**

--- a/src/Strategy/ClosureStrategy.php
+++ b/src/Strategy/ClosureStrategy.php
@@ -4,6 +4,9 @@ declare(strict_types=1);
 
 namespace Laminas\Hydrator\Strategy;
 
+/**
+ * @final
+ */
 class ClosureStrategy implements StrategyInterface
 {
     /**

--- a/src/Strategy/DateTimeImmutableFormatterStrategy.php
+++ b/src/Strategy/DateTimeImmutableFormatterStrategy.php
@@ -9,6 +9,9 @@ use DateTimeImmutable;
 use DateTimeInterface;
 use Laminas\Hydrator\Strategy\DateTimeFormatterStrategy;
 
+/**
+ * @final
+ */
 class DateTimeImmutableFormatterStrategy implements StrategyInterface
 {
     public function __construct(private DateTimeFormatterStrategy $dateTimeStrategy)

--- a/src/Strategy/DefaultStrategy.php
+++ b/src/Strategy/DefaultStrategy.php
@@ -4,6 +4,9 @@ declare(strict_types=1);
 
 namespace Laminas\Hydrator\Strategy;
 
+/**
+ * @final
+ */
 class DefaultStrategy implements StrategyInterface
 {
     /**

--- a/src/Strategy/HydratorStrategy.php
+++ b/src/Strategy/HydratorStrategy.php
@@ -14,6 +14,9 @@ use function is_array;
 use function is_object;
 use function sprintf;
 
+/**
+ * @final
+ */
 class HydratorStrategy implements StrategyInterface
 {
     private string $objectClassName;

--- a/src/Strategy/NullableStrategy.php
+++ b/src/Strategy/NullableStrategy.php
@@ -6,6 +6,9 @@ namespace Laminas\Hydrator\Strategy;
 
 use Laminas\Hydrator\Strategy\StrategyInterface;
 
+/**
+ * @final
+ */
 class NullableStrategy implements StrategyInterface
 {
     public function __construct(private StrategyInterface $strategy, private bool $treatEmptyAsNull = false)

--- a/src/Strategy/SerializableStrategy.php
+++ b/src/Strategy/SerializableStrategy.php
@@ -15,6 +15,9 @@ use function is_string;
 use function iterator_to_array;
 use function sprintf;
 
+/**
+ * @final
+ */
 class SerializableStrategy implements StrategyInterface
 {
     /** @var string|SerializerAdapter */


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | no
| BC Break      | no
| New Feature   | no
| RFC           | yes
| QA            | yes

### Description

This PR marks selected classes with the `@final` annotation, indicating they will be made `final` in the next major release.

**Why**
- Provides advance notice to library consumers about which extension points will remain and which will be closed in the future.

**What was done**
- Added `@final` docblock annotations to classes that are intended to become `final`.
- No runtime behavior or signatures have changed.