### PR TITLE
refactor: change static properties to instance properties in hydrators

### DIFF
--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -155,9 +155,6 @@
       <code><![CDATA[$value]]></code>
       <code><![CDATA[$value]]></code>
     </MixedAssignment>
-    <UnsupportedReferenceUsage>
-      <code><![CDATA[$properties = &self::$skippedPropertiesCache[$object::class]]]></code>
-    </UnsupportedReferenceUsage>
   </file>
   <file src="src/ReflectionHydrator.php">
     <MixedArgumentTypeCoercion>

--- a/src/ObjectPropertyHydrator.php
+++ b/src/ObjectPropertyHydrator.php
@@ -13,8 +13,8 @@ use function get_object_vars;
 
 final class ObjectPropertyHydrator extends AbstractHydrator
 {
-    /** @var (null|array)[] indexed by class name and then property name */
-    private static array $skippedPropertiesCache = [];
+    /** @var array<class-string, array<string, true>> indexed by class name and then property name */
+    private array $skippedPropertiesCache = [];
 
     /**
      * Extracts the accessible non-static properties of the given $object.
@@ -56,11 +56,11 @@ final class ObjectPropertyHydrator extends AbstractHydrator
      */
     public function hydrate(array $data, object $object): object
     {
-        $properties = &self::$skippedPropertiesCache[$object::class] ?? null;
+        $className = $object::class;
 
-        if (null === $properties) {
-            $reflection = new ReflectionClass($object);
-            $properties = array_fill_keys(
+        if (! isset($this->skippedPropertiesCache[$className])) {
+            $reflection                               = new ReflectionClass($object);
+            $this->skippedPropertiesCache[$className] = array_fill_keys(
                 array_map(
                     static fn(ReflectionProperty $property): string => $property->getName(),
                     $reflection->getProperties(
@@ -72,6 +72,8 @@ final class ObjectPropertyHydrator extends AbstractHydrator
                 true
             );
         }
+
+        $properties = $this->skippedPropertiesCache[$className];
 
         foreach ($data as $name => $value) {
             $property = $this->hydrateName($name, $data);

--- a/src/ReflectionHydrator.php
+++ b/src/ReflectionHydrator.php
@@ -14,7 +14,7 @@ final class ReflectionHydrator extends AbstractHydrator
      *
      * @var ReflectionProperty[][]
      */
-    private static array $reflProperties = [];
+    private array $reflProperties = [];
 
     /**
      * Extract values from an object
@@ -64,18 +64,18 @@ final class ReflectionHydrator extends AbstractHydrator
     {
         $class = $input::class;
 
-        if (isset(self::$reflProperties[$class])) {
-            return self::$reflProperties[$class];
+        if (isset($this->reflProperties[$class])) {
+            return $this->reflProperties[$class];
         }
 
-        self::$reflProperties[$class] = [];
+        $this->reflProperties[$class] = [];
         $reflClass                    = new ReflectionClass($class);
         $reflProperties               = $reflClass->getProperties();
 
         foreach ($reflProperties as $property) {
-            self::$reflProperties[$class][$property->getName()] = $property;
+            $this->reflProperties[$class][$property->getName()] = $property;
         }
 
-        return self::$reflProperties[$class];
+        return $this->reflProperties[$class];
     }
 }


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | no
| BC Break      | no
| New Feature   | yes
| RFC           | no
| QA            | yes

### Description

This PR makes hydrator internals safer for long-running runtimes (e.g. Swoole) by removing shared static cache state and using per-instance caches instead.

Why this approach:
- Static mutable caches are process-wide shared state and persist across requests in long-running workers

BC impact:
- No public API changes.
- No behavioral change expected for normal request/response usage