### PR TITLE
feat: introduce FilterCondition enum and update filter methods for de…

### DIFF
--- a/src/AbstractHydrator.php
+++ b/src/AbstractHydrator.php
@@ -183,15 +183,20 @@ abstract class AbstractHydrator implements
      *             return false;
      *         }
      *         return true;
-     *     }, FilterComposite::CONDITION_AND
+     *     }, FilterCondition::And
      * );
      * </code>
      *
      * @param string $name Index in the composite
      * @param callable|Filter\FilterInterface $filter
+     * @param Filter\FilterCondition|int $condition Passing an int is deprecated;
+     *     use {@see Filter\FilterCondition} instead.
      */
-    public function addFilter(string $name, $filter, int $condition = Filter\FilterComposite::CONDITION_OR): void
-    {
+    public function addFilter(
+        string $name,
+        $filter,
+        Filter\FilterCondition|int $condition = Filter\FilterCondition::Or
+    ): void {
         $this->getCompositeFilter()->addFilter($name, $filter, $condition);
     }
 

--- a/src/ClassMethodsHydrator.php
+++ b/src/ClassMethodsHydrator.php
@@ -251,8 +251,11 @@ class ClassMethodsHydrator extends AbstractHydrator implements HydratorOptionsIn
     /**
      * {@inheritDoc}
      */
-    public function addFilter(string $name, $filter, int $condition = Filter\FilterComposite::CONDITION_OR): void
-    {
+    public function addFilter(
+        string $name,
+        $filter,
+        Filter\FilterCondition|int $condition = Filter\FilterCondition::Or
+    ): void {
         $this->resetCaches();
         parent::addFilter($name, $filter, $condition);
     }

--- a/src/Filter/FilterComposite.php
+++ b/src/Filter/FilterComposite.php
@@ -11,17 +11,22 @@ use Laminas\Hydrator\Exception\InvalidArgumentException;
 use function array_walk;
 use function count;
 use function is_callable;
+use function is_int;
 use function sprintf;
 
 final class FilterComposite implements FilterInterface
 {
     /**
      * Constant to add with "or" condition
+     *
+     * @deprecated Use {@see FilterCondition::Or} instead. This constant will be removed in v5.
      */
     public const CONDITION_OR = 1;
 
     /**
      * Constant to add with "and" condition
+     *
+     * @deprecated Use {@see FilterCondition::And} instead. This constant will be removed in v5.
      */
     public const CONDITION_AND = 2;
 
@@ -57,28 +62,30 @@ final class FilterComposite implements FilterInterface
      *             return false;
      *         }
      *         return true;
-     *     }, FilterComposite::CONDITION_AND
+     *     }, FilterCondition::And
      * );
      * </code>
      *
-     * @param  callable|FilterInterface $filter
-     * @param  int                      $condition Can be either
-     *     FilterComposite::CONDITION_OR or FilterComposite::CONDITION_AND
+     * @param  callable|FilterInterface    $filter
+     * @param  FilterCondition|int         $condition Can be either
+     *     {@see FilterCondition::Or} or {@see FilterCondition::And}.
+     *     Passing an int is deprecated; use {@see FilterCondition} instead.
      * @throws InvalidArgumentException
      */
-    public function addFilter(string $name, $filter, int $condition = self::CONDITION_OR): void
+    public function addFilter(string $name, $filter, FilterCondition|int $condition = FilterCondition::Or): void
     {
         $this->validateFilter($filter, $name);
 
-        if ($condition === self::CONDITION_OR) {
+        if (is_int($condition)) {
+            $condition = FilterCondition::from($condition);
+        }
+
+        if ($condition === FilterCondition::Or) {
             $this->orFilter[$name] = $filter;
             return;
         }
 
-        if ($condition === self::CONDITION_AND) {
-            $this->andFilter[$name] = $filter;
-            return;
-        }
+        $this->andFilter[$name] = $filter;
     }
 
     /**

--- a/src/Filter/FilterCondition.php
+++ b/src/Filter/FilterCondition.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Laminas\Hydrator\Filter;
+
+enum FilterCondition: int
+{
+    case Or = 1;
+
+    case And = 2;
+}

--- a/src/Filter/FilterEnabledInterface.php
+++ b/src/Filter/FilterEnabledInterface.php
@@ -20,14 +20,15 @@ interface FilterEnabledInterface extends FilterProviderInterface
      *         }
      *         return true;
      *     },
-     *     FilterComposite::CONDITION_AND
+     *     FilterCondition::And
      * );
      * </code>
      *
      * @param string $name Index in the composite
      * @param callable|FilterInterface $filter
+     * @param FilterCondition|int $condition Passing an int is deprecated; use {@see FilterCondition} instead.
      */
-    public function addFilter(string $name, $filter, int $condition = FilterComposite::CONDITION_OR): void;
+    public function addFilter(string $name, $filter, FilterCondition|int $condition = FilterCondition::Or): void;
 
     /**
      * Check whether a specific filter exists at key $name or not

--- a/test/HydratorTest.php
+++ b/test/HydratorTest.php
@@ -7,7 +7,7 @@ namespace LaminasTest\Hydrator;
 use Laminas\Hydrator\AbstractHydrator;
 use Laminas\Hydrator\ArraySerializableHydrator;
 use Laminas\Hydrator\ClassMethodsHydrator;
-use Laminas\Hydrator\Filter\FilterComposite;
+use Laminas\Hydrator\Filter\FilterCondition;
 use Laminas\Hydrator\ObjectPropertyHydrator;
 use Laminas\Hydrator\ReflectionHydrator;
 use Laminas\Hydrator\Strategy\DefaultStrategy;
@@ -365,7 +365,7 @@ final class HydratorTest extends TestCase
 
                 return true;
             },
-            FilterComposite::CONDITION_AND
+            FilterCondition::And
         );
 
         $datas = $hydrator->extract($this->classMethodsCamelCase);
@@ -408,7 +408,7 @@ final class HydratorTest extends TestCase
                 return false;
             }
             return true;
-        }, FilterComposite::CONDITION_AND);
+        }, FilterCondition::And);
 
         self::assertSame(
             [


### PR DESCRIPTION
## Introduce `FilterCondition` enum and deprecate integer constants

|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | no
| BC Break      | no
| New Feature   | yes
| RFC           | no
| QA            | no

### Description

Prepares for v5 (https://github.com/laminas/laminas-hydrator/pull/162) by introducing the `FilterCondition` enum and deprecating
`FilterComposite::CONDITION_OR` / `CONDITION_AND` constants.

No BC break — `addFilter()` still accepts `int`, allowing users to migrate at their own pace before v5.
