### PR TITLE
Refactor: Replace integer constants with enum for filter conditions

### DIFF
--- a/docs/book/v5/migration/v4-to-v5.md
+++ b/docs/book/v5/migration/v4-to-v5.md
@@ -42,6 +42,26 @@ Please update your codebase to use the corresponding `*Hydrator` classes:
 | `Laminas\Hydrator\ObjectProperty`         | `Laminas\Hydrator\ObjectPropertyHydrator`          |
 | `Laminas\Hydrator\Reflection`             | `Laminas\Hydrator\ReflectionHydrator`              |
 
+### `FilterComposite`: Integer Constants Replaced by `FilterCondition` Enum
+
+The `FilterComposite::CONDITION_OR` and `FilterComposite::CONDITION_AND` integer constants have been removed.
+Replace them with the new `FilterCondition` enum.
+
+```php
+// Before (v4)
+use Laminas\Hydrator\Filter\FilterComposite;
+
+$hydrator->addFilter('exclude', $myFilter, FilterComposite::CONDITION_AND);
+
+// After (v5)
+use Laminas\Hydrator\Filter\FilterCondition;
+
+$hydrator->addFilter('exclude', $myFilter, FilterCondition::And);
+```
+
+The `$condition` parameter of `addFilter()` now requires a `FilterCondition` value instead of an `int`
+on `FilterComposite`, `FilterEnabledInterface`, `AbstractHydrator`, and `ClassMethodsHydrator`.
+
 ## Removed Features
 
 ### Removal of Module Manager Support

--- a/src/AbstractHydrator.php
+++ b/src/AbstractHydrator.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Laminas\Hydrator;
 
 use Laminas\Hydrator\Filter\FilterComposite;
+use Laminas\Hydrator\Filter\FilterCondition;
 use Laminas\Hydrator\Filter\FilterInterface;
 use Laminas\Hydrator\NamingStrategy\NamingStrategyInterface;
 
@@ -180,7 +181,7 @@ abstract class AbstractHydrator implements
      *             return false;
      *         }
      *         return true;
-     *     }, FilterComposite::CONDITION_AND
+     *     }, FilterCondition::And
      * );
      * </code>
      *
@@ -190,7 +191,7 @@ abstract class AbstractHydrator implements
     public function addFilter(
         string $name,
         callable|FilterInterface $filter,
-        int $condition = FilterComposite::CONDITION_OR
+        FilterCondition $condition = FilterCondition::Or
     ): void {
         $this->getCompositeFilter()->addFilter($name, $filter, $condition);
     }

--- a/src/ClassMethodsHydrator.php
+++ b/src/ClassMethodsHydrator.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Laminas\Hydrator;
 
+use Laminas\Hydrator\Filter\FilterCondition;
 use Laminas\Hydrator\Filter\FilterInterface;
 use Laminas\Stdlib\ArrayUtils;
 use Traversable;
@@ -247,7 +248,7 @@ final class ClassMethodsHydrator extends AbstractHydrator implements HydratorOpt
     public function addFilter(
         string $name,
         callable|FilterInterface $filter,
-        int $condition = Filter\FilterComposite::CONDITION_OR
+        FilterCondition $condition = FilterCondition::Or
     ): void {
         $this->resetCaches();
         parent::addFilter($name, $filter, $condition);

--- a/src/Filter/FilterComposite.php
+++ b/src/Filter/FilterComposite.php
@@ -14,16 +14,6 @@ use function sprintf;
 
 final class FilterComposite implements FilterInterface
 {
-    /**
-     * Constant to add with "or" condition
-     */
-    public const CONDITION_OR = 1;
-
-    /**
-     * Constant to add with "and" condition
-     */
-    public const CONDITION_AND = 2;
-
     private ArrayObject $andFilter;
 
     private ArrayObject $orFilter;
@@ -56,28 +46,23 @@ final class FilterComposite implements FilterInterface
      *             return false;
      *         }
      *         return true;
-     *     }, FilterComposite::CONDITION_AND
+     *     }, FilterCondition::And
      * );
      * </code>
      *
      * @param  callable|FilterInterface $filter
-     * @param  int                      $condition Can be either
-     *     FilterComposite::CONDITION_OR or FilterComposite::CONDITION_AND
      * @throws InvalidArgumentException
      */
-    public function addFilter(string $name, $filter, int $condition = self::CONDITION_OR): void
+    public function addFilter(string $name, $filter, FilterCondition $condition = FilterCondition::Or): void
     {
         $this->validateFilter($filter, $name);
 
-        if ($condition === self::CONDITION_OR) {
+        if ($condition === FilterCondition::Or) {
             $this->orFilter[$name] = $filter;
             return;
         }
 
-        if ($condition === self::CONDITION_AND) {
-            $this->andFilter[$name] = $filter;
-            return;
-        }
+        $this->andFilter[$name] = $filter;
     }
 
     /**

--- a/src/Filter/FilterCondition.php
+++ b/src/Filter/FilterCondition.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Laminas\Hydrator\Filter;
+
+enum FilterCondition: int
+{
+    case Or = 1;
+
+    case And = 2;
+}

--- a/src/Filter/FilterEnabledInterface.php
+++ b/src/Filter/FilterEnabledInterface.php
@@ -20,7 +20,7 @@ interface FilterEnabledInterface extends FilterProviderInterface
      *         }
      *         return true;
      *     },
-     *     FilterComposite::CONDITION_AND
+     *     FilterCondition::And
      * );
      * </code>
      *
@@ -30,7 +30,7 @@ interface FilterEnabledInterface extends FilterProviderInterface
     public function addFilter(
         string $name,
         callable|FilterInterface $filter,
-        int $condition = FilterComposite::CONDITION_OR,
+        FilterCondition $condition = FilterCondition::Or,
     ): void;
 
     /**

--- a/test/HydratorTest.php
+++ b/test/HydratorTest.php
@@ -7,7 +7,7 @@ namespace LaminasTest\Hydrator;
 use Laminas\Hydrator\AbstractHydrator;
 use Laminas\Hydrator\ArraySerializableHydrator;
 use Laminas\Hydrator\ClassMethodsHydrator;
-use Laminas\Hydrator\Filter\FilterComposite;
+use Laminas\Hydrator\Filter\FilterCondition;
 use Laminas\Hydrator\ObjectPropertyHydrator;
 use Laminas\Hydrator\ReflectionHydrator;
 use Laminas\Hydrator\Strategy\DefaultStrategy;
@@ -355,7 +355,7 @@ final class HydratorTest extends TestCase
                 $method = explode('::', $property)[1];
                 return $method !== 'getHasFoo';
             },
-            FilterComposite::CONDITION_AND
+            FilterCondition::And
         );
 
         $datas = $hydrator->extract($this->classMethodsCamelCase);
@@ -385,7 +385,7 @@ final class HydratorTest extends TestCase
         $hydrator->addFilter(
             'len',
             static fn($property): bool => strlen($property) === 3,
-            FilterComposite::CONDITION_AND
+            FilterCondition::And
         );
 
         $this->assertSame([

--- a/test/TestAsset/ClassMethodsFilterProviderInterface.php
+++ b/test/TestAsset/ClassMethodsFilterProviderInterface.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace LaminasTest\Hydrator\TestAsset;
 
 use Laminas\Hydrator\Filter\FilterComposite;
+use Laminas\Hydrator\Filter\FilterCondition;
 use Laminas\Hydrator\Filter\FilterInterface;
 use Laminas\Hydrator\Filter\FilterProviderInterface;
 use Laminas\Hydrator\Filter\GetFilter;
@@ -54,14 +55,14 @@ class ClassMethodsFilterProviderInterface implements FilterProviderInterface
         $excludes->addFilter(
             "servicemanager",
             new MethodMatchFilter("getServiceManager"),
-            FilterComposite::CONDITION_AND
+            FilterCondition::And
         );
         $excludes->addFilter(
             "eventmanager",
             new MethodMatchFilter("getEventManager"),
-            FilterComposite::CONDITION_AND
+            FilterCondition::And
         );
-        $filterComposite->addFilter("excludes", $excludes, FilterComposite::CONDITION_AND);
+        $filterComposite->addFilter("excludes", $excludes, FilterCondition::And);
 
         return $filterComposite;
     }


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | yes
| Bugfix        | no
| BC Break      | yes
| New Feature   | no
| RFC           | yes
| QA            | no

### Description

Replaces `FilterComposite::CONDITION_OR` / `CONDITION_AND` integer constants with a backed enum `FilterCondition`.

```php
// Before
$hydrator->addFilter('exclude', $myFilter, FilterComposite::CONDITION_AND);

// After
$hydrator->addFilter('exclude', $myFilter, FilterCondition::And);
```