### PR TITLE
Mark CONDITION_OR and CONDITION_AND as deprecated for future removal

### DIFF
--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -16,6 +16,11 @@
       <code><![CDATA[ArraySerializableHydrator]]></code>
     </InvalidExtendClass>
   </file>
+  <file src="src/AbstractHydrator.php">
+    <DeprecatedConstant>
+      <code><![CDATA[Filter\FilterComposite::CONDITION_OR]]></code>
+    </DeprecatedConstant>
+  </file>
   <file src="src/ArraySerializableHydrator.php">
     <MixedArgument>
       <code><![CDATA[$original]]></code>
@@ -53,6 +58,9 @@
     </InvalidExtendClass>
   </file>
   <file src="src/ClassMethodsHydrator.php">
+    <DeprecatedConstant>
+      <code><![CDATA[Filter\FilterComposite::CONDITION_OR]]></code>
+    </DeprecatedConstant>
     <DocblockTypeContradiction>
       <code><![CDATA[$options instanceof Traversable]]></code>
       <code><![CDATA[null === $this->extractionMethodsCache[$objectClass]]]></code>
@@ -95,12 +103,20 @@
     </MixedReturnStatement>
   </file>
   <file src="src/Filter/FilterComposite.php">
+    <DeprecatedConstant>
+      <code><![CDATA[self::CONDITION_OR]]></code>
+      <code><![CDATA[self::CONDITION_OR]]></code>
+      <code><![CDATA[self::CONDITION_AND]]></code>
+    </DeprecatedConstant>
     <MixedArgumentTypeCoercion>
       <code><![CDATA[$filter]]></code>
       <code><![CDATA[$filter]]></code>
     </MixedArgumentTypeCoercion>
   </file>
   <file src="src/Filter/FilterEnabledInterface.php">
+    <DeprecatedConstant>
+      <code><![CDATA[FilterComposite::CONDITION_OR]]></code>
+    </DeprecatedConstant>
     <PossiblyUnusedMethod>
       <code><![CDATA[hasFilter]]></code>
     </PossiblyUnusedMethod>
@@ -571,6 +587,10 @@
     </UndefinedInterfaceMethod>
   </file>
   <file src="test/HydratorTest.php">
+    <DeprecatedConstant>
+      <code><![CDATA[FilterComposite::CONDITION_AND]]></code>
+      <code><![CDATA[FilterComposite::CONDITION_AND]]></code>
+    </DeprecatedConstant>
     <MissingClosureParamType>
       <code><![CDATA[$property]]></code>
       <code><![CDATA[$property]]></code>

--- a/src/Filter/FilterComposite.php
+++ b/src/Filter/FilterComposite.php
@@ -17,11 +17,15 @@ final class FilterComposite implements FilterInterface
 {
     /**
      * Constant to add with "or" condition
+     *
+     * @deprecated This constant will be replaced with FilterCondition::class in the v5
      */
     public const CONDITION_OR = 1;
 
     /**
      * Constant to add with "and" condition
+     *
+     * @deprecated This constant will be replaced with FilterCondition::class in the v5
      */
     public const CONDITION_AND = 2;
 


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | yes
| Bugfix        | no
| BC Break      | no
| New Feature   | no
| RFC           | no
| QA            | yes

### Description

This PR adds deprecation notices to constants in `FilterComposite` that will be replaced by enum in the next major release (v5).